### PR TITLE
Pin truffle to 4.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "mocha-lcov-reporter": "^1.3.0",
     "solidity-coverage": "^0.3.5",
     "solium": "^1.1.2",
-    "truffle": "^4.0.4",
+    "truffle": "4.0.5",
     "truffle-config": "^1.0.4",
     "truffle-hdwallet-provider": "0.0.3"
   }


### PR DESCRIPTION
Truffle@4.0.6 upgrades solidity to 0.4.19, which breaks our fixed contracts.