### PR TITLE
ITokenController: remove constant modifier

### DIFF
--- a/contracts/lib/minime/ITokenController.sol
+++ b/contracts/lib/minime/ITokenController.sol
@@ -15,7 +15,7 @@ interface ITokenController {
     /// @param _to The destination of the transfer
     /// @param _amount The amount of the transfer
     /// @return False if the controller does not authorize the transfer
-    function onTransfer(address _from, address _to, uint _amount) public constant returns(bool);
+    function onTransfer(address _from, address _to, uint _amount) public returns(bool);
 
     /// @notice Notifies the controller about an approval allowing the
     ///  controller to react if desired
@@ -23,5 +23,5 @@ interface ITokenController {
     /// @param _spender The spender in the `approve()` call
     /// @param _amount The amount in the `approve()` call
     /// @return False if the controller does not authorize the approval
-    function onApprove(address _owner, address _spender, uint _amount) public constant returns(bool);
+    function onApprove(address _owner, address _spender, uint _amount) public returns(bool);
 }


### PR DESCRIPTION
`onTransfer()` and `onApprove()` are arbitrary and should be allowed to modify state (e.g. keeping a list of transferees).

Needed for https://github.com/aragon/aragon-apps/pull/104.