### PR TITLE
Relicense interface and extendible contracts as MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -674,3 +674,35 @@ may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
 <http://www.gnu.org/philosophy/why-not-lgpl.html>.
+
+----------------------------------------------------------------------------
+
+MIT License
+
+Copyright (c) 2018 Aragon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+----------------------------------------------------------------------------
+
+Note:
+Unless otherwise specified, individual files are licensed as GPL-3.0-or-later.
+Individual files contain the following tag instead of the full license text.
+
+        SPDX-License-Identifier:    MIT

--- a/contracts/acl/ACLSyntaxSugar.sol
+++ b/contracts/acl/ACLSyntaxSugar.sol
@@ -1,3 +1,7 @@
+/*
+ * SPDX-License-Identitifer:    MIT
+ */
+
 pragma solidity ^0.4.18;
 
 

--- a/contracts/acl/IACL.sol
+++ b/contracts/acl/IACL.sol
@@ -1,3 +1,7 @@
+/*
+ * SPDX-License-Identitifer:    MIT
+ */
+
 pragma solidity ^0.4.18;
 
 

--- a/contracts/apps/AppStorage.sol
+++ b/contracts/apps/AppStorage.sol
@@ -1,3 +1,7 @@
+/*
+ * SPDX-License-Identitifer:    MIT
+ */
+
 pragma solidity ^0.4.18;
 
 import "../kernel/IKernel.sol";

--- a/contracts/apps/AragonApp.sol
+++ b/contracts/apps/AragonApp.sol
@@ -1,3 +1,7 @@
+/*
+ * SPDX-License-Identitifer:    MIT
+ */
+
 pragma solidity ^0.4.18;
 
 import "./AppStorage.sol";

--- a/contracts/common/EtherTokenConstant.sol
+++ b/contracts/common/EtherTokenConstant.sol
@@ -1,3 +1,7 @@
+/*
+ * SPDX-License-Identitifer:    MIT
+ */
+
 pragma solidity ^0.4.18;
 
 

--- a/contracts/common/IForwarder.sol
+++ b/contracts/common/IForwarder.sol
@@ -1,3 +1,7 @@
+/*
+ * SPDX-License-Identitifer:    MIT
+ */
+
 pragma solidity ^0.4.18;
 
 

--- a/contracts/common/IVaultRecoverable.sol
+++ b/contracts/common/IVaultRecoverable.sol
@@ -1,3 +1,7 @@
+/*
+ * SPDX-License-Identitifer:    MIT
+ */
+
 pragma solidity ^0.4.18;
 
 

--- a/contracts/common/Initializable.sol
+++ b/contracts/common/Initializable.sol
@@ -1,3 +1,7 @@
+/*
+ * SPDX-License-Identitifer:    MIT
+ */
+
 pragma solidity ^0.4.18;
 
 import "../apps/AppStorage.sol";

--- a/contracts/common/IsContract.sol
+++ b/contracts/common/IsContract.sol
@@ -1,3 +1,7 @@
+/*
+ * SPDX-License-Identitifer:    MIT
+ */
+
 pragma solidity ^0.4.18;
 
 

--- a/contracts/common/VaultRecoverable.sol
+++ b/contracts/common/VaultRecoverable.sol
@@ -1,3 +1,7 @@
+/*
+ * SPDX-License-Identitifer:    MIT
+ */
+
 pragma solidity ^0.4.18;
 
 import "./EtherTokenConstant.sol";

--- a/contracts/ens/ENSConstants.sol
+++ b/contracts/ens/ENSConstants.sol
@@ -1,3 +1,7 @@
+/*
+ * SPDX-License-Identitifer:    MIT
+ */
+
 pragma solidity ^0.4.18;
 
 

--- a/contracts/evmscript/EVMScriptRunner.sol
+++ b/contracts/evmscript/EVMScriptRunner.sol
@@ -1,3 +1,7 @@
+/*
+ * SPDX-License-Identitifer:    MIT
+ */
+
 pragma solidity ^0.4.18;
 
 import "./ScriptHelpers.sol";

--- a/contracts/evmscript/IEVMScriptExecutor.sol
+++ b/contracts/evmscript/IEVMScriptExecutor.sol
@@ -1,3 +1,7 @@
+/*
+ * SPDX-License-Identitifer:    MIT
+ */
+
 pragma solidity ^0.4.18;
 
 

--- a/contracts/evmscript/IEVMScriptRegistry.sol
+++ b/contracts/evmscript/IEVMScriptRegistry.sol
@@ -1,3 +1,7 @@
+/*
+ * SPDX-License-Identitifer:    MIT
+ */
+
 pragma solidity ^0.4.18;
 
 

--- a/contracts/evmscript/ScriptHelpers.sol
+++ b/contracts/evmscript/ScriptHelpers.sol
@@ -1,3 +1,7 @@
+/*
+ * SPDX-License-Identitifer:    MIT
+ */
+
 pragma solidity ^0.4.18;
 
 

--- a/contracts/kernel/IKernel.sol
+++ b/contracts/kernel/IKernel.sol
@@ -1,3 +1,7 @@
+/*
+ * SPDX-License-Identitifer:    MIT
+ */
+
 pragma solidity ^0.4.18;
 
 import "../acl/IACL.sol";

--- a/contracts/lib/misc/ERCProxy.sol
+++ b/contracts/lib/misc/ERCProxy.sol
@@ -1,3 +1,7 @@
+/*
+ * SPDX-License-Identitifer:    MIT
+ */
+
 pragma solidity ^0.4.18;
 
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "Jorge Izquierdo <jorge@aragon.one>"
   ],
   "repository": "https://github.com/aragon/aragonOS",
-  "license": "GPL-3.0",
+  "license": "(GPL-3.0-or-later OR MIT)",
   "devDependencies": {
     "coveralls": "^2.13.3",
     "eth-ens-namehash": "^2.0.8",


### PR DESCRIPTION
See https://spdx.org/using-spdx-license-identifier and https://spdx.org/sites/cpstandard/files/pages/files/using_spdx_license_list_short_identifiers.pdf.