### PR TITLE
Truffle console is now truffle dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test:gas": "GAS_REPORTER=true npm test",
     "lint": "solium --dir ./contracts",
     "coverage": "SOLIDITY_COVERAGE=true npm run ganache-cli:test",
-    "console": "truffle console",
+    "console": "truffle dev",
     "ganache-cli:test": "scripts/ganache-cli.sh",
     "deploy:devnet:ens": "truffle compile && truffle exec --network devnet scripts/deploy-beta-ens.js",
     "deploy:devnet:apm": "truffle compile && truffle exec --network devnet scripts/deploy-beta-apm.js",


### PR DESCRIPTION
Seems like we forgot to do this in aragonOS 😅 