### PR TITLE
ACL: simplify XOR op

### DIFF
--- a/contracts/acl/ACL.sol
+++ b/contracts/acl/ACL.sol
@@ -304,7 +304,7 @@ contract ACL is IACL, AragonApp, ACLHelpers {
         bool r2 = evalParam(_paramsHash, v2, _who, _where, _what, _how);
 
         if (Op(_param.op) == Op.XOR) {
-            return (r1 && !r2) || (!r1 && r2);
+            return r1 != r2;
         }
 
         return r2; // both or and and depend on result of r2 after checks


### PR DESCRIPTION
adriamb:
> https://github.com/aragon/aragonOS/blob/dev/contracts/acl/ACL.sol#L311 > (r1 && !r2) || (!r1 && r2);  why not to use the ^ xor operator?

ji:
> i didn't know the operator was available in solidity

------------

XOR for two booleans is simply `!=` :).