### PR TITLE
ACL: remove sender param

### DIFF
--- a/contracts/acl/ACL.sol
+++ b/contracts/acl/ACL.sol
@@ -34,10 +34,9 @@ contract ACL is IACL, AragonApp, ACLHelpers {
 
     uint8 constant BLOCK_NUMBER_PARAM_ID = 200;
     uint8 constant TIMESTAMP_PARAM_ID    = 201;
-    uint8 constant SENDER_PARAM_ID       = 202;
-    uint8 constant ORACLE_PARAM_ID       = 203;
-    uint8 constant LOGIC_OP_PARAM_ID     = 204;
-    uint8 constant PARAM_VALUE_PARAM_ID  = 205;
+    uint8 constant ORACLE_PARAM_ID       = 202;
+    uint8 constant LOGIC_OP_PARAM_ID     = 203;
+    uint8 constant PARAM_VALUE_PARAM_ID  = 204;
     // TODO: Add execution times param type?
 
     // Hardcoded constant to save gas
@@ -302,8 +301,6 @@ contract ACL is IACL, AragonApp, ACLHelpers {
             value = blockN();
         } else if (param.id == TIMESTAMP_PARAM_ID) {
             value = time();
-        } else if (param.id == SENDER_PARAM_ID) {
-            value = uint256(msg.sender);
         } else if (param.id == PARAM_VALUE_PARAM_ID) {
             value = uint256(param.value);
         } else {

--- a/docs/aragonOS.md
+++ b/docs/aragonOS.md
@@ -291,8 +291,6 @@ are some *special Argument IDs*:
 	- `TIMESTAMP_PARAM_ID` (`id = 201`): Sets comparison value to the timestamp of the
 	current block at the time of execution. This allows for setting up timelocks
 	on time.
-	- `SENDER_PARAM_ID` (`id = 202`): Sets comparison value to the sender of the call.
-	(Currently useless because of [this issue]())
 	- `ORACLE_PARAM_ID` (`id = 203`): Checks with an oracle at the address in the
 	*argument value* and returns whether it returned true or false (no comparison with arg).
 	- `LOGIC_OP_PARAM_ID` (`id = 204`): Evaluates a logical operation and returns

--- a/test/TestACLInterpreter.sol
+++ b/test/TestACLInterpreter.sol
@@ -62,11 +62,6 @@ contract TestACLInterpreter is ACL, ACLHelper {
         assertEval(arr(uint256(10), 11), 1, Op.LTE, 11, true);
     }
 
-    function testSender() public {
-        assertEval(arr(), SENDER_PARAM_ID, Op.EQ, uint256(msg.sender), true);
-        assertEval(arr(), SENDER_PARAM_ID, Op.EQ, uint256(0x1234), false);
-    }
-
     function testTimestamp() public {
         assertEval(arr(), TIMESTAMP_PARAM_ID, Op.EQ, uint256(block.timestamp), true);
         assertEval(arr(), TIMESTAMP_PARAM_ID, Op.EQ, uint256(1), false);


### PR DESCRIPTION
Fixes #210.

As it is now, there's no good way to fix this without just passing in the sender as an argument.

It is a breaking change, but given that nobody's using the params, it's probably something we can quietly remove.