### PR TITLE
Tests: increase gas limit in truffle config

### DIFF
--- a/truffle-config.js
+++ b/truffle-config.js
@@ -33,13 +33,13 @@ module.exports = {
       network_id: 15,
       host: 'localhost',
       port: 8545,
-      gas: 6.9e6,
+      gas: 8.0e6,
     },
     devnet: {
       network_id: 15,
       host: 'devnet',
       port: 8545,
-      gas: 6.9e6,
+      gas: 8.0e6,
     },
     ropsten: {
       network_id: 3,


### PR DESCRIPTION
So I found this fixes `npm run test`, but not the coverage locally :(.

Related to #286, #288.