### PR TITLE
Tests: Make string concats for BigNumber more obvious

### DIFF
--- a/test/kernel_acl.js
+++ b/test/kernel_acl.js
@@ -100,7 +100,7 @@ contract('Kernel ACL', accounts => {
             const argId = '0x00' // arg 0
             const op = '02'      // not equal
             const value = '000000000000000000000000000000000000000000000000000000000000'  // namespace 0
-            const param = new web3.BigNumber(argId + op + value)
+            const param = new web3.BigNumber(`${argId}${op}${value}`)
 
             const r1 = await acl.grantPermissionP(accounts[3], app, role, [param], { from: granted })
             // grants again without re-saving params

--- a/test/kernel_apps.js
+++ b/test/kernel_apps.js
@@ -165,7 +165,7 @@ contract('Kernel apps', accounts => {
                         const argId = '0x00' // arg 0
                         const op = '03'      // greater than
                         const value = '000000000000000000000000000000000000000000000000000000000005'  // 5
-                        const param = new web3.BigNumber(argId + op + value)
+                        const param = new web3.BigNumber(`${argId}${op}${value}`)
 
                         await acl.grantPermissionP(accounts[2], appProxy.address, r2, [param], { from: permissionsRoot })
                     })


### PR DESCRIPTION
I think this makes it much more clear we're relying on the string concat rather than math addition for computing a number :).