### PR TITLE
Improvements for App support: add authP modifiers in AragonApp base and add more syntax sugar

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,7 +1,7 @@
 // NOTE: Upgrading to solidity-coverage 0.4.x breaks our tests
 
 const libFiles = require('glob').sync('contracts/lib/**/*.sol').map(n => n.replace('contracts/', ''))
-const interfaces = ['common/IForwarder.sol', 'kernel/IKernel.sol', 'evmscript/IEVMScriptExecutor.sol', 'apps/IAppProxy.sol', 'acl/IACL.sol']
+const interfaces = ['common/IForwarder.sol', 'kernel/IKernel.sol', 'evmscript/IEVMScriptExecutor.sol', 'apps/IAppProxy.sol', 'acl/IACL.sol', 'acl/ACLSyntaxSugar.sol']
 
 module.exports = {
     norpc: true,

--- a/contracts/acl/ACL.sol
+++ b/contracts/acl/ACL.sol
@@ -10,7 +10,7 @@ interface ACLOracle {
 }
 
 
-contract ACL is IACL, AragonApp, ACLSyntaxSugar {
+contract ACL is IACL, AragonApp, ACLHelpers {
     bytes32 constant public CREATE_PERMISSIONS_ROLE = bytes32(1);
 
     // whether a certain entity has a permission

--- a/contracts/acl/ACLSyntaxSugar.sol
+++ b/contracts/acl/ACLSyntaxSugar.sol
@@ -76,6 +76,7 @@ contract ACLSyntaxSugar {
     }
 }
 
+
 contract ACLHelpers {
     function decodeParamOp(uint256 _x) internal pure returns (uint8 b) {
         return uint8(_x >> (8 * 30));

--- a/contracts/acl/ACLSyntaxSugar.sol
+++ b/contracts/acl/ACLSyntaxSugar.sol
@@ -4,11 +4,6 @@ pragma solidity 0.4.18;
 contract ACLSyntaxSugar {
     function arr() internal pure returns (uint256[] r) {}
 
-    function arr(uint256 _a) internal pure returns (uint256[] r) {
-        r = new uint256[](1);
-        r[0] = _a;
-    }
-
     function arr(bytes32 _a) internal pure returns (uint256[] r) {
         return arr(uint256(_a));
     }
@@ -21,12 +16,67 @@ contract ACLSyntaxSugar {
         return arr(uint256(_a));
     }
 
+    function arr(address _a, address _b) internal pure returns (uint256[] r) {
+        return arr(uint256(_a), uint256(_b));
+    }
+
+    function arr(address _a, uint256 _b, uint256 _c) internal pure returns (uint256[] r) {
+        return arr(uint256(_a), _b, _c);
+    }
+
+    function arr(address _a, uint256 _b) internal pure returns (uint256[] r) {
+        return arr(uint256(_a), uint256(_b));
+    }
+
+    function arr(address _a, address _b, uint256 _c, uint256 _d, uint256 _e) internal pure returns (uint256[] r) {
+        return arr(uint256(_a), uint256(_b), _c, _d, _e);
+    }
+
+    function arr(address _a, address _b, address _c) internal pure returns (uint256[] r) {
+        return arr(uint256(_a), uint256(_b), uint256(_c));
+    }
+
+    function arr(address _a, address _b, uint256 _c) internal pure returns (uint256[] r) {
+        return arr(uint256(_a), uint256(_b), uint256(_c));
+    }
+
+    function arr(uint256 _a) internal pure returns (uint256[] r) {
+        r = new uint256[](1);
+        r[0] = _a;
+    }
+
     function arr(uint256 _a, uint256 _b) internal pure returns (uint256[] r) {
         r = new uint256[](2);
         r[0] = _a;
         r[1] = _b;
     }
 
+    function arr(uint256 _a, uint256 _b, uint256 _c) internal pure returns (uint256[] r) {
+        r = new uint256[](3);
+        r[0] = _a;
+        r[1] = _b;
+        r[2] = _c;
+    }
+
+    function arr(uint256 _a, uint256 _b, uint256 _c, uint256 _d) internal pure returns (uint256[] r) {
+        r = new uint256[](4);
+        r[0] = _a;
+        r[1] = _b;
+        r[2] = _c;
+        r[3] = _d;
+    }
+
+    function arr(uint256 _a, uint256 _b, uint256 _c, uint256 _d, uint256 _e) internal pure returns (uint256[] r) {
+        r = new uint256[](5);
+        r[0] = _a;
+        r[1] = _b;
+        r[2] = _c;
+        r[3] = _d;
+        r[4] = _e;
+    }
+}
+
+contract ACLHelpers {
     function decodeParamOp(uint256 _x) internal pure returns (uint8 b) {
         return uint8(_x >> (8 * 30));
     }

--- a/contracts/apps/AragonApp.sol
+++ b/contracts/apps/AragonApp.sol
@@ -3,15 +3,29 @@ pragma solidity ^0.4.18;
 import "./AppStorage.sol";
 import "../common/Initializable.sol";
 import "../evmscript/EVMScriptRunner.sol";
+import "../acl/ACLSyntaxSugar.sol";
 
 
-contract AragonApp is AppStorage, Initializable, EVMScriptRunner {
+contract AragonApp is AppStorage, Initializable, ACLSyntaxSugar, EVMScriptRunner {
     modifier auth(bytes32 _role) {
-        require(canPerform(msg.sender, _role));
+        require(canPerform(msg.sender, _role, new uint256[](0)));
         _;
     }
 
-    function canPerform(address _sender, bytes32 _role) public view returns (bool) {
-        return address(kernel) == 0 || kernel.hasPermission(_sender, address(this), _role, new bytes(0));
+    modifier authP(bytes32 _role, uint256[] params) {
+        require(canPerform(msg.sender, _role, params));
+        _;
+    }
+
+    function canPerform(address _sender, bytes32 _role, uint256[] params) public view returns (bool) {
+        bytes memory how; // no need to init memory as it is never used
+        if (params.length > 0) {
+            uint256 byteLength = params.length * 32;
+            assembly {
+                how := params // forced casting
+                mstore(how, byteLength)
+            }
+        }
+        return address(kernel) == 0 || kernel.hasPermission(_sender, address(this), _role, how);
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/os",
-  "version": "3.0.0-1",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/TestACLInterpreter.sol
+++ b/test/TestACLInterpreter.sol
@@ -1,10 +1,10 @@
 pragma solidity 0.4.18;
 
 import "truffle/Assert.sol";
-import "./helpers/ACLHelpers.sol";
+import "./helpers/ACLHelper.sol";
 
 
-contract TestACLInterpreter is ACL, ACLHelpers {
+contract TestACLInterpreter is ACL, ACLHelper {
     function testEqualityUint() public {
         // Assert param 0 is equal to 10, given that params are [10, 11]
         assertEval(arr(uint256(10), 11), 0, Op.EQ, 10, true);

--- a/test/helpers/ACLHelper.sol
+++ b/test/helpers/ACLHelper.sol
@@ -3,7 +3,7 @@ pragma solidity 0.4.18;
 import "../../contracts/acl/ACL.sol";
 
 
-contract ACLHelpers {
+contract ACLHelper {
     function encodeOperator(uint256 param1, uint256 param2) internal pure returns (uint240) {
         return encodeIfElse(param1, param2, 0);
     }

--- a/test/mocks/AppStub.sol
+++ b/test/mocks/AppStub.sol
@@ -19,6 +19,10 @@ contract AppStub is AragonApp, AppSt {
         a = i;
     }
 
+    function setValueParam(uint i) authP(ROLE, arr(i)) {
+        a = i;
+    }
+
     function getValue() constant returns (uint) {
         return a;
     }


### PR DESCRIPTION
Looks like we might need to release aOS 3.0.1 earlier than expected 😅