### PR TITLE
Add more static contract types to state and function parameters

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -5,7 +5,6 @@ const interfaces = [
   'acl/IACL.sol',
   'acl/IACLOracle.sol',
   'acl/ACLSyntaxSugar.sol'
-  'apps/IAppProxy.sol',
   'evmscript/IEVMScriptExecutor.sol',
   'common/IForwarder.sol',
   'common/IVaultRecoverable.sol',

--- a/.solcover.js
+++ b/.solcover.js
@@ -4,10 +4,10 @@ const libFiles = require('glob').sync('contracts/lib/**/*.sol').map(n => n.repla
 const interfaces = [
   'acl/IACL.sol',
   'acl/IACLOracle.sol',
-  'acl/ACLSyntaxSugar.sol'
-  'evmscript/IEVMScriptExecutor.sol',
+  'acl/ACLSyntaxSugar.sol',
   'common/IForwarder.sol',
   'common/IVaultRecoverable.sol',
+  'evmscript/IEVMScriptExecutor.sol',
   'kernel/IKernel.sol',
 ]
 

--- a/.solcover.js
+++ b/.solcover.js
@@ -1,7 +1,16 @@
 // NOTE: Upgrading to solidity-coverage 0.4.x breaks our tests
 
 const libFiles = require('glob').sync('contracts/lib/**/*.sol').map(n => n.replace('contracts/', ''))
-const interfaces = ['common/IForwarder.sol', 'common/IVaultRecoverable.sol', 'kernel/IKernel.sol', 'evmscript/IEVMScriptExecutor.sol', 'apps/IAppProxy.sol', 'acl/IACL.sol', 'acl/ACLSyntaxSugar.sol']
+const interfaces = [
+  'acl/IACL.sol',
+  'acl/IACLOracle.sol',
+  'acl/ACLSyntaxSugar.sol'
+  'apps/IAppProxy.sol',
+  'evmscript/IEVMScriptExecutor.sol',
+  'common/IForwarder.sol',
+  'common/IVaultRecoverable.sol',
+  'kernel/IKernel.sol',
+]
 
 module.exports = {
     norpc: true,

--- a/contracts/acl/ACL.sol
+++ b/contracts/acl/ACL.sol
@@ -3,11 +3,7 @@ pragma solidity 0.4.18;
 import "../apps/AragonApp.sol";
 import "./ACLSyntaxSugar.sol";
 import "./IACL.sol";
-
-
-interface ACLOracle {
-    function canPerform(address who, address where, bytes32 what, uint256[] how) public view returns (bool);
-}
+import "./IACLOracle.sol";
 
 
 contract ACL is IACL, AragonApp, ACLHelpers {
@@ -296,7 +292,7 @@ contract ACL is IACL, AragonApp, ACLHelpers {
 
         // get value
         if (param.id == ORACLE_PARAM_ID) {
-            value = checkOracle(address(param.value), _who, _where, _what, _how) ? 1 : 0;
+            value = checkOracle(IACLOracle(param.value), _who, _where, _what, _how) ? 1 : 0;
             comparedTo = 1;
         } else if (param.id == BLOCK_NUMBER_PARAM_ID) {
             value = blockN();
@@ -362,11 +358,11 @@ contract ACL is IACL, AragonApp, ACLHelpers {
         return false;
     }
 
-    function checkOracle(address _oracleAddr, address _who, address _where, bytes32 _what, uint256[] _how) internal view returns (bool) {
-        bytes4 sig = ACLOracle(_oracleAddr).canPerform.selector;
+    function checkOracle(IACLOracle _oracleAddr, address _who, address _where, bytes32 _what, uint256[] _how) internal view returns (bool) {
+        bytes4 sig = _oracleAddr.canPerform.selector;
 
         // a raw call is required so we can return false if the call reverts, rather than reverting
-        bool ok = _oracleAddr.call(sig, _who, _where, _what, 0x80, _how.length, _how);
+        bool ok = address(_oracleAddr).call(sig, _who, _where, _what, 0x80, _how.length, _how);
         // 0x80 is the position where the array that goes there starts
 
         if (!ok) {

--- a/contracts/acl/IACLOracle.sol
+++ b/contracts/acl/IACLOracle.sol
@@ -1,0 +1,10 @@
+/*
+ * SPDX-License-Identitifer:    MIT
+ */
+
+pragma solidity ^0.4.18;
+
+
+interface IACLOracle {
+    function canPerform(address who, address where, bytes32 what, uint256[] how) public view returns (bool);
+}

--- a/contracts/evmscript/EVMScriptRegistry.sol
+++ b/contracts/evmscript/EVMScriptRegistry.sol
@@ -15,7 +15,7 @@ contract EVMScriptRegistry is IEVMScriptRegistry, EVMScriptRegistryConstants, Ar
     bytes32 constant public REGISTRY_MANAGER_ROLE = 0xf7a450ef335e1892cb42c8ca72e7242359d7711924b75db5717410da3f614aa3;
 
     struct ExecutorEntry {
-        address executor;
+        IEVMScriptExecutor executor;
         bool enabled;
     }
 
@@ -24,10 +24,10 @@ contract EVMScriptRegistry is IEVMScriptRegistry, EVMScriptRegistryConstants, Ar
     function initialize() onlyInit public {
         initialized();
         // Create empty record to begin executor IDs at 1
-        executors.push(ExecutorEntry(address(0), false));
+        executors.push(ExecutorEntry(IEVMScriptExecutor(0), false));
     }
 
-    function addScriptExecutor(address _executor) external auth(REGISTRY_MANAGER_ROLE) returns (uint id) {
+    function addScriptExecutor(IEVMScriptExecutor _executor) external auth(REGISTRY_MANAGER_ROLE) returns (uint id) {
         return executors.push(ExecutorEntry(_executor, true));
     }
 
@@ -35,14 +35,14 @@ contract EVMScriptRegistry is IEVMScriptRegistry, EVMScriptRegistryConstants, Ar
         executors[_executorId].enabled = false;
     }
 
-    function getScriptExecutor(bytes _script) public view returns (address) {
+    function getScriptExecutor(bytes _script) public view returns (IEVMScriptExecutor) {
         uint256 id = _script.getSpecId();
 
         if (id == 0 || id >= executors.length) {
-            return address(0);
+            return IEVMScriptExecutor(0);
         }
 
         ExecutorEntry storage entry = executors[id];
-        return entry.enabled ? entry.executor : address(0);
+        return entry.enabled ? entry.executor : IEVMScriptExecutor(0);
     }
 }

--- a/contracts/evmscript/EVMScriptRunner.sol
+++ b/contracts/evmscript/EVMScriptRunner.sol
@@ -16,13 +16,13 @@ contract EVMScriptRunner is AppStorage, EVMScriptRegistryConstants {
 
     function runScript(bytes _script, bytes _input, address[] _blacklist) protectState internal returns (bytes output) {
         // TODO: Too much data flying around, maybe extracting spec id here is cheaper
-        address executorAddr = getExecutor(_script);
-        require(executorAddr != address(0));
+        IEVMScriptExecutor executorAddr = getExecutor(_script);
+        require(address(executorAddr) != address(0));
 
         bytes memory calldataArgs = _script.encode(_input, _blacklist);
-        bytes4 sig = IEVMScriptExecutor(0).execScript.selector;
+        bytes4 sig = executorAddr.execScript.selector;
 
-        require(executorAddr.delegatecall(sig, calldataArgs));
+        require(address(executorAddr).delegatecall(sig, calldataArgs));
 
         return returnedDataDecoded();
     }

--- a/contracts/evmscript/EVMScriptRunner.sol
+++ b/contracts/evmscript/EVMScriptRunner.sol
@@ -16,13 +16,13 @@ contract EVMScriptRunner is AppStorage, EVMScriptRegistryConstants {
 
     function runScript(bytes _script, bytes _input, address[] _blacklist) protectState internal returns (bytes output) {
         // TODO: Too much data flying around, maybe extracting spec id here is cheaper
-        IEVMScriptExecutor executorAddr = getExecutor(_script);
-        require(address(executorAddr) != address(0));
+        IEVMScriptExecutor executor = getExecutor(_script);
+        require(address(executor) != address(0));
 
         bytes memory calldataArgs = _script.encode(_input, _blacklist);
-        bytes4 sig = executorAddr.execScript.selector;
+        bytes4 sig = executor.execScript.selector;
 
-        require(address(executorAddr).delegatecall(sig, calldataArgs));
+        require(address(executor).delegatecall(sig, calldataArgs));
 
         return returnedDataDecoded();
     }

--- a/contracts/evmscript/EVMScriptRunner.sol
+++ b/contracts/evmscript/EVMScriptRunner.sol
@@ -28,7 +28,7 @@ contract EVMScriptRunner is AppStorage, EVMScriptRegistryConstants {
 
         output = returnedDataDecoded();
 
-        ScriptResult(executorAddr, _script, _input, output);
+        ScriptResult(address(executor), _script, _input, output);
     }
 
     function getExecutor(bytes _script) public view returns (IEVMScriptExecutor) {

--- a/contracts/evmscript/IEVMScriptRegistry.sol
+++ b/contracts/evmscript/IEVMScriptRegistry.sol
@@ -4,6 +4,8 @@
 
 pragma solidity ^0.4.18;
 
+import "./IEVMScriptExecutor.sol";
+
 
 contract EVMScriptRegistryConstants {
     /* Hardcoded constants to save gas
@@ -20,8 +22,8 @@ contract EVMScriptRegistryConstants {
 
 
 interface IEVMScriptRegistry {
-    function addScriptExecutor(address executor) external returns (uint id);
+    function addScriptExecutor(IEVMScriptExecutor executor) external returns (uint id);
     function disableScriptExecutor(uint256 executorId) external;
 
-    function getScriptExecutor(bytes script) public view returns (address);
+    function getScriptExecutor(bytes script) public view returns (IEVMScriptExecutor);
 }

--- a/contracts/factory/AppProxyFactory.sol
+++ b/contracts/factory/AppProxyFactory.sol
@@ -13,7 +13,7 @@ contract AppProxyFactory {
 
     function newAppProxy(IKernel _kernel, bytes32 _appId, bytes _initializePayload) public returns (AppProxyUpgradeable) {
         AppProxyUpgradeable proxy = new AppProxyUpgradeable(_kernel, _appId, _initializePayload);
-        NewAppProxy(proxy, true, _appId);
+        NewAppProxy(address(proxy), true, _appId);
         return proxy;
     }
 
@@ -23,7 +23,7 @@ contract AppProxyFactory {
 
     function newAppProxyPinned(IKernel _kernel, bytes32 _appId, bytes _initializePayload) public returns (AppProxyPinned) {
         AppProxyPinned proxy = new AppProxyPinned(_kernel, _appId, _initializePayload);
-        NewAppProxy(proxy, false, _appId);
+        NewAppProxy(address(proxy), false, _appId);
         return proxy;
     }
 }

--- a/contracts/factory/AppProxyFactory.sol
+++ b/contracts/factory/AppProxyFactory.sol
@@ -13,7 +13,7 @@ contract AppProxyFactory {
 
     function newAppProxy(IKernel _kernel, bytes32 _appId, bytes _initializePayload) public returns (AppProxyUpgradeable) {
         AppProxyUpgradeable proxy = new AppProxyUpgradeable(_kernel, _appId, _initializePayload);
-        NewAppProxy(address(proxy), true, _appId);
+        NewAppProxy(proxy, true, _appId);
         return proxy;
     }
 
@@ -23,7 +23,7 @@ contract AppProxyFactory {
 
     function newAppProxyPinned(IKernel _kernel, bytes32 _appId, bytes _initializePayload) public returns (AppProxyPinned) {
         AppProxyPinned proxy = new AppProxyPinned(_kernel, _appId, _initializePayload);
-        NewAppProxy(address(proxy), false, _appId);
+        NewAppProxy(proxy, false, _appId);
         return proxy;
     }
 }

--- a/contracts/factory/DAOFactory.sol
+++ b/contracts/factory/DAOFactory.sol
@@ -1,25 +1,27 @@
 pragma solidity 0.4.18;
 
+import "../kernel/IKernel.sol";
 import "../kernel/Kernel.sol";
 import "../kernel/KernelProxy.sol";
 
+import "../acl/IACL.sol";
 import "../acl/ACL.sol";
 
 import "./EVMScriptRegistryFactory.sol";
 
 
 contract DAOFactory {
-    address public baseKernel;
-    address public baseACL;
+    IKernel public baseKernel;
+    IACL public baseACL;
     EVMScriptRegistryFactory public regFactory;
 
     event DeployDAO(address dao);
     event DeployEVMScriptRegistry(address reg);
 
-    function DAOFactory(address _baseKernel, address _baseACL, address _regFactory) public {
+    function DAOFactory(IKernel _baseKernel, IACL _baseACL, EVMScriptRegistryFactory _regFactory) public {
         // No need to init as it cannot be killed by devops199
-        if (_regFactory != address(0)) {
-            regFactory = EVMScriptRegistryFactory(_regFactory);
+        if (address(_regFactory) != address(0)) {
+            regFactory = _regFactory;
         }
 
         baseKernel = _baseKernel;

--- a/contracts/factory/DAOFactory.sol
+++ b/contracts/factory/DAOFactory.sol
@@ -48,7 +48,7 @@ contract DAOFactory {
             acl.createPermission(regFactory, dao, appManagerRole, this);
 
             EVMScriptRegistry reg = regFactory.newEVMScriptRegistry(dao, _root);
-            DeployEVMScriptRegistry(address(reg));
+            DeployEVMScriptRegistry(reg);
 
             acl.revokePermission(regFactory, dao, appManagerRole);
             acl.revokePermission(regFactory, acl, permRole);

--- a/contracts/factory/DAOFactory.sol
+++ b/contracts/factory/DAOFactory.sol
@@ -48,7 +48,7 @@ contract DAOFactory {
             acl.createPermission(regFactory, dao, appManagerRole, this);
 
             EVMScriptRegistry reg = regFactory.newEVMScriptRegistry(dao, _root);
-            DeployEVMScriptRegistry(reg);
+            DeployEVMScriptRegistry(address(reg));
 
             acl.revokePermission(regFactory, dao, appManagerRole);
             acl.revokePermission(regFactory, acl, permRole);
@@ -59,6 +59,6 @@ contract DAOFactory {
             acl.setPermissionManager(_root, acl, permRole);
         }
 
-        DeployDAO(dao);
+        DeployDAO(address(dao));
     }
 }

--- a/contracts/factory/EVMScriptRegistryFactory.sol
+++ b/contracts/factory/EVMScriptRegistryFactory.sol
@@ -1,5 +1,6 @@
 pragma solidity 0.4.18;
 
+import "../evmscript/IEVMScriptExecutor.sol";
 import "../evmscript/EVMScriptRegistry.sol";
 
 import "../evmscript/executors/CallsScript.sol";
@@ -10,12 +11,12 @@ import "../acl/ACL.sol";
 
 
 contract EVMScriptRegistryFactory is AppProxyFactory, EVMScriptRegistryConstants {
-    address public baseReg;
-    address public baseCalls;
+    EVMScriptRegistry public baseReg;
+    IEVMScriptExecutor public baseCallScript;
 
     function EVMScriptRegistryFactory() public {
-        baseReg = address(new EVMScriptRegistry());
-        baseCalls = address(new CallsScript());
+        baseReg = new EVMScriptRegistry();
+        baseCallScript = IEVMScriptExecutor(new CallsScript());
     }
 
     function newEVMScriptRegistry(Kernel _dao, address _root) public returns (EVMScriptRegistry reg) {
@@ -26,7 +27,7 @@ contract EVMScriptRegistryFactory is AppProxyFactory, EVMScriptRegistryConstants
 
         acl.createPermission(this, reg, reg.REGISTRY_MANAGER_ROLE(), this);
 
-        reg.addScriptExecutor(baseCalls);     // spec 1 = CallsScript
+        reg.addScriptExecutor(baseCallScript);     // spec 1 = CallsScript
 
         acl.revokePermission(this, reg, reg.REGISTRY_MANAGER_ROLE());
         acl.setPermissionManager(_root, reg, reg.REGISTRY_MANAGER_ROLE());

--- a/contracts/kernel/Kernel.sol
+++ b/contracts/kernel/Kernel.sol
@@ -2,6 +2,7 @@ pragma solidity 0.4.18;
 
 import "./IKernel.sol";
 import "./KernelStorage.sol";
+import "../acl/IACL.sol";
 import "../acl/ACLSyntaxSugar.sol";
 import "../lib/misc/ERCProxy.sol";
 import "../common/Initializable.sol";
@@ -23,7 +24,7 @@ contract Kernel is IKernel, KernelStorage, Initializable, IsContract, AppProxyFa
     * @param _baseAcl Address of base ACL app
     * @param _permissionsCreator Entity that will be given permission over createPermission
     */
-    function initialize(address _baseAcl, address _permissionsCreator) onlyInit public {
+    function initialize(IACL _baseAcl, address _permissionsCreator) onlyInit public {
         initialized();
 
         IACL acl = IACL(newAppProxy(this, ACL_APP_ID));

--- a/contracts/kernel/KernelProxy.sol
+++ b/contracts/kernel/KernelProxy.sol
@@ -1,5 +1,6 @@
 pragma solidity 0.4.18;
 
+import "./IKernel.sol";
 import "./KernelStorage.sol";
 import "../common/DepositableDelegateProxy.sol";
 
@@ -10,7 +11,7 @@ contract KernelProxy is KernelStorage, DepositableDelegateProxy {
     *      can update the reference, which effectively upgrades the contract
     * @param _kernelImpl Address of the contract used as implementation for kernel
     */
-    function KernelProxy(address _kernelImpl) public {
+    function KernelProxy(IKernel _kernelImpl) public {
         apps[keccak256(CORE_NAMESPACE, KERNEL_APP_ID)] = _kernelImpl;
     }
 

--- a/contracts/lib/minime/MiniMeToken.sol
+++ b/contracts/lib/minime/MiniMeToken.sol
@@ -373,7 +373,7 @@ contract MiniMeToken is Controlled {
         cloneToken.changeController(msg.sender);
 
         // An event to make the token easy to find on the blockchain
-        NewCloneToken(cloneToken, snapshot);
+        NewCloneToken(address(cloneToken), snapshot);
         return cloneToken;
     }
 

--- a/contracts/lib/minime/MiniMeToken.sol
+++ b/contracts/lib/minime/MiniMeToken.sol
@@ -373,7 +373,7 @@ contract MiniMeToken is Controlled {
         cloneToken.changeController(msg.sender);
 
         // An event to make the token easy to find on the blockchain
-        NewCloneToken(address(cloneToken), snapshot);
+        NewCloneToken(cloneToken, snapshot);
         return cloneToken;
     }
 

--- a/contracts/lib/minime/MiniMeToken.sol
+++ b/contracts/lib/minime/MiniMeToken.sol
@@ -124,8 +124,8 @@ contract MiniMeToken is Controlled {
     /// @param _tokenSymbol Token Symbol for the new token
     /// @param _transfersEnabled If true, tokens will be able to be transferred
     function MiniMeToken(
-        address _tokenFactory,
-        address _parentToken,
+        MiniMeTokenFactory _tokenFactory,
+        MiniMeToken _parentToken,
         uint _parentSnapShotBlock,
         string _tokenName,
         uint8 _decimalUnits,
@@ -133,11 +133,11 @@ contract MiniMeToken is Controlled {
         bool _transfersEnabled
     )  public
     {
-        tokenFactory = MiniMeTokenFactory(_tokenFactory);
+        tokenFactory = _tokenFactory;
         name = _tokenName;                                 // Set the name
         decimals = _decimalUnits;                          // Set the decimals
         symbol = _tokenSymbol;                             // Set the symbol
-        parentToken = MiniMeToken(_parentToken);
+        parentToken = _parentToken;
         parentSnapShotBlock = _parentSnapShotBlock;
         transfersEnabled = _transfersEnabled;
         creationBlock = block.number;
@@ -265,10 +265,10 @@ contract MiniMeToken is Controlled {
     /// @param _spender The address of the contract able to transfer the tokens
     /// @param _amount The amount of tokens to be approved for transfer
     /// @return True if the function call was successful
-    function approveAndCall(address _spender, uint256 _amount, bytes _extraData) public returns (bool success) {
+    function approveAndCall(ApproveAndCallFallBack _spender, uint256 _amount, bytes _extraData) public returns (bool success) {
         require(approve(_spender, _amount));
 
-        ApproveAndCallFallBack(_spender).receiveApproval(
+        _spender.receiveApproval(
             msg.sender,
             _amount,
             this,
@@ -357,7 +357,7 @@ contract MiniMeToken is Controlled {
         string _cloneTokenSymbol,
         uint _snapshotBlock,
         bool _transfersEnabled
-    ) public returns(address)
+    ) public returns(MiniMeToken)
     {
         uint256 snapshot = _snapshotBlock == 0 ? block.number - 1 : _snapshotBlock;
 
@@ -374,7 +374,7 @@ contract MiniMeToken is Controlled {
 
         // An event to make the token easy to find on the blockchain
         NewCloneToken(address(cloneToken), snapshot);
-        return address(cloneToken);
+        return cloneToken;
     }
 
 ////////////////
@@ -554,7 +554,7 @@ contract MiniMeTokenFactory {
     /// @param _transfersEnabled If true, tokens will be able to be transferred
     /// @return The address of the new token contract
     function createCloneToken(
-        address _parentToken,
+        MiniMeToken _parentToken,
         uint _snapshotBlock,
         string _tokenName,
         uint8 _decimalUnits,

--- a/test/TestACLInterpreter.sol
+++ b/test/TestACLInterpreter.sol
@@ -1,6 +1,7 @@
 pragma solidity 0.4.18;
 
 import "truffle/Assert.sol";
+import "../contracts/acl/ACL.sol";
 import "./helpers/ACLHelper.sol";
 
 

--- a/test/TestAclOracle.sol
+++ b/test/TestAclOracle.sol
@@ -2,23 +2,27 @@ pragma solidity 0.4.18;
 
 import "truffle/Assert.sol";
 import "../contracts/acl/ACL.sol";
+import "../contracts/acl/IACLOracle.sol";
 
 
-contract Oracle {
-    function () public {
+contract ErroringOracle is IACLOracle {
+    function canPerform(address who, address where, bytes32 what, uint256[] how) public view returns (bool) {
+        // Force error
+        require(false);
     }
 }
 
+
 contract TestAclOracle is ACL {
-    Oracle oracle;
+    IACLOracle oracle;
 
     function before() {
-        oracle = new Oracle();
+        oracle = new ErroringOracle();
     }
 
     function testCheckOracleEmptyReturn() {
         uint256[] memory empty = new uint256[](0);
-        bool result = checkOracle(address(oracle), address(0), address(0), bytes32(0), empty);
+        bool result = checkOracle(oracle, address(0), address(0), bytes32(0), empty);
         Assert.isFalse(result, "should return false");
     }
 }

--- a/test/helpers/ACLHelper.sol
+++ b/test/helpers/ACLHelper.sol
@@ -1,6 +1,6 @@
 pragma solidity 0.4.18;
 
-import "../../contracts/acl/ACL.sol";
+import "../../contracts/acl/IACLOracle.sol";
 
 
 contract ACLHelper {
@@ -14,28 +14,28 @@ contract ACLHelper {
 }
 
 
-contract AcceptOracle is ACLOracle {
+contract AcceptOracle is IACLOracle {
     function canPerform(address who, address where, bytes32 what, uint256[] how) public constant returns (bool) {
         return true;
     }
 }
 
 
-contract RejectOracle is ACLOracle {
+contract RejectOracle is IACLOracle {
     function canPerform(address who, address where, bytes32 what, uint256[] how) public constant returns (bool) {
         return false;
     }
 }
 
 
-contract RevertOracle is ACLOracle {
+contract RevertOracle is IACLOracle {
     function canPerform(address who, address where, bytes32 what, uint256[] how) public constant returns (bool) {
         revert();
     }
 }
 
 
-contract ConditionalOracle is ACLOracle {
+contract ConditionalOracle is IACLOracle {
     function canPerform(address who, address where, bytes32 what, uint256[] how) public constant returns (bool) {
         return how[0] > 0;
     }


### PR DESCRIPTION
From https://github.com/ConsenSys/aragonOS-audit-repo/issues/14:

> Avoid using the address type for contract references. Instead use the actual contract type or an interface to statically restrict the different possible configurations that your contracts can be composed into.

-------------

Some parameters or state are left to be `address` due to their dynamic nature.