### PR TITLE
Allow tracking of number of authorized users for specific role

### DIFF
--- a/contracts/acl/ACL.sol
+++ b/contracts/acl/ACL.sol
@@ -17,6 +17,8 @@ contract ACL is IACL, AragonApp, ACLHelpers {
 
     // whether a certain entity has a permission
     mapping (bytes32 => bytes32) permissions; // 0 for no permission, or parameters id
+    // Number of people authorized with a permission
+    mapping (bytes32 => uint256) numberOfAuthorized;
     mapping (bytes32 => Param[]) public permissionParams;
 
     // who is the manager of a permission
@@ -222,6 +224,10 @@ contract ACL is IACL, AragonApp, ACLHelpers {
         return hasPermission(_who, _where, _what, empty);
     }
 
+    function numAuthorized(address _who, address _where, bytes32 _what) public view returns (uint) {
+        return numberOfAuthorized[permissionHash(_who, _where, _what)];
+    }
+
     function evalParams(
         bytes32 _paramsHash,
         address _who,
@@ -253,6 +259,11 @@ contract ACL is IACL, AragonApp, ACLHelpers {
     */
     function _setPermission(address _entity, address _app, bytes32 _role, bytes32 _paramsHash) internal {
         permissions[permissionHash(_entity, _app, _role)] = _paramsHash;
+        if (_paramsHash != bytes32(0)) {
+            numberOfAuthorized[permissionHash(_entity, _app, _role)] += 1;
+        } else {
+            numberOfAuthorized[permissionHash(_entity, _app, _role)] -= 1;
+        }
 
         SetPermission(_entity, _app, _role, _paramsHash != bytes32(0));
     }

--- a/contracts/acl/IACL.sol
+++ b/contracts/acl/IACL.sol
@@ -8,4 +8,5 @@ pragma solidity ^0.4.18;
 interface IACL {
     function initialize(address permissionsCreator) public;
     function hasPermission(address who, address where, bytes32 what, bytes how) public view returns (bool);
+    function numAuthorized(address who, address where, bytes32 what) public view returns (uint256);
 }

--- a/contracts/kernel/IKernel.sol
+++ b/contracts/kernel/IKernel.sol
@@ -14,6 +14,7 @@ contract IKernel is IVaultRecoverable {
 
     function acl() public view returns (IACL);
     function hasPermission(address who, address where, bytes32 what, bytes how) public view returns (bool);
+    function numAuthorized(address who, address where, bytes32 what) public view returns (uint256);
 
     function setApp(bytes32 namespace, bytes32 name, address app) public returns (bytes32 id);
     function getApp(bytes32 id) public view returns (address);

--- a/contracts/kernel/Kernel.sol
+++ b/contracts/kernel/Kernel.sol
@@ -152,6 +152,17 @@ contract Kernel is IKernel, KernelStorage, Initializable, IsContract, AppProxyFa
         return acl().hasPermission(_who, _where, _what, _how);
     }
 
+    /**
+    * @dev Function called by apps to check number of addresses that have a permission
+    * @param _who Sender of the original call
+    * @param _where Address of the app
+    * @param _what Identifier for a group of actions in app
+    * @return uint256 indicating how many addresses are given this permission
+    */
+    function numAuthorized(address _who, address _where, bytes32 _what) public view returns (uint256) {
+        return acl().numAuthorized(_who, _where, _what);
+    }
+
     function _setApp(bytes32 _namespace, bytes32 _name, address _app) internal returns (bytes32 id) {
         require(isContract(_app));
         id = keccak256(_namespace, _name);

--- a/test/kernel_acl.js
+++ b/test/kernel_acl.js
@@ -79,6 +79,8 @@ contract('Kernel ACL', accounts => {
     it('create permission action can be performed by root by default', async () => {
         const createPermissionRole = await acl.CREATE_PERMISSIONS_ROLE()
         assert.isTrue(await acl.hasPermission(permissionsRoot, acl.address, createPermissionRole))
+        const num = await acl.numAuthorized(permissionsRoot, acl.address, createPermissionRole);
+        assert.equal(num, 1, "There should be only 1 person");
     })
 
     it('cannot create permissions without permission', async () => {

--- a/test/kernel_acl.js
+++ b/test/kernel_acl.js
@@ -79,8 +79,12 @@ contract('Kernel ACL', accounts => {
     it('create permission action can be performed by root by default', async () => {
         const createPermissionRole = await acl.CREATE_PERMISSIONS_ROLE()
         assert.isTrue(await acl.hasPermission(permissionsRoot, acl.address, createPermissionRole))
-        const num = await acl.numAuthorized(permissionsRoot, acl.address, createPermissionRole);
-        assert.equal(num, 1, "There should be only 1 person");
+    })
+
+    it('can check that there is one authorized user for the root permission', async () => {
+      const createPermissionRole = await acl.CREATE_PERMISSIONS_ROLE()
+      const num = await acl.numAuthorized(permissionsRoot, acl.address, createPermissionRole);
+      assert.equal(num, 1, "There should be only 1 person");
     })
 
     it('cannot create permissions without permission', async () => {

--- a/test/kernel_acl.js
+++ b/test/kernel_acl.js
@@ -85,6 +85,8 @@ contract('Kernel ACL', accounts => {
       const createPermissionRole = await acl.CREATE_PERMISSIONS_ROLE()
       const num = await acl.numAuthorized(permissionsRoot, acl.address, createPermissionRole);
       assert.equal(num, 1, "There should be only 1 person");
+      const kernelNum = await kernel.numAuthorized(permissionsRoot, acl.address, createPermissionRole);
+      assert.equal(num, 1, "There should be only 1 person");
     })
 
     it('cannot create permissions without permission', async () => {


### PR DESCRIPTION
Added functionality to check how many addresses are given permission for a specific role in the acl