### PR TITLE
EVMScriptRunner: remove protectState modifier

### DIFF
--- a/contracts/evmscript/EVMScriptRunner.sol
+++ b/contracts/evmscript/EVMScriptRunner.sol
@@ -14,7 +14,7 @@ import "../apps/AppStorage.sol";
 contract EVMScriptRunner is AppStorage, EVMScriptRegistryConstants {
     using ScriptHelpers for bytes;
 
-    function runScript(bytes _script, bytes _input, address[] _blacklist) protectState internal returns (bytes output) {
+    function runScript(bytes _script, bytes _input, address[] _blacklist) internal returns (bytes output) {
         // TODO: Too much data flying around, maybe extracting spec id here is cheaper
         address executorAddr = getExecutor(_script);
         require(executorAddr != address(0));
@@ -52,13 +52,5 @@ contract EVMScriptRunner is AppStorage, EVMScriptRegistryConstants {
             }
         }
         return ret;
-    }
-
-    modifier protectState {
-        address preKernel = kernel;
-        bytes32 preAppId = appId;
-        _; // exec
-        require(kernel == preKernel);
-        require(appId == preAppId);
     }
 }


### PR DESCRIPTION
From https://github.com/ConsenSys/aragonOS-audit-repo/issues/28:

> While this works for the two attributes just mentioned it leaves all other storage variables exposed when the execution of `DeployDelegateScript` or `DelegateScript` is permitted.

> The protectState modifier gives a false sense of security and it should be removed from the contract.

Given that, in general, no `DelegateScript` executor would be considered safe if it contains an `SSTORE` opcode, this modifier is unnecessary.