### PR TITLE
Expose APMNamehash

### DIFF
--- a/contracts/apm/APMConstants.sol
+++ b/contracts/apm/APMConstants.sol
@@ -1,8 +1,0 @@
-pragma solidity ^0.4.18;
-
-import "../ens/ENSConstants.sol";
-
-
-contract APMConstants is ENSConstants {
-    bytes32 constant public APM_NODE = keccak256(ETH_TLD_NODE, keccak256("aragonpm"));
-}

--- a/contracts/apm/APMConstants.sol
+++ b/contracts/apm/APMConstants.sol
@@ -1,0 +1,8 @@
+pragma solidity ^0.4.18;
+
+import "../ens/ENSConstants.sol";
+
+
+contract APMConstants is ENSConstants {
+    bytes32 constant public APM_NODE = keccak256(ETH_TLD_NODE, keccak256("aragonpm"));
+}

--- a/contracts/apm/APMNamehash.sol
+++ b/contracts/apm/APMNamehash.sol
@@ -1,9 +1,11 @@
 pragma solidity ^0.4.18;
 
-import "../../contracts/apm/APMConstants.sol";
+import "../ens/ENSConstants.sol";
 
 
-contract APMNamehash is APMConstants {
+contract APMNamehash is ENSConstants {
+    bytes32 constant public APM_NODE = keccak256(ETH_TLD_NODE, keccak256("aragonpm"));
+
     function apmNamehash(string name) internal pure returns (bytes32) {
         return keccak256(APM_NODE, keccak256(name));
     }

--- a/test/mocks/APMNamehash.sol
+++ b/test/mocks/APMNamehash.sol
@@ -1,10 +1,9 @@
 pragma solidity ^0.4.18;
 
+import "../../contracts/apm/APMConstants.sol";
 
-contract APMNamehash {
-    bytes32 constant public ETH_NODE = keccak256(bytes32(0), keccak256("eth"));
-    bytes32 constant public APM_NODE = keccak256(ETH_NODE, keccak256("aragonpm"));
 
+contract APMNamehash is APMConstants {
     function apmNamehash(string name) internal pure returns (bytes32) {
         return keccak256(APM_NODE, keccak256(name));
     }

--- a/test/mocks/APMNamehashWrapper.sol
+++ b/test/mocks/APMNamehashWrapper.sol
@@ -8,7 +8,7 @@ contract APMNamehashWrapper is APMNamehash {
 
     function getAPMNamehash(string name) public returns (bytes32 hash) {
         hash = apmNamehash(name);
-        LogHash("eth node", ETH_NODE);
+        LogHash("eth node", ETH_TLD_NODE);
         LogHash("aragonpm.eth", APM_NODE);
         LogHash(name, hash);
         return hash;

--- a/test/mocks/APMNamehashWrapper.sol
+++ b/test/mocks/APMNamehashWrapper.sol
@@ -1,6 +1,6 @@
 pragma solidity 0.4.18;
 
-import "./APMNamehash.sol";
+import "../../contracts/apm/APMNamehash.sol";
 
 
 contract APMNamehashWrapper is APMNamehash {


### PR DESCRIPTION
Exposes `APMNamehash.sol` to let packages like the DAO kits to get an APM namehash without reimplementing it.