### PR TITLE
Tests: restart ganache every test

### DIFF
--- a/scripts/ganache-cli.sh
+++ b/scripts/ganache-cli.sh
@@ -24,8 +24,9 @@ start_testrpc() {
 }
 
 if testrpc_running; then
-  echo "Using existing testrpc instance at port $testrpc_port"
-else
-  echo "Starting our own testrpc instance at port $testrpc_port"
-  start_testrpc
+  echo "Killing testrpc instance at port $testrpc_port"
+  kill -9 $(lsof -i:$testrpc_port -t)
 fi
+
+echo "Starting our own testrpc instance at port $testrpc_port"
+start_testrpc


### PR DESCRIPTION
It's not as necessary in aragonOS, but I thought we mind as well restart a clean instance of ganache on every test.

Was there a reason we didn't do this here though, @bingen (I think you added this to aragon-apps?)