### PR TITLE
Split APM creation transaction

### DIFF
--- a/contracts/factory/APMRegistryFactory.sol
+++ b/contracts/factory/APMRegistryFactory.sol
@@ -16,6 +16,7 @@ contract APMRegistryFactory is APMRegistryConstants {
     ENSSubdomainRegistrar public ensSubdomainRegistrarBase;
     ENS public ens;
 
+    event DeployAPMDao(bytes32 indexed node, address dao);
     event DeployAPM(bytes32 indexed node, address apm);
 
     // Needs either one ENS or ENSFactory
@@ -39,7 +40,14 @@ contract APMRegistryFactory is APMRegistryConstants {
         ens = _ens != address(0) ? _ens : _ensFactory.newENS(this);
     }
 
-    function newAPM(bytes32 _tld, bytes32 _label, address _root) public returns (APMRegistry) {
+    function newAPMDao(bytes32 _tld, bytes32 _label) public returns (Kernel) {
+        bytes32 node = keccak256(_tld, _label);
+        Kernel dao = daoFactory.newDAO(this);
+        DeployAPMDao(node, dao);
+        return dao;
+    }
+
+    function newAPM(bytes32 _tld, bytes32 _label, address _root, address _dao) public returns (APMRegistry) {
         bytes32 node = keccak256(_tld, _label);
 
         // Assume it is the test ENS
@@ -48,7 +56,7 @@ contract APMRegistryFactory is APMRegistryConstants {
             ens.setSubnodeOwner(_tld, _label, this);
         }
 
-        Kernel dao = daoFactory.newDAO(this);
+        Kernel dao = Kernel(_dao);
         ACL acl = ACL(dao.acl());
 
         acl.createPermission(this, dao, dao.APP_MANAGER_ROLE(), this);

--- a/migrations/2_apm.js
+++ b/migrations/2_apm.js
@@ -1,6 +1,8 @@
 const namehash = require('eth-ens-namehash').hash
 const keccak256 = require('js-sha3').keccak_256
 
+const getEvent = (receipt, event, arg) => { return receipt.logs.filter(l => l.event == event)[0].args[arg] }
+
 module.exports = async (deployer, network, accounts, arts = null) => {
   if (arts != null) artifacts = arts // allow running outside
 
@@ -30,8 +32,10 @@ module.exports = async (deployer, network, accounts, arts = null) => {
 
   console.log('Deploying APM...')
   const root = '0xffffffffffffffffffffffffffffffffffffffff' // public
-  const receipt = await factory.newAPM(namehash('eth'), '0x'+keccak256('aragonpm'), root)
-  const apmAddr = receipt.logs.filter(l => l.event == 'DeployAPM')[0].args.apm
+  const receiptDao = await factory.newAPMDao(namehash('eth'), '0x'+keccak256('aragonpm'))
+  const daoAddr = getEvent(receiptDao, 'DeployAPMDao', 'dao')
+  const receipt = await factory.newAPM(namehash('eth'), '0x'+keccak256('aragonpm'), root, daoAddr)
+  const apmAddr = getEvent(receipt, 'DeployAPM', 'apm')
   console.log('Deployed APM at:', apmAddr)
 
   const apm = getContract('APMRegistry').at(apmAddr)

--- a/test/mocks/APMRegistryFactoryMock.sol
+++ b/test/mocks/APMRegistryFactoryMock.sol
@@ -16,7 +16,7 @@ contract APMRegistryFactoryMock is APMRegistryFactory {
     )
     APMRegistryFactory(_daoFactory, _registryBase, _repoBase, _ensSubBase, _ens, _ensFactory) public {}
 
-    function newAPM(bytes32 tld, bytes32 label, address _root) public returns (APMRegistry) {}
+    function newAPM(bytes32 tld, bytes32 label, address _root, address _dao) public returns (APMRegistry) {}
 
     function newBadAPM(bytes32 tld, bytes32 label, address _root, bool withoutACL) public returns (APMRegistry) {
         bytes32 node = keccak256(tld, label);


### PR DESCRIPTION
To fix gas issues and on deployment and `npm run test`, `newAPM` is
now split into 2 transactions to avoid passing the transaction gas
limit. The first one just creates the DAO, which currently consumes
~1.5M gas.

Replaces #295 