### PR TITLE
[Prototype] Check for initialization during access control check

### DIFF
--- a/contracts/apps/AragonApp.sol
+++ b/contracts/apps/AragonApp.sol
@@ -38,6 +38,10 @@ contract AragonApp is AppStorage, Petrifiable, ACLSyntaxSugar, VaultRecoverable,
     }
 
     function canPerform(address _sender, bytes32 _role, uint256[] params) public view returns (bool) {
+        if (!hasInitialized()) {
+            return false;
+        }
+
         bytes memory how; // no need to init memory as it is never used
         if (params.length > 0) {
             uint256 byteLength = params.length * 32;

--- a/contracts/common/Initializable.sol
+++ b/contracts/common/Initializable.sol
@@ -14,7 +14,7 @@ contract Initializable is AppStorage {
     }
 
     modifier isInitialized {
-        require(initializationBlock != 0 && getBlockNumber() >= initializationBlock);
+        require(hasInitialized());
         _;
     }
 
@@ -23,6 +23,13 @@ contract Initializable is AppStorage {
     */
     function getInitializationBlock() public view returns (uint256) {
         return initializationBlock;
+    }
+
+    /**
+    * @return Whether the contract has been initialized by the time of the current block
+    */
+    function hasInitialized() public view returns (bool) {
+        return initializationBlock != 0 && getBlockNumber() >= initializationBlock;
     }
 
     /**

--- a/contracts/kernel/Kernel.sol
+++ b/contracts/kernel/Kernel.sol
@@ -156,10 +156,11 @@ contract Kernel is IKernel, KernelStorage, Petrifiable, IsContract, AppProxyFact
     * @param _where Address of the app
     * @param _what Identifier for a group of actions in app
     * @param _how Extra data for ACL auth
-    * @return boolean indicating whether the ACL allows the role or not
+    * @return Boolean indicating whether the ACL allows the role or not.
+    *         Always returns false if the kernel has not been initialized yet.
     */
     function hasPermission(address _who, address _where, bytes32 _what, bytes _how) public view returns (bool) {
-        return acl().hasPermission(_who, _where, _what, _how);
+        return hasInitialized() && acl().hasPermission(_who, _where, _what, _how);
     }
 
     function _setApp(bytes32 _namespace, bytes32 _name, address _app) internal returns (bytes32 id) {


### PR DESCRIPTION
**The current tests haven't been adjusted (and new tests need to be added) so CI will be breaking**

Depends on #355.

Adds checks for initialization when checking if someone can perform an action (either `hasPermission()` or `canPerform()` in the `Kernel` and `AragonApp`, respectively). This solves 90% of the instances where people will need to add `isInitialized` in the face of the new requirement that all public-facing state-changing functions must check for initialization.