### PR TITLE
Implement and test conditional recoverability

### DIFF
--- a/contracts/common/IVaultRecoverable.sol
+++ b/contracts/common/IVaultRecoverable.sol
@@ -2,6 +2,8 @@ pragma solidity ^0.4.18;
 
 
 interface IVaultRecoverable {
+    function transferToVault(address token) external;
+
+    function allowRecoverability(address token) public view returns (bool);
     function getRecoveryVault() public view returns (address);
-    function transferToVault(address _token) external;
 }

--- a/contracts/common/VaultRecoverable.sol
+++ b/contracts/common/VaultRecoverable.sol
@@ -13,6 +13,7 @@ contract VaultRecoverable is IVaultRecoverable, EtherTokenConstant, IsContract {
      * @param _token Token balance to be sent to recovery vault.
      */
     function transferToVault(address _token) external {
+        require(allowRecoverability(_token));
         address vault = getRecoveryVault();
         require(isContract(vault));
 
@@ -22,5 +23,14 @@ contract VaultRecoverable is IVaultRecoverable, EtherTokenConstant, IsContract {
             uint256 amount = ERC20(_token).balanceOf(this);
             ERC20(_token).transfer(vault, amount);
         }
+    }
+
+    /**
+    * @dev By default deriving from AragonApp makes it recoverable
+    * @param token Token address that would be recovered
+    * @return bool whether the app allows the recovery
+    */
+    function allowRecoverability(address token) public view returns (bool) {
+        return true;
     }
 }

--- a/test/mocks/AppStubConditionalRecovery.sol
+++ b/test/mocks/AppStubConditionalRecovery.sol
@@ -1,0 +1,11 @@
+pragma solidity 0.4.18;
+
+import "../../contracts/apps/AragonApp.sol";
+
+
+contract AppStubConditionalRecovery is AragonApp {
+	function allowRecoverability(address token) public view returns (bool) {
+		// Doesn't allow to recover ether
+		return token != address(0);
+	}
+} 


### PR DESCRIPTION
Adds the `allowRecoverability(address token)` function that can be overwritten by apps to block recoverability of certain tokens. 

Blocking recoverability is important for some apps that hold assets themselves, otherwise an organization with 2 vaults can have all funds moved to the default vault.
