### PR TITLE
renamed ACL functions to simpler names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ scTopics
 functions.csv
 artifacts/
 allFiredEvents
+truffle.js

--- a/contracts/acl/ACL.sol
+++ b/contracts/acl/ACL.sol
@@ -106,7 +106,7 @@ contract ACL is IACL, AragonApp, ACLHelpers {
         public
     {
         bytes32 paramsHash = _params.length > 0 ? _saveParams(_params) : EMPTY_PARAM_HASH;
-        _set(_entity, _app, _role, paramsHash);
+        _setPermission(_entity, _app, _role, paramsHash);
     }
 
     /**
@@ -120,7 +120,7 @@ contract ACL is IACL, AragonApp, ACLHelpers {
         onlyPermissionManager(_app, _role)
         external
     {
-        _set(_entity, _app, _role, bytes32(0));
+        _setPermission(_entity, _app, _role, bytes32(0));
     }
 
     /**
@@ -244,14 +244,14 @@ contract ACL is IACL, AragonApp, ACLHelpers {
         // only allow permission creation (or re-creation) when there is no manager
         require(getManager(_app, _role) == address(0));
 
-        _set(_entity, _app, _role, EMPTY_PARAM_HASH);
+        _setPermission(_entity, _app, _role, EMPTY_PARAM_HASH);
         _setManager(_manager, _app, _role);
     }
 
     /**
     * @dev Internal function called to actually save the permission
     */
-    function _set(address _entity, address _app, bytes32 _role, bytes32 _paramsHash) internal {
+    function _setPermission(address _entity, address _app, bytes32 _role, bytes32 _paramsHash) internal {
         permissions[permissionHash(_entity, _app, _role)] = _paramsHash;
 
         SetPermission(_entity, _app, _role, _paramsHash != bytes32(0));

--- a/contracts/apm/APMRegistry.sol
+++ b/contracts/apm/APMRegistry.sol
@@ -73,9 +73,9 @@ contract APMRegistry is AragonApp, AppProxyFactory, APMRegistryConstants {
 
         // Give permissions to _dev
         ACL acl = ACL(kernel.acl());
-        acl.revokePermission(this, repo, repo.CREATE_VERSION_ROLE());
-        acl.grantPermission(_dev, repo, repo.CREATE_VERSION_ROLE());
-        acl.setPermissionManager(_dev, repo, repo.CREATE_VERSION_ROLE());
+        acl.revoke(this, repo, repo.CREATE_VERSION_ROLE());
+        acl.grant(_dev, repo, repo.CREATE_VERSION_ROLE());
+        acl.setManager(_dev, repo, repo.CREATE_VERSION_ROLE());
         return repo;
     }
 
@@ -84,7 +84,7 @@ contract APMRegistry is AragonApp, AppProxyFactory, APMRegistryConstants {
 
         Repo repo = newClonedRepo();
 
-        ACL(kernel.acl()).createPermission(_dev, repo, repo.CREATE_VERSION_ROLE(), _dev);
+        ACL(kernel.acl()).create(_dev, repo, repo.CREATE_VERSION_ROLE(), _dev);
 
         // Creates [name] subdomain in the rootNode and sets registry as resolver
         // This will fail if repo name already exists

--- a/contracts/factory/APMRegistryFactory.sol
+++ b/contracts/factory/APMRegistryFactory.sol
@@ -51,7 +51,7 @@ contract APMRegistryFactory is APMRegistryConstants {
         Kernel dao = daoFactory.newDAO(this);
         ACL acl = ACL(dao.acl());
 
-        acl.createPermission(this, dao, dao.APP_MANAGER_ROLE(), this);
+        acl.create(this, dao, dao.APP_MANAGER_ROLE(), this);
 
         bytes32 namespace = dao.APP_BASES_NAMESPACE();
 
@@ -65,13 +65,13 @@ contract APMRegistryFactory is APMRegistryConstants {
         DeployAPM(node, apm);
 
         // Grant permissions needed for APM on ENSSubdomainRegistrar
-        acl.createPermission(apm, ensSub, ensSub.CREATE_NAME_ROLE(), _root);
-        acl.createPermission(apm, ensSub, ensSub.POINT_ROOTNODE_ROLE(), _root);
+        acl.create(apm, ensSub, ensSub.CREATE_NAME_ROLE(), _root);
+        acl.create(apm, ensSub, ensSub.POINT_ROOTNODE_ROLE(), _root);
 
         // allow apm to create permissions for Repos in Kernel
         bytes32 permRole = acl.CREATE_PERMISSIONS_ROLE();
 
-        acl.grantPermission(apm, acl, permRole);
+        acl.grant(apm, acl, permRole);
 
         // Initialize
         ens.setOwner(node, ensSub);
@@ -81,7 +81,7 @@ contract APMRegistryFactory is APMRegistryConstants {
         uint16[3] memory firstVersion;
         firstVersion[0] = 1;
 
-        acl.createPermission(this, apm, apm.CREATE_REPO_ROLE(), this);
+        acl.create(this, apm, apm.CREATE_REPO_ROLE(), this);
 
         apm.newRepoWithVersion(APM_APP_NAME, _root, firstVersion, registryBase, b("ipfs:apm"));
         apm.newRepoWithVersion(ENS_SUB_APP_NAME, _root, firstVersion, ensSubdomainRegistrarBase, b("ipfs:enssub"));
@@ -90,10 +90,10 @@ contract APMRegistryFactory is APMRegistryConstants {
         configureAPMPermissions(acl, apm, _root);
 
         // Permission transition to _root
-        acl.setPermissionManager(_root, dao, dao.APP_MANAGER_ROLE());
-        acl.revokePermission(this, acl, permRole);
-        acl.grantPermission(_root, acl, permRole);
-        acl.setPermissionManager(_root, acl, permRole);
+        acl.setManager(_root, dao, dao.APP_MANAGER_ROLE());
+        acl.revoke(this, acl, permRole);
+        acl.grant(_root, acl, permRole);
+        acl.setManager(_root, acl, permRole);
 
         return apm;
     }
@@ -104,7 +104,7 @@ contract APMRegistryFactory is APMRegistryConstants {
 
     // Factory can be subclassed and permissions changed
     function configureAPMPermissions(ACL _acl, APMRegistry _apm, address _root) internal {
-        _acl.grantPermission(_root, _apm, _apm.CREATE_REPO_ROLE());
-        _acl.setPermissionManager(_root, _apm, _apm.CREATE_REPO_ROLE());
+        _acl.grant(_root, _apm, _apm.CREATE_REPO_ROLE());
+        _acl.setManager(_root, _apm, _apm.CREATE_REPO_ROLE());
     }
 }

--- a/contracts/factory/DAOFactory.sol
+++ b/contracts/factory/DAOFactory.sol
@@ -41,20 +41,20 @@ contract DAOFactory {
             bytes32 permRole = acl.CREATE_PERMISSIONS_ROLE();
             bytes32 appManagerRole = dao.APP_MANAGER_ROLE();
 
-            acl.grantPermission(regFactory, acl, permRole);
+            acl.grant(regFactory, acl, permRole);
 
-            acl.createPermission(regFactory, dao, appManagerRole, this);
+            acl.create(regFactory, dao, appManagerRole, this);
 
             EVMScriptRegistry reg = regFactory.newEVMScriptRegistry(dao, _root);
             DeployEVMScriptRegistry(address(reg));
 
-            acl.revokePermission(regFactory, dao, appManagerRole);
-            acl.revokePermission(regFactory, acl, permRole);
-            acl.revokePermission(this, acl, permRole);
-            acl.grantPermission(_root, acl, permRole);
+            acl.revoke(regFactory, dao, appManagerRole);
+            acl.revoke(regFactory, acl, permRole);
+            acl.revoke(this, acl, permRole);
+            acl.grant(_root, acl, permRole);
 
-            acl.removePermissionManager(dao, appManagerRole);
-            acl.setPermissionManager(_root, acl, permRole);
+            acl.removeManager(dao, appManagerRole);
+            acl.setManager(_root, acl, permRole);
         }
 
         DeployDAO(dao);

--- a/contracts/factory/EVMScriptRegistryFactory.sol
+++ b/contracts/factory/EVMScriptRegistryFactory.sol
@@ -31,14 +31,14 @@ contract EVMScriptRegistryFactory is AppProxyFactory, EVMScriptRegistryConstants
         ACL acl = ACL(_dao.acl());
 
         _dao.setApp(_dao.APP_ADDR_NAMESPACE(), EVMSCRIPT_REGISTRY_APP_ID, reg);
-        acl.createPermission(this, reg, reg.REGISTRY_MANAGER_ROLE(), this);
+        acl.create(this, reg, reg.REGISTRY_MANAGER_ROLE(), this);
 
         reg.addScriptExecutor(baseCalls);     // spec 1 = CallsScript
         reg.addScriptExecutor(baseDel);       // spec 2 = DelegateScript
         reg.addScriptExecutor(baseDeployDel); // spec 3 = DeployDelegateScript
 
-        acl.revokePermission(this, reg, reg.REGISTRY_MANAGER_ROLE());
-        acl.setPermissionManager(_root, reg, reg.REGISTRY_MANAGER_ROLE());
+        acl.revoke(this, reg, reg.REGISTRY_MANAGER_ROLE());
+        acl.setManager(_root, reg, reg.REGISTRY_MANAGER_ROLE());
 
         return reg;
     }

--- a/contracts/kernel/Kernel.sol
+++ b/contracts/kernel/Kernel.sol
@@ -17,7 +17,7 @@ contract Kernel is IKernel, KernelStorage, Initializable, AppProxyFactory, ACLSy
     * @dev Initialize can only be called once. It saves the block number in which it was initialized.
     * @notice Initializes a kernel instance along with its ACL and sets `_permissionsCreator` as the entity that can create other permissions
     * @param _baseAcl Address of base ACL app
-    * @param _permissionsCreator Entity that will be given permission over createPermission
+    * @param _permissionsCreator Entity that will be given permission over create
     */
     function initialize(address _baseAcl, address _permissionsCreator) onlyInit public {
         initialized();

--- a/contracts/kernel/KernelProxy.sol
+++ b/contracts/kernel/KernelProxy.sol
@@ -4,6 +4,7 @@ import "./KernelStorage.sol";
 import "../common/DelegateProxy.sol";
 import "../lib/misc/ERCProxy.sol";
 
+
 contract KernelProxy is KernelStorage, DelegateProxy, ERCProxy {
     /**
     * @dev KernelProxy is a proxy contract to a kernel implementation. The implementation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/os",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/apm_registry.js
+++ b/test/apm_registry.js
@@ -47,7 +47,7 @@ contract('APMRegistry', accounts => {
         const subdomainRegistrar = baseDeployed[2]
 
         // Get permission to delete names after each test case
-        await acl.createPermission(apmOwner, await registry.registrar(), await subdomainRegistrar.DELETE_NAME_ROLE(), apmOwner, { from: apmOwner })
+        await acl.create(apmOwner, await registry.registrar(), await subdomainRegistrar.DELETE_NAME_ROLE(), apmOwner, { from: apmOwner })
     })
 
     it('aragonpm.eth should resolve to registry', async () => {
@@ -130,7 +130,7 @@ contract('APMRegistry', accounts => {
             await repo.newVersion([1, 0, 0], '0x00', '0x00', { from: repoDev })
             const newOwner = accounts[8]
 
-            await acl.grantPermission(newOwner, repo.address, await repo.CREATE_VERSION_ROLE(), { from: repoDev })
+            await acl.grant(newOwner, repo.address, await repo.CREATE_VERSION_ROLE(), { from: repoDev })
 
             await repo.newVersion([2, 0, 0], '0x00', '0x00', { from: newOwner })
             await repo.newVersion([2, 1, 0], '0x00', '0x00', { from: repoDev }) // repoDev can still create them
@@ -140,7 +140,7 @@ contract('APMRegistry', accounts => {
 
         it('repo dev can no longer create versions if permission is removed', async () => {
             await repo.newVersion([1, 0, 0], '0x00', '0x00', { from: repoDev })
-            await acl.revokePermission(repoDev, repo.address, await repo.CREATE_VERSION_ROLE(), { from: repoDev })
+            await acl.revoke(repoDev, repo.address, await repo.CREATE_VERSION_ROLE(), { from: repoDev })
 
             return assertRevert(async () => {
                 await repo.newVersion([2, 0, 0], '0x00', '0x00', { from: repoDev })

--- a/test/ens_subdomains.js
+++ b/test/ens_subdomains.js
@@ -52,8 +52,8 @@ contract('ENSSubdomainRegistrar', accounts => {
         const subdomainRegistrar = baseDeployed[2]
 
         // Get permission to delete names after each test case
-        await acl.grantPermission(apmOwner, await registry.registrar(), await subdomainRegistrar.CREATE_NAME_ROLE(), { from: apmOwner })
-        await acl.createPermission(apmOwner, await registry.registrar(), await subdomainRegistrar.DELETE_NAME_ROLE(), apmOwner, { from: apmOwner })
+        await acl.grant(apmOwner, await registry.registrar(), await subdomainRegistrar.CREATE_NAME_ROLE(), { from: apmOwner })
+        await acl.create(apmOwner, await registry.registrar(), await subdomainRegistrar.DELETE_NAME_ROLE(), apmOwner, { from: apmOwner })
     })
 
     afterEach(async () => {

--- a/test/evm_script.js
+++ b/test/evm_script.js
@@ -47,7 +47,7 @@ contract('EVM Script', accounts => {
         acl = ACL.at(await dao.acl())
         reg = EVMScriptRegistry.at(receipt.logs.filter(l => l.event == 'DeployEVMScriptRegistry')[0].args.reg)
 
-        await acl.createPermission(boss, dao.address, await dao.APP_MANAGER_ROLE(), boss, { from: boss })
+        await acl.create(boss, dao.address, await dao.APP_MANAGER_ROLE(), boss, { from: boss })
         baseExecutor = await Executor.new()
         await dao.setApp(APP_BASE_NAMESPACE, executorAppId, baseExecutor.address, { from: boss })
     })
@@ -74,7 +74,7 @@ contract('EVM Script', accounts => {
             executor = Executor.at(receipt.logs.filter(l => l.event == 'NewAppProxy')[0].args.proxy)
             executionTarget = await ExecutionTarget.new()
 
-            await acl.grantPermission(boss, reg.address, await reg.REGISTRY_MANAGER_ROLE(), { from: boss })
+            await acl.grant(boss, reg.address, await reg.REGISTRY_MANAGER_ROLE(), { from: boss })
         })
 
         it('fails to execute if spec ID is 0', async () => {

--- a/test/kernel_acl.js
+++ b/test/kernel_acl.js
@@ -32,7 +32,7 @@ contract('Kernel ACL', accounts => {
 
         kernel = Kernel.at(app)
 
-        // events for kernel.createPermission permission
+        // events for kernel.create permission
         //assertEvent(receipt, 'SetPermission')
         //assertEvent(receipt, 'ChangePermissionManager')
 
@@ -83,13 +83,13 @@ contract('Kernel ACL', accounts => {
 
     it('cannot create permissions without permission', async () => {
         return assertRevert(async () => {
-            await acl.createPermission(granted, app, role, granted, { from: accounts[8] })
+            await acl.create(granted, app, role, granted, { from: accounts[8] })
         })
     })
 
     context('creating permission', () => {
         beforeEach(async () => {
-            const receipt = await acl.createPermission(granted, app, role, granted, { from: permissionsRoot })
+            const receipt = await acl.create(granted, app, role, granted, { from: permissionsRoot })
             assertEvent(receipt, 'SetPermission')
             assertEvent(receipt, 'ChangePermissionManager')
         })
@@ -102,7 +102,7 @@ contract('Kernel ACL', accounts => {
             const value = '000000000000000000000000000000000000000000000000000000000000'  // namespace 0
             const param = new web3.BigNumber(`${argId}${op}${value}`)
 
-            const r1 = await acl.grantPermissionP(accounts[3], app, role, [param], { from: granted })
+            const r1 = await acl.grantP(accounts[3], app, role, [param], { from: granted })
 
             // retrieve the params back with the getters
             const numParams = await acl.getPermissionParamsLength(accounts[3], app, role)
@@ -113,7 +113,7 @@ contract('Kernel ACL', accounts => {
             assert.equal(returnedParam[2].valueOf(), parseInt(value, 10), 'param value should match')
 
             // grants again without re-saving params
-            const r2 = await acl.grantPermissionP(accounts[4], app, role, [param], { from: granted })
+            const r2 = await acl.grantP(accounts[4], app, role, [param], { from: granted })
 
             assert.isBelow(r2.receipt.gasUsed, r1.receipt.gasUsed, 'should have used less gas because of cache')
             // Allow setting code for namespace other than 0
@@ -130,7 +130,7 @@ contract('Kernel ACL', accounts => {
         it('can grant a public permission', async () => {
             const anyEntity = "0xffffffffffffffffffffffffffffffffffffffff"
 
-            await acl.grantPermission(anyEntity, app, role, { from: granted })
+            await acl.grant(anyEntity, app, role, { from: granted })
             // many entities can succesfully perform action
             // acl is used here just to provide an address which is a contract
             await kernel.setApp('0x121212', '0x00', acl.address, { from: accounts[4] })
@@ -141,7 +141,7 @@ contract('Kernel ACL', accounts => {
 
         it('returns created permission', async () => {
             const allowed = await acl.hasPermission(granted, app, role)
-            const manager = await acl.getPermissionManager(app, role)
+            const manager = await acl.getManager(app, role)
 
             assert.isTrue(allowed, 'entity should be allowed to perform role actions')
             assert.equal(manager, granted, 'permission parent should be correct')
@@ -159,13 +159,13 @@ contract('Kernel ACL', accounts => {
 
         it('root cannot revoke permission', async () => {
             return assertRevert(async () => {
-                await acl.revokePermission(granted, app, role, { from: permissionsRoot })
+                await acl.revoke(granted, app, role, { from: permissionsRoot })
             })
         })
 
         it('root cannot re-create permission', async () => {
             return assertRevert(async () => {
-                await acl.createPermission(granted, app, role, granted, { from: permissionsRoot })
+                await acl.create(granted, app, role, granted, { from: permissionsRoot })
             })
         })
 
@@ -173,7 +173,7 @@ contract('Kernel ACL', accounts => {
             // Make sure grandchild doesn't have permission yet
             assert.isFalse(await acl.hasPermission(child, app, role))
             return assertRevert(async () => {
-                await acl.grantPermission(child, app, role, { from: permissionsRoot })
+                await acl.grant(child, app, role, { from: permissionsRoot })
             })
         })
 
@@ -182,17 +182,17 @@ contract('Kernel ACL', accounts => {
             assert.notEqual(newManager, granted, 'newManager should not be the same as granted')
 
             beforeEach(async () => {
-                const receipt = await acl.setPermissionManager(newManager, app, role, { from: granted })
+                const receipt = await acl.setManager(newManager, app, role, { from: granted })
                 assertEvent(receipt, 'ChangePermissionManager')
             })
 
             it('changes manager', async () => {
-                const manager = await acl.getPermissionManager(app, role)
+                const manager = await acl.getManager(app, role)
                 assert.equal(manager, newManager, 'manager should have changed')
             })
 
             it('can grant permission', async () => {
-                const receipt = await acl.grantPermission(newManager, app, role, { from: newManager })
+                const receipt = await acl.grant(newManager, app, role, { from: newManager })
                 assertEvent(receipt, 'SetPermission')
             })
 
@@ -200,7 +200,7 @@ contract('Kernel ACL', accounts => {
                 // Make sure new manager doesn't have permission yet
                 assert.isFalse(await acl.hasPermission(newManager, app, role))
                 return assertRevert(async () => {
-                    await acl.grantPermission(newManager, app, role, { from: granted })
+                    await acl.grant(newManager, app, role, { from: granted })
                 })
             })
         })
@@ -210,21 +210,21 @@ contract('Kernel ACL', accounts => {
             assert.notEqual(newManager, granted, 'newManager should not be the same as granted')
 
             beforeEach(async () => {
-                const receipt = await acl.removePermissionManager(app, role, { from: granted })
+                const receipt = await acl.removeManager(app, role, { from: granted })
                 assertEvent(receipt, 'ChangePermissionManager')
             })
 
             it('removes manager', async () => {
-                const noManager = await acl.getPermissionManager(app, role)
+                const noManager = await acl.getManager(app, role)
                 assert.equal('0x0000000000000000000000000000000000000000', noManager, 'manager should have been removed')
             })
 
             it('can recreate permission', async () => {
-                const createReceipt = await acl.createPermission(newManager, app, role, newManager, { from: permissionsRoot })
+                const createReceipt = await acl.create(newManager, app, role, newManager, { from: permissionsRoot })
                 assertEvent(createReceipt, 'SetPermission')
                 assertEvent(createReceipt, 'ChangePermissionManager')
 
-                const grantReceipt = await acl.grantPermission(granted, app, role, { from: newManager })
+                const grantReceipt = await acl.grant(granted, app, role, { from: newManager })
                 assertEvent(grantReceipt, 'SetPermission')
             })
 
@@ -232,14 +232,14 @@ contract('Kernel ACL', accounts => {
                 // Make sure new manager doesn't have permission yet
                 assert.isFalse(await acl.hasPermission(newManager, app, role))
                 return assertRevert(async () => {
-                    await acl.grantPermission(newManager, app, role, { from: granted })
+                    await acl.grant(newManager, app, role, { from: granted })
                 })
             })
         })
 
         context('self-revokes permission', () => {
             beforeEach(async () => {
-                const receipt = await acl.revokePermission(granted, app, role, { from: granted })
+                const receipt = await acl.revoke(granted, app, role, { from: granted })
                 assertEvent(receipt, 'SetPermission')
             })
 
@@ -249,19 +249,19 @@ contract('Kernel ACL', accounts => {
 
             it('permissions root cannot re-create', async () => {
                 return assertRevert(async () => {
-                    await acl.createPermission(granted, app, role, granted, { from: permissionsRoot })
+                    await acl.create(granted, app, role, granted, { from: permissionsRoot })
                 })
             })
 
             it('permission manager can grant the permission', async () => {
-                await acl.grantPermission(granted, app, role, { from: granted })
+                await acl.grant(granted, app, role, { from: granted })
                 assert.isTrue(await acl.hasPermission(granted, app, role))
             })
         })
 
         context('re-grants to child', () => {
             beforeEach(async () => {
-                const receipt = await acl.grantPermission(child, app, role, { from: granted })
+                const receipt = await acl.grant(child, app, role, { from: granted })
                 assertEvent(receipt, 'SetPermission')
             })
 
@@ -274,12 +274,12 @@ contract('Kernel ACL', accounts => {
                 // Make sure grandchild doesn't have permission yet
                 assert.isFalse(await acl.hasPermission(grandchild, app, role))
                 return assertRevert(async () => {
-                    await acl.grantPermission(grandchild, app, role, { from: child })
+                    await acl.grant(grandchild, app, role, { from: child })
                 })
             })
 
             it('parent can revoke permission', async () => {
-                const receipt = await acl.revokePermission(child, app, role, { from: granted })
+                const receipt = await acl.revoke(child, app, role, { from: granted })
                 assert.isFalse(await acl.hasPermission(child, app, role))
                 assertEvent(receipt, 'SetPermission')
             })

--- a/test/kernel_apps.js
+++ b/test/kernel_apps.js
@@ -38,7 +38,7 @@ contract('Kernel apps', accounts => {
         acl = ACL.at(await kernel.acl())
 
         const r = await kernel.APP_MANAGER_ROLE()
-        await acl.createPermission(permissionsRoot, kernel.address, r, permissionsRoot)
+        await acl.create(permissionsRoot, kernel.address, r, permissionsRoot)
 
         code1 = await AppStub.new()
         code2 = await AppStub2.new()
@@ -127,7 +127,7 @@ contract('Kernel apps', accounts => {
 
                 // assign app permissions
                 r2 = await appCode1.ROLE()
-                await acl.createPermission(permissionsRoot, appProxy.address, r2, permissionsRoot)
+                await acl.create(permissionsRoot, appProxy.address, r2, permissionsRoot)
             })
 
             it('throws if using app without reference in kernel', async () => {
@@ -176,7 +176,7 @@ contract('Kernel apps', accounts => {
                         const value = '000000000000000000000000000000000000000000000000000000000005'  // 5
                         const param = new web3.BigNumber(`${argId}${op}${value}`)
 
-                        await acl.grantPermissionP(accounts[2], appProxy.address, r2, [param], { from: permissionsRoot })
+                        await acl.grantP(accounts[2], appProxy.address, r2, [param], { from: permissionsRoot })
                     })
 
                     it('parametrized app call fails if param eval fails', async () => {
@@ -231,7 +231,7 @@ contract('Kernel apps', accounts => {
 
             // assign app permissions
             const r2 = await appCode1.ROLE()
-            await acl.createPermission(permissionsRoot, appProxy.address, r2, permissionsRoot)
+            await acl.create(permissionsRoot, appProxy.address, r2, permissionsRoot)
         })
 
         it('checks ERC897 functions', async () => {

--- a/test/kernel_upgrade.js
+++ b/test/kernel_upgrade.js
@@ -52,7 +52,7 @@ contract('Kernel Upgrade', accounts => {
 
     it('successfully upgrades kernel', async () => {
         const role = await kernel.APP_MANAGER_ROLE()
-        await acl.createPermission(permissionsRoot, kernel.address, role, permissionsRoot, { from: permissionsRoot })
+        await acl.create(permissionsRoot, kernel.address, role, permissionsRoot, { from: permissionsRoot })
 
         const upgradedImpl = await UpgradedKernel.new()
         await kernel.setApp(namespace, kernelId, upgradedImpl.address)
@@ -62,7 +62,7 @@ contract('Kernel Upgrade', accounts => {
 
     it('fails if upgrading to kernel that is not a contract', async () => {
         const role = await kernel.APP_MANAGER_ROLE()
-        await acl.createPermission(permissionsRoot, kernel.address, role, permissionsRoot, { from: permissionsRoot })
+        await acl.create(permissionsRoot, kernel.address, role, permissionsRoot, { from: permissionsRoot })
 
         const upgradedImpl = await UpgradedKernel.new()
 

--- a/test/mocks/APMRegistryFactoryMock.sol
+++ b/test/mocks/APMRegistryFactoryMock.sol
@@ -30,7 +30,7 @@ contract APMRegistryFactoryMock is APMRegistryFactory {
         Kernel dao = daoFactory.newDAO(this);
         ACL acl = ACL(dao.acl());
 
-        acl.createPermission(this, dao, dao.APP_MANAGER_ROLE(), this);
+        acl.create(this, dao, dao.APP_MANAGER_ROLE(), this);
 
         bytes32 namespace = dao.APP_BASES_NAMESPACE();
 
@@ -46,10 +46,10 @@ contract APMRegistryFactoryMock is APMRegistryFactory {
         // Grant permissions needed for APM on ENSSubdomainRegistrar
 
         if (withoutACL) {
-            acl.createPermission(apm, ensSub, ensSub.CREATE_NAME_ROLE(), _root);
+            acl.create(apm, ensSub, ensSub.CREATE_NAME_ROLE(), _root);
         }
 
-        acl.createPermission(apm, ensSub, ensSub.POINT_ROOTNODE_ROLE(), _root);
+        acl.create(apm, ensSub, ensSub.POINT_ROOTNODE_ROLE(), _root);
 
         configureAPMPermissions(acl, apm, _root);
 
@@ -57,14 +57,14 @@ contract APMRegistryFactoryMock is APMRegistryFactory {
         bytes32 permRole = acl.CREATE_PERMISSIONS_ROLE();
 
         if (!withoutACL) {
-            acl.grantPermission(apm, acl, permRole);
+            acl.grant(apm, acl, permRole);
         }
 
         // Permission transition to _root
-        acl.setPermissionManager(_root, dao, dao.APP_MANAGER_ROLE());
-        acl.revokePermission(this, acl, permRole);
-        acl.grantPermission(_root, acl, permRole);
-        acl.setPermissionManager(_root, acl, permRole);
+        acl.setManager(_root, dao, dao.APP_MANAGER_ROLE());
+        acl.revoke(this, acl, permRole);
+        acl.grant(_root, acl, permRole);
+        acl.setManager(_root, acl, permRole);
 
         // Initialize
         ens.setOwner(node, ensSub);


### PR DESCRIPTION
Based on this issue:

https://github.com/aragon/aragonOS/issues/223

I renamed the  ACL functions to reduce verbosity, ```npm test``` had all 224 tests passing. 
```npm run lint``` complained about using keyword ```emit``` for events but I did not find protocol for this since most files have different compiler versions, so I left alone. 