### PR TITLE
Kernel is AppProxyFactory

### DIFF
--- a/contracts/factory/APMRegistryFactory.sol
+++ b/contracts/factory/APMRegistryFactory.sol
@@ -9,7 +9,7 @@ import "./ENSFactory.sol";
 import "./AppProxyFactory.sol";
 
 
-contract APMRegistryFactory is DAOFactory, APMRegistryConstants {
+contract APMRegistryFactory is DAOFactory, AppProxyFactory, APMRegistryConstants {
     APMRegistry public registryBase;
     Repo public repoBase;
     ENSSubdomainRegistrar public ensSubdomainRegistrarBase;
@@ -52,14 +52,12 @@ contract APMRegistryFactory is DAOFactory, APMRegistryConstants {
 
         bytes32 namespace = dao.APP_BASES_NAMESPACE();
 
-        // App code for relevant apps
-        dao.setApp(namespace, APM_APP_ID, registryBase);
-        dao.setApp(namespace, REPO_APP_ID, repoBase);
-        dao.setApp(namespace, ENS_SUB_APP_ID, ensSubdomainRegistrarBase);
+        // Deploy app proxies
+        ENSSubdomainRegistrar ensSub = ENSSubdomainRegistrar(dao.newAppInstance(ENS_SUB_APP_ID, ensSubdomainRegistrarBase));
+        APMRegistry apm = APMRegistry(dao.newAppInstance(APM_APP_ID, registryBase));
 
-        // Deploy proxies
-        ENSSubdomainRegistrar ensSub = ENSSubdomainRegistrar(newAppProxy(dao, ENS_SUB_APP_ID));
-        APMRegistry apm = APMRegistry(newAppProxy(dao, APM_APP_ID));
+        // APMRegistry controls Repos
+        dao.setApp(namespace, REPO_APP_ID, repoBase);
 
         DeployAPM(node, apm);
 

--- a/contracts/factory/DAOFactory.sol
+++ b/contracts/factory/DAOFactory.sol
@@ -5,11 +5,10 @@ import "../kernel/KernelProxy.sol";
 
 import "../acl/ACL.sol";
 
-import "./AppProxyFactory.sol";
 import "./EVMScriptRegistryFactory.sol";
 
 
-contract DAOFactory is AppProxyFactory {
+contract DAOFactory {
     address public baseKernel;
     address public baseACL;
     EVMScriptRegistryFactory public regFactory;
@@ -32,10 +31,11 @@ contract DAOFactory is AppProxyFactory {
     */
     function newDAO(address _root) public returns (Kernel dao) {
         dao = Kernel(new KernelProxy(baseKernel));
-        ACL acl = ACL(newAppProxy(dao, dao.ACL_APP_ID()));
 
         address initialRoot = address(regFactory) != address(0) ? this : _root;
-        dao.initialize(acl, baseACL, initialRoot);
+        dao.initialize(baseACL, initialRoot);
+
+        ACL acl = ACL(dao.acl());
 
         if (address(regFactory) != address(0)) {
             bytes32 permRole = acl.CREATE_PERMISSIONS_ROLE();

--- a/contracts/factory/EVMScriptRegistryFactory.sol
+++ b/contracts/factory/EVMScriptRegistryFactory.sol
@@ -25,8 +25,7 @@ contract EVMScriptRegistryFactory is AppProxyFactory, EVMScriptRegistryConstants
     }
 
     function newEVMScriptRegistry(Kernel _dao, address _root) public returns (EVMScriptRegistry reg) {
-        _dao.setApp(_dao.APP_BASES_NAMESPACE(), EVMSCRIPT_REGISTRY_APP_ID, baseReg);
-        reg = EVMScriptRegistry(newAppProxyPinned(_dao, EVMSCRIPT_REGISTRY_APP_ID));
+        reg = EVMScriptRegistry(_dao.newPinnedAppInstance(EVMSCRIPT_REGISTRY_APP_ID, baseReg));
         reg.initialize();
 
         ACL acl = ACL(_dao.acl());

--- a/test/evm_script.js
+++ b/test/evm_script.js
@@ -63,7 +63,7 @@ contract('EVM Script', accounts => {
 
     context('executor', () => {
         beforeEach(async () => {
-            const receipt = await daoFact.newAppProxy(dao.address, executorAppId)
+            const receipt = await dao.newAppInstance(executorAppId, '0x0', { from: boss })
             executor = Executor.at(receipt.logs.filter(l => l.event == 'NewAppProxy')[0].args.proxy)
             executionTarget = await ExecutionTarget.new()
         })

--- a/test/kernel_acl.js
+++ b/test/kernel_acl.js
@@ -49,7 +49,7 @@ contract('Kernel ACL', accounts => {
 
     it('throws on reinitialization', async () => {
         return assertRevert(async () => {
-            await kernel.initialize(accounts[0], accounts[0], accounts[0])
+            await kernel.initialize(accounts[0], accounts[0])
         })
     })
 

--- a/test/kernel_acl.js
+++ b/test/kernel_acl.js
@@ -58,6 +58,14 @@ contract('Kernel ACL', accounts => {
         assert.isFalse(await acl.hasPermission(permissionsRoot, app, role))
     })
 
+    it('actions cannot be performed if uninitialized', async () => {
+        const newKernelProxy = await KernelProxy.new(await factory.baseKernel())
+        const newKernel = Kernel.at(newKernelProxy.address)
+        return assertRevert(async () => {
+          const result = await newKernel.hasPermission(permissionsRoot, app, role, '0x00')
+        })
+    })
+
     it('protected actions fail if not allowed', async () => {
         return assertRevert(async () => {
             await kernel.setApp('0x0', '0x1234', accounts[0])


### PR DESCRIPTION
Allows users of our Kernel implementation to deploy app instances directly from the kernel.

The most common use case would be when an existing DAO finds a new app they want to install. Rather than having to spend two transactions to separately deploy a `AppProxy` and invoke `kernel.setApp()`, they could just do `kernel.newAppInstance()`. Actually "installing" the app would still take another transaction, to set the permissions.

This change also allows the kernel's initialization to directly spawn an ACL app, rather than expecting it to be provided from the outside. I think this makes sense, as "initializing" the kernel should set everything essential (only ACL right now) up for you.