### PR TITLE
AragonApp: add comments for inheriting from ACLSyntaxSugar, EVMScriptRunner

### DIFF
--- a/contracts/apps/AragonApp.sol
+++ b/contracts/apps/AragonApp.sol
@@ -6,6 +6,8 @@ import "../evmscript/EVMScriptRunner.sol";
 import "../acl/ACLSyntaxSugar.sol";
 
 
+// ACLSyntaxSugar and EVMScriptRunner are not directly used by this contract, but are included so
+// that they are automatically usable by subclassing contracts
 contract AragonApp is AppStorage, Initializable, ACLSyntaxSugar, EVMScriptRunner {
     modifier auth(bytes32 _role) {
         require(canPerform(msg.sender, _role, new uint256[](0)));


### PR DESCRIPTION
adriamb:
> Seems that AragonApp does not need to be a EVMScriptRunner

ji:
> we decided to add it to the baseclass instead of requiring every app to add it

adriamb:

> Cool, I think that is good idea to annotate this decision in the code. Code readers usually expect that some functionality is used when a class implements another"