### PR TITLE
Add migrations folder in published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build/",
     "artifacts/",
     "contracts/",
+    "migrations/",
     "truffle-config.js"
   ],
   "author": "Aragon Institution MTU <contact@aragon.one>",


### PR DESCRIPTION
Some of the templates are requiring the aragonOS migrations and will fail if these aren't included in the published package.