### PR TITLE
Use && rather than ; in npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "ganache-cli:dev": "scripts/ganache-cli.sh",
     "ganache-cli:coverage": "SOLIDITY_COVERAGE=true scripts/ganache-cli.sh",
     "migrate:dev": "npm run ganache-cli:dev && npm run migrate:dev:contracts",
-    "migrate:dev:contracts": "truffle migrate --all --network rpc;",
-    "generate:artifacts-dev": "npm run migrate:dev; truffle exec --network rpc scripts/generate_artifacts.js",
-    "deploy:devnet:ens": "truffle compile; truffle exec --network devnet scripts/deploy-beta-ens.js",
-    "deploy:devnet:apm": "truffle compile; truffle exec --network devnet scripts/deploy-beta-apm.js",
+    "migrate:dev:contracts": "truffle migrate --all --network rpc",
+    "generate:artifacts-dev": "npm run migrate:dev && truffle exec --network rpc scripts/generate_artifacts.js",
+    "deploy:devnet:ens": "truffle compile && truffle exec --network devnet scripts/deploy-beta-ens.js",
+    "deploy:devnet:apm": "truffle compile && truffle exec --network devnet scripts/deploy-beta-apm.js",
     "prepublishOnly": "truffle compile --all"
   },
   "files": [


### PR DESCRIPTION
Generally you want to use `&&` when chaining to avoid running the second step if the first step fails.