### PR TITLE
Explicitly state state visibility

### DIFF
--- a/contracts/acl/ACL.sol
+++ b/contracts/acl/ACL.sol
@@ -16,11 +16,11 @@ contract ACL is IACL, AragonApp, ACLHelpers {
     bytes32 constant public CREATE_PERMISSIONS_ROLE = 0x0b719b33c83b8e5d300c521cb8b54ae9bd933996a14bef8c2f4e0285d2d2400a;
 
     // whether a certain entity has a permission
-    mapping (bytes32 => bytes32) permissions; // 0 for no permission, or parameters id
-    mapping (bytes32 => Param[]) public permissionParams;
+    mapping (bytes32 => bytes32) internal permissions; // 0 for no permission, or parameters id
+    mapping (bytes32 => Param[]) internal permissionParams;
 
     // who is the manager of a permission
-    mapping (bytes32 => address) permissionManager;
+    mapping (bytes32 => address) internal permissionManager;
 
     enum Op { NONE, EQ, NEQ, GT, LT, GTE, LTE, RET, NOT, AND, OR, XOR, IF_ELSE } // op types
 

--- a/contracts/apm/APMRegistry.sol
+++ b/contracts/apm/APMRegistry.sol
@@ -18,7 +18,7 @@ contract APMRegistryConstants {
 
 
 contract APMRegistry is AragonApp, AppProxyFactory, APMRegistryConstants {
-    AbstractENS ens;
+    AbstractENS public ens;
     ENSSubdomainRegistrar public registrar;
 
     // bytes32 constant public CREATE_REPO_ROLE = keccak256("CREATE_REPO_ROLE");

--- a/contracts/apm/Repo.sol
+++ b/contracts/apm/Repo.sol
@@ -10,9 +10,9 @@ contract Repo is AragonApp {
         bytes contentURI;
     }
 
-    Version[] versions;
-    mapping (bytes32 => uint256) versionIdForSemantic;
-    mapping (address => uint256) latestVersionIdForContract;
+    Version[] public versions;
+    mapping (bytes32 => uint256) internal versionIdForSemantic;
+    mapping (address => uint256) internal latestVersionIdForContract;
 
     // bytes32 constant public CREATE_VERSION_ROLE = keccak256("CREATE_VERSION_ROLE");
     bytes32 constant public CREATE_VERSION_ROLE = 0x1f56cfecd3595a2e6cc1a7e6cb0b20df84cdbd92eff2fee554e70e4e45a9a7d8;


### PR DESCRIPTION
Default to `public` unless there's a good reason (e.g. a custom getter).