### PR TITLE
delegatecall safety: Implement min return size in DelegateProxy

### DIFF
--- a/contracts/common/DelegateProxy.sol
+++ b/contracts/common/DelegateProxy.sol
@@ -18,26 +18,26 @@ contract DelegateProxy {
     * @param _minReturnSize Minimum size the call needs to return, if less than that it will revert
     */
     function delegateFwd(address _dst, bytes _calldata, uint256 _minReturnSize) internal {
-      require(isContract(_dst));
-      uint256 size;
-      uint256 result;
+        require(isContract(_dst));
+        uint256 size;
+        uint256 result;
 
-      assembly {
-          result := delegatecall(sub(gas, 10000), _dst, add(_calldata, 0x20), mload(_calldata), 0, 0)
-          size := returndatasize
-      }
+        assembly {
+            result := delegatecall(sub(gas, 10000), _dst, add(_calldata, 0x20), mload(_calldata), 0, 0)
+            size := returndatasize
+        }
 
-      require(size >= _minReturnSize);
+        require(size >= _minReturnSize);
 
-      assembly {
-          let ptr := mload(0x40)
-          returndatacopy(ptr, 0, size)
+        assembly {
+            let ptr := mload(0x40)
+            returndatacopy(ptr, 0, size)
 
-          // revert instead of invalid() bc if the underlying call failed with invalid() it already wasted gas.
-          // if the call returned error data, forward it
-          switch result case 0 { revert(ptr, size) }
-          default { return(ptr, size) }
-      }
+            // revert instead of invalid() bc if the underlying call failed with invalid() it already wasted gas.
+            // if the call returned error data, forward it
+            switch result case 0 { revert(ptr, size) }
+            default { return(ptr, size) }
+        }
     }
 
     function isContract(address _target) internal view returns (bool) {

--- a/contracts/common/DelegateProxy.sol
+++ b/contracts/common/DelegateProxy.sol
@@ -8,19 +8,36 @@ contract DelegateProxy {
     * @param _calldata Calldata for the delegatecall
     */
     function delegatedFwd(address _dst, bytes _calldata) internal {
-        require(isContract(_dst));
-        assembly {
-            let result := delegatecall(sub(gas, 10000), _dst, add(_calldata, 0x20), mload(_calldata), 0, 0)
-            let size := returndatasize
+        delegateFwd(_dst, _calldata, 0);
+    }
 
-            let ptr := mload(0x40)
-            returndatacopy(ptr, 0, size)
+    /**
+    * @dev Performs a delegatecall and returns whatever the delegatecall returned (entire context execution will return!)
+    * @param _dst Destination address to perform the delegatecall
+    * @param _calldata Calldata for the delegatecall
+    * @param _minReturnSize Minimum size the call needs to return, if less than that it will revert
+    */
+    function delegateFwd(address _dst, bytes _calldata, uint256 _minReturnSize) internal {
+      require(isContract(_dst));
+      uint256 size;
+      uint256 result;
 
-            // revert instead of invalid() bc if the underlying call failed with invalid() it already wasted gas.
-            // if the call returned error data, forward it
-            switch result case 0 { revert(ptr, size) }
-            default { return(ptr, size) }
-        }
+      assembly {
+          result := delegatecall(sub(gas, 10000), _dst, add(_calldata, 0x20), mload(_calldata), 0, 0)
+          size := returndatasize
+      }
+
+      require(size >= _minReturnSize);
+
+      assembly {
+          let ptr := mload(0x40)
+          returndatacopy(ptr, 0, size)
+
+          // revert instead of invalid() bc if the underlying call failed with invalid() it already wasted gas.
+          // if the call returned error data, forward it
+          switch result case 0 { revert(ptr, size) }
+          default { return(ptr, size) }
+      }
     }
 
     function isContract(address _target) internal view returns (bool) {

--- a/test/TestDelegateProxy.sol
+++ b/test/TestDelegateProxy.sol
@@ -1,0 +1,75 @@
+pragma solidity 0.4.18;
+
+import "truffle/Assert.sol";
+import "./helpers/ThrowProxy.sol";
+
+import "../contracts/common/DelegateProxy.sol";
+import "../contracts/evmscript/ScriptHelpers.sol";
+
+
+contract Target {
+    function returnSomething() public pure returns (bool) { return true; }
+    function dontReturn() {}
+    function fail() { revert(); }
+    function die() { selfdestruct(0); }
+}
+
+
+contract TestDelegateProxy is DelegateProxy {
+    using ScriptHelpers for *;
+
+    Target target;
+    ThrowProxy throwProxy;
+
+    function beforeAll() {
+        target = new Target();
+    }
+
+    function beforeEach() {
+        throwProxy = new ThrowProxy(address(this));
+    }
+
+    function testMinReturn0WithoutReturn() {
+        delegateFwd(target, target.dontReturn.selector.toBytes(), 0);
+    }
+
+    function testMinReturn0WithReturn() {
+        delegateFwd(target, target.returnSomething.selector.toBytes(), 0);
+    }
+
+    function testMinReturn32WithReturn() {
+        delegateFwd(target, target.returnSomething.selector.toBytes(), 32);
+    }
+
+    function testFailsIfReturnLessThanMin() {
+        TestDelegateProxy(throwProxy).revertIfReturnLessThanMin();
+        throwProxy.assertThrows("should have reverted if return data was less than min");
+    }
+
+    function revertIfReturnLessThanMin() {
+        delegateFwd(target, target.dontReturn.selector.toBytes(), 32);
+    }
+
+    function testSelfdestructIsRevertedWithMinReturn() {
+        TestDelegateProxy(throwProxy).revertIfReturnLessThanMinAndDie();
+        throwProxy.assertThrows("should have reverted to stop selfdestruct");
+    }
+
+    function revertIfReturnLessThanMinAndDie() {
+        delegateFwd(target, target.die.selector.toBytes(), 32);
+    }
+
+    function testFailIfReverts() {
+        TestDelegateProxy(throwProxy).revertIfReturnLessThanMinAndDie();
+        throwProxy.assertThrows("should have reverted if call reverted");
+    }
+
+    function revertCall() {
+        delegateFwd(target, target.fail.selector.toBytes(), 0);
+    }
+
+    // keep as last test as it will kill this contract
+    function testDieIfMinReturn0() {
+        delegateFwd(target, target.die.selector.toBytes(), 0);
+    }
+}

--- a/test/TestDelegateProxy.sol
+++ b/test/TestDelegateProxy.sol
@@ -60,7 +60,7 @@ contract TestDelegateProxy is DelegateProxy {
     }
 
     function testFailIfReverts() {
-        TestDelegateProxy(throwProxy).revertIfReturnLessThanMinAndDie();
+        TestDelegateProxy(throwProxy).revertCall();
         throwProxy.assertThrows("should have reverted if call reverted");
     }
 

--- a/test/helpers/ThrowProxy.sol
+++ b/test/helpers/ThrowProxy.sol
@@ -1,0 +1,32 @@
+pragma solidity ^0.4.18;
+
+import "truffle/Assert.sol";
+
+// Based on Simon de la Rouviere method: http://truffleframework.com/tutorials/testing-for-throws-in-solidity-tests
+
+// Proxy contract for testing throws
+contract ThrowProxy {
+  address public target;
+  bytes data;
+
+  function ThrowProxy(address _target) {
+    target = _target;
+  }
+
+  //prime the data using the fallback function.
+  function() {
+    data = msg.data;
+  }
+
+  function assertThrows(string msg) {
+    Assert.isFalse(execute(), msg);
+  }
+
+  function assertItDoesntThrow(string msg) {
+    Assert.isTrue(execute(), msg);
+  }
+
+  function execute() returns (bool) {
+    return target.call(data);
+  }
+}


### PR DESCRIPTION
Adds a new param to `delegateFwd(...)` to pass the minimum amount of bytes the underlying call must return, otherwise, it reverts. I kept the old function as a convenince method that just passes `0` as the minimum return data size.

This allows things such as always forcing to return something when calling a specific type of contract to avoid a `selfdesctruct`. Given that when a `selfdestruct` occurs the context is exited returning `1` (success) but always returns 0 bytes of data. Ideally this would be done at the protocol level, returning a different error code when it `selfdestruct`s but we can't wait.

This only works if you force the functions you forward to return something (setting the min to 32 and returning a boolean is enough).