### PR TITLE
[WIP] Switch namespace order - DO NOT merge!!

### DIFF
--- a/contracts/ens/ENSConstants.sol
+++ b/contracts/ens/ENSConstants.sol
@@ -3,8 +3,14 @@ pragma solidity ^0.4.18;
 
 contract ENSConstants {
     bytes32 constant public ENS_ROOT = bytes32(0);
+    /* Constants are hardcoded to save gas
     bytes32 constant public ETH_TLD_LABEL = keccak256("eth");
     bytes32 constant public ETH_TLD_NODE = keccak256(ENS_ROOT, ETH_TLD_LABEL);
     bytes32 constant public PUBLIC_RESOLVER_LABEL = keccak256("resolver");
     bytes32 constant public PUBLIC_RESOLVER_NODE = keccak256(ETH_TLD_NODE, PUBLIC_RESOLVER_LABEL);
+    */
+    bytes32 constant public ETH_TLD_LABEL = 0x4f5b812789fc606be1b3b16908db13fc7a9adf7ca72641f84d75b47069d3d7f0;
+    bytes32 constant public ETH_TLD_NODE = 0x93cdeb708b7545dc668eb9280176169d1c33cfd8ed6f04690a0bcc88a93fc4ae;
+    bytes32 constant public PUBLIC_RESOLVER_LABEL = 0x329539a1d23af1810c48a07fe7fc66a3b34fbc8b37e9b3cdb97bb88ceab7e4bf;
+    bytes32 constant public PUBLIC_RESOLVER_NODE = 0xfdd5d5de6dd63db72bbc2d487944ba13bf775b50a80805fe6fcaba9b0fba88f5;
 }

--- a/contracts/kernel/KernelStorage.sol
+++ b/contracts/kernel/KernelStorage.sol
@@ -1,18 +1,30 @@
 pragma solidity 0.4.18;
 
-import "../apm/APMNamehash.sol";
 
-
-contract KernelConstants is APMNamehash {
+contract KernelConstants {
+    /* Replacing by constants to save gas
     bytes32 constant public CORE_NAMESPACE = keccak256("core");
     bytes32 constant public APP_BASES_NAMESPACE = keccak256("base");
     bytes32 constant public APP_ADDR_NAMESPACE = keccak256("app");
 
+    bytes32 constant public ETH_NODE = keccak256(bytes32(0), keccak256("eth"));
+    bytes32 constant public APM_NODE = keccak256(ETH_NODE, keccak256("aragonpm"));
+
     bytes32 constant public KERNEL_APP_ID = apmNamehash("kernel");
-    bytes32 constant public KERNEL_APP = keccak256(CORE_NAMESPACE, KERNEL_APP_ID);
+    bytes32 constant public KERNEL_APP = keccak256(KERNEL_APP_ID, CORE_NAMESPACE);
 
     bytes32 constant public ACL_APP_ID = apmNamehash("acl");
-    bytes32 constant public ACL_APP = keccak256(APP_ADDR_NAMESPACE, ACL_APP_ID);
+    bytes32 constant public ACL_APP = keccak256(ACL_APP_ID, APP_ADDR_NAMESPACE);
+    */
+    bytes32 constant public CORE_NAMESPACE = 0xc681a85306374a5ab27f0bbc385296a54bcd314a1948b6cf61c4ea1bc44bb9f8;
+    bytes32 constant public APP_BASES_NAMESPACE = 0xf1f3eb40f5bc1ad1344716ced8b8a0431d840b5783aea1fd01786bc26f35ac0f;
+    bytes32 constant public APP_ADDR_NAMESPACE = 0xd6f028ca0e8edb4a8c9757ca4fdccab25fa1e0317da1188108f7d2dee14902fb;
+    bytes32 constant public ETH_NODE = 0x93cdeb708b7545dc668eb9280176169d1c33cfd8ed6f04690a0bcc88a93fc4ae;
+    bytes32 constant public APM_NODE = 0x9065c3e7f7b7ef1ef4e53d2d0b8e0cef02874ab020c1ece79d5f0d3d0111c0ba;
+    bytes32 constant public KERNEL_APP_ID = 0x3b4bf6bf3ad5000ecf0f989d5befde585c6860fea3e574a4fab4c49d1c177d9c;
+    bytes32 constant public KERNEL_APP = 0x23e35788a6d6a5b272751cb430674134e18cd490aafd5d2dcf3d697ff56a98ca;
+    bytes32 constant public ACL_APP_ID = 0xe3262375f45a6e2026b7e7b18c2b807434f2508fe1a2a3dfb493c7df8f4aad6a;
+    bytes32 constant public ACL_APP = 0xe580c974172afa3b038e1c862cec20f3ece8d5fb54e3239f30446e26d2920c49;
 }
 
 

--- a/test/constants.js
+++ b/test/constants.js
@@ -1,0 +1,40 @@
+const namehash = require('eth-ens-namehash').hash
+const keccak_256 = require('js-sha3').keccak_256
+
+const getContract = name => artifacts.require(name)
+const keccak256 = (name) => '0x' + keccak_256(name)
+
+contract('Constants', accounts => {
+  const coreString = 'core'
+  const baseString = 'base'
+  const appString = 'app'
+  const apmNodeString = 'aragonpm.eth'
+  const kernelString = 'kernel'
+  const aclString = 'acl'
+
+  it('checks kernel constants', async () => {
+    const kernelConstants = await getContract('KernelConstants').new()
+    console.log("ETH node: " + await kernelConstants.ETH_NODE())
+    console.log("Apm node: " + await kernelConstants.APM_NODE())
+    assert.equal(await kernelConstants.CORE_NAMESPACE(), keccak256(coreString), "core namespace doesn't match")
+    assert.equal(await kernelConstants.APP_BASES_NAMESPACE(), keccak256(baseString), "base namespace doesn't match")
+    assert.equal(await kernelConstants.APP_ADDR_NAMESPACE(), keccak256(appString), "app namespace doesn't match")
+
+    assert.equal(await kernelConstants.KERNEL_APP_ID(), namehash(kernelString + '.' + apmNodeString), "kernel app id doesn't match")
+    assert.equal(await kernelConstants.KERNEL_APP(), namehash(coreString + '.' + kernelString + '.' + apmNodeString), "kernel app doesn't match")
+
+    assert.equal(await kernelConstants.ACL_APP_ID(), namehash(aclString + '.' + apmNodeString), "acl app id doesn't match")
+    assert.equal(await kernelConstants.ACL_APP(), namehash(appString + '.' + aclString + '.' + apmNodeString), "acl app doesn't match")
+  })
+
+  it('checks ENS constants', async () => {
+    const ethString = 'eth'
+    const resolverString = 'resolver'
+
+    const ensConstants = await getContract('ENSConstants').new()
+    assert.equal(await ensConstants.ETH_TLD_LABEL(), keccak256(ethString), "ETH tld label doesn't match")
+    assert.equal(await ensConstants.ETH_TLD_NODE(), namehash(ethString), "ETH tld node doesn't match")
+    assert.equal(await ensConstants.PUBLIC_RESOLVER_LABEL(), keccak256(resolverString), "public resolver label doesn't match")
+    assert.equal(await ensConstants.PUBLIC_RESOLVER_NODE(), namehash(resolverString + '.' + ethString), "public resolver node doesn't match")
+  })
+})


### PR DESCRIPTION
Temporary PR with namespace change proposal, to remember later on an eventual discussion.

Before we were using, e.g. for kernel app:

`keccak256(keccak256(keccak256(keccak256(keccak256('core'), bytes32(0)),
'eth'), 'aragonpm'), 'kernel')`

With this change we would use:

`keccak256(keccak256(keccak256(keccak256(keccak256(bytes32(0)), 'eth'),
'aragonpm'), 'kernel'), 'core')`

Which is equivalent to `namehash("core.kernel.aragonpm.eth")`

TODO:
- Remove APMNamehash
- Change constants in IEVMScriptRegistry.sol
- Change constants in ACL.sol
- Change order everywhere namespaces are used
- Add bytes32(0) at the other end (after namespace)??