### PR TITLE
EVMScriptRunner: add ScriptResult log

### DIFF
--- a/contracts/evmscript/EVMScriptRunner.sol
+++ b/contracts/evmscript/EVMScriptRunner.sol
@@ -14,7 +14,7 @@ import "../apps/AppStorage.sol";
 contract EVMScriptRunner is AppStorage, EVMScriptRegistryConstants {
     using ScriptHelpers for bytes;
 
-    event ScriptResult(bytes script, bytes input, bytes returnData);
+    event ScriptResult(address indexed executor, bytes script, bytes input, bytes returnData);
 
     function runScript(bytes _script, bytes _input, address[] _blacklist) internal protectState returns (bytes output) {
         // TODO: Too much data flying around, maybe extracting spec id here is cheaper
@@ -28,7 +28,7 @@ contract EVMScriptRunner is AppStorage, EVMScriptRegistryConstants {
 
         output = returnedDataDecoded();
 
-        ScriptResult(_script, _input, output);
+        ScriptResult(executorAddr, _script, _input, output);
     }
 
     function getExecutor(bytes _script) public view returns (IEVMScriptExecutor) {

--- a/contracts/evmscript/EVMScriptRunner.sol
+++ b/contracts/evmscript/EVMScriptRunner.sol
@@ -14,7 +14,9 @@ import "../apps/AppStorage.sol";
 contract EVMScriptRunner is AppStorage, EVMScriptRegistryConstants {
     using ScriptHelpers for bytes;
 
-    function runScript(bytes _script, bytes _input, address[] _blacklist) protectState internal returns (bytes output) {
+    event ScriptResult(bytes script, bytes input, bytes returnData);
+
+    function runScript(bytes _script, bytes _input, address[] _blacklist) internal protectState returns (bytes output) {
         // TODO: Too much data flying around, maybe extracting spec id here is cheaper
         address executorAddr = getExecutor(_script);
         require(executorAddr != address(0));
@@ -24,7 +26,9 @@ contract EVMScriptRunner is AppStorage, EVMScriptRegistryConstants {
 
         require(executorAddr.delegatecall(sig, calldataArgs));
 
-        return returnedDataDecoded();
+        output = returnedDataDecoded();
+
+        ScriptResult(_script, _input, output);
     }
 
     function getExecutor(bytes _script) public view returns (IEVMScriptExecutor) {

--- a/test/evm_script.js
+++ b/test/evm_script.js
@@ -93,9 +93,16 @@ contract('EVM Script', accounts => {
                 const action = { to: executionTarget.address, calldata: executionTarget.contract.execute.getData() }
                 const script = encodeCallScript([action])
 
-                await executor.execute(script)
+                const receipt = await executor.execute(script)
 
                 assert.equal(await executionTarget.counter(), 1, 'should have executed action')
+
+                // Check logs
+                // The Executor always uses 0x for the input and callscripts always have 0x returns
+                const scriptResult = receipt.logs.filter(l => l.event == 'ScriptResult')[0]
+                assert.equal(scriptResult.args.script, script)
+                assert.equal(scriptResult.args.input, '0x')
+                assert.equal(scriptResult.args.returnData, '0x')
             })
 
             it('fails to execute if has blacklist addresses being called', async () => {

--- a/test/evm_script.js
+++ b/test/evm_script.js
@@ -20,7 +20,7 @@ const APP_BASE_NAMESPACE = '0x'+keccak256('base')
 const getContract = artifacts.require
 
 contract('EVM Script', accounts => {
-    let executor, executionTarget, dao, daoFact, reg, constants, acl = {}, baseExecutor
+    let executor, executionTarget, dao, daoFact, reg, constants, acl, baseExecutor
 
     const boss = accounts[1]
 
@@ -100,9 +100,10 @@ contract('EVM Script', accounts => {
                 // Check logs
                 // The Executor always uses 0x for the input and callscripts always have 0x returns
                 const scriptResult = receipt.logs.filter(l => l.event == 'ScriptResult')[0]
-                assert.equal(scriptResult.args.script, script)
-                assert.equal(scriptResult.args.input, '0x')
-                assert.equal(scriptResult.args.returnData, '0x')
+                assert.equal(scriptResult.args.executor, await reg.getScriptExecutor('0x00000001'), 'should log the same executor')
+                assert.equal(scriptResult.args.script, script, 'should log the same script')
+                assert.equal(scriptResult.args.input, '0x', 'should log the same input')
+                assert.equal(scriptResult.args.returnData, '0x', 'should log the return data')
             })
 
             it('fails to execute if has blacklist addresses being called', async () => {


### PR DESCRIPTION
From https://github.com/ConsenSys/aragon-apps-audit-repo/issues/32:

> The _executeVote function executes an EVMScript if a vote has sufficient support. The result of the execution is not logged nor is checked if it throws an exception.