### PR TITLE
ENSFactory: import ENSConstants instead of ENSSubdomainRegistrar

### DIFF
--- a/contracts/factory/ENSFactory.sol
+++ b/contracts/factory/ENSFactory.sol
@@ -2,7 +2,7 @@ pragma solidity 0.4.18;
 
 import "../lib/ens/ENS.sol";
 import "../lib/ens/PublicResolver.sol";
-import "../ens/ENSSubdomainRegistrar.sol";
+import "../ens/ENSConstants.sol";
 
 
 contract ENSFactory is ENSConstants {


### PR DESCRIPTION
> for ENSFactory.js import "./ENSConstants.sol" instead of import "../ens/ENSSubdomainRegistrar.sol"