### PR TITLE
[Prototype] Default bases to petrified

### DIFF
--- a/contracts/acl/ACL.sol
+++ b/contracts/acl/ACL.sol
@@ -1,7 +1,6 @@
 pragma solidity 0.4.18;
 
 import "../apps/AragonApp.sol";
-import "../kernel/IKernel.sol";
 import "./ACLSyntaxSugar.sol";
 import "./IACL.sol";
 import "./IACLOracle.sol";
@@ -51,12 +50,6 @@ contract ACL is IACL, AragonApp, ACLHelpers {
 
     event SetPermission(address indexed entity, address indexed app, bytes32 indexed role, bool allowed);
     event ChangePermissionManager(address indexed app, bytes32 indexed role, address indexed manager);
-
-    /**
-    * @dev Constructor that allows a deployer to choose if the base instance should be connected to
-    *      a kernel or petrified immediately.
-    */
-    function ACL(IKernel _kernel) AragonApp(_kernel) public {}
 
     /**
     * @dev Initialize can only be called once. It saves the block number in which it was initialized.

--- a/contracts/apm/APMRegistry.sol
+++ b/contracts/apm/APMRegistry.sol
@@ -4,7 +4,6 @@ import "../lib/ens/AbstractENS.sol";
 import "../ens/ENSSubdomainRegistrar.sol";
 import "../factory/AppProxyFactory.sol";
 import "../apps/AragonApp.sol";
-import "../kernel/IKernel.sol";
 import "../acl/ACL.sol";
 import "./Repo.sol";
 
@@ -26,12 +25,6 @@ contract APMRegistry is AragonApp, AppProxyFactory, APMRegistryConstants {
     bytes32 constant public CREATE_REPO_ROLE = 0x2a9494d64846c9fdbf0158785aa330d8bc9caf45af27fa0e8898eb4d55adcea6;
 
     event NewRepo(bytes32 id, string name, address repo);
-
-    /**
-    * @dev Constructor that allows a deployer to choose if the base instance should be connected to
-    *      a kernel or petrified immediately.
-    */
-    function APMRegistry(IKernel _kernel) AragonApp(_kernel) public {}
 
     /**
     * NEEDS CREATE_NAME_ROLE and POINT_ROOTNODE_ROLE permissions on registrar

--- a/contracts/apm/Repo.sol
+++ b/contracts/apm/Repo.sol
@@ -1,7 +1,6 @@
 pragma solidity 0.4.18;
 
 import "../apps/AragonApp.sol";
-import "../kernel/IKernel.sol";
 
 
 contract Repo is AragonApp {
@@ -19,12 +18,6 @@ contract Repo is AragonApp {
     bytes32 constant public CREATE_VERSION_ROLE = 0x1f56cfecd3595a2e6cc1a7e6cb0b20df84cdbd92eff2fee554e70e4e45a9a7d8;
 
     event NewVersion(uint256 versionId, uint16[3] semanticVersion);
-
-    /**
-    * @dev Constructor that allows a deployer to choose if the base instance should be connected to
-    *      a kernel or petrified immediately.
-    */
-    function Repo(IKernel _kernel) AragonApp(_kernel) public {}
 
     /**
     * @notice Create new version for repo

--- a/contracts/apps/AragonApp.sol
+++ b/contracts/apps/AragonApp.sol
@@ -5,25 +5,18 @@
 pragma solidity ^0.4.18;
 
 import "./AppStorage.sol";
-import "../common/Petrifiable.sol";
+import "../common/Autopetrified.sol";
 import "../common/VaultRecoverable.sol";
 import "../evmscript/EVMScriptRunner.sol";
 import "../acl/ACLSyntaxSugar.sol";
 
 
+// Contracts inheriting from AragonApp will, by default, be immediately petrified upon deployment
+// so that it can never be initialized.
+// Unless overriden, this behaviour enforces those apps to only be usable when behind an AppProxy.
 // ACLSyntaxSugar and EVMScriptRunner are not directly used by this contract, but are included so
 // that they are automatically usable by subclassing contracts
-contract AragonApp is AppStorage, Petrifiable, ACLSyntaxSugar, VaultRecoverable, EVMScriptRunner {
-    /**
-    * @dev Contracts inheriting from AragonApp will, by default, be immediately petrified upon
-    *      deployment so that it can never be initialized.
-    *      Unless overriden, this behaviour enforces those apps to only be usable when behind an
-    *      AppProxy.
-    */
-    function AragonApp() public {
-        petrify();
-    }
-
+contract AragonApp is AppStorage, Autopetrified, ACLSyntaxSugar, VaultRecoverable, EVMScriptRunner {
     modifier auth(bytes32 _role) {
         require(canPerform(msg.sender, _role, new uint256[](0)));
         _;

--- a/contracts/apps/AragonApp.sol
+++ b/contracts/apps/AragonApp.sol
@@ -16,7 +16,7 @@ import "../acl/ACLSyntaxSugar.sol";
 // Unless overriden, this behaviour enforces those contracts to be usable only behind an AppProxy.
 // ACLSyntaxSugar and EVMScriptRunner are not directly used by this contract, but are included so
 // that they are automatically usable by subclassing contracts
-contract AragonApp is AppStorage, Autopetrified, ACLSyntaxSugar, VaultRecoverable, EVMScriptRunner {
+contract AragonApp is AppStorage, Autopetrified, VaultRecoverable, EVMScriptRunner, ACLSyntaxSugar {
     modifier auth(bytes32 _role) {
         require(canPerform(msg.sender, _role, new uint256[](0)));
         _;

--- a/contracts/apps/AragonApp.sol
+++ b/contracts/apps/AragonApp.sol
@@ -15,16 +15,13 @@ import "../acl/ACLSyntaxSugar.sol";
 // that they are automatically usable by subclassing contracts
 contract AragonApp is AppStorage, Petrifiable, ACLSyntaxSugar, VaultRecoverable, EVMScriptRunner {
     /**
-    * @dev If no kernel is provided when deploying the app, this instance is immediately petrified
-    *      so that it can never be initialized.
-    * @param _kernel Kernel to connect the deployed app to
+    * @dev Contracts inheriting from AragonApp will, by default, be immediately petrified upon
+    *      deployment so that it can never be initialized.
+    *      Unless overriden, this behaviour enforces those apps to only be usable when behind an
+    *      AppProxy.
     */
-    function AragonApp(IKernel _kernel) public {
-        if (_kernel == address(0)) {
-            petrify();
-        } else {
-            kernel = _kernel;
-        }
+    function AragonApp() public {
+        petrify();
     }
 
     modifier auth(bytes32 _role) {

--- a/contracts/apps/AragonApp.sol
+++ b/contracts/apps/AragonApp.sol
@@ -11,9 +11,9 @@ import "../evmscript/EVMScriptRunner.sol";
 import "../acl/ACLSyntaxSugar.sol";
 
 
-// Contracts inheriting from AragonApp will, by default, be immediately petrified upon deployment
-// so that it can never be initialized.
-// Unless overriden, this behaviour enforces those apps to only be usable when behind an AppProxy.
+// Contracts inheriting from AragonApp are, by default, immediately petrified upon deployment so
+// that they can never be initialized.
+// Unless overriden, this behaviour enforces those contracts to be usable only behind an AppProxy.
 // ACLSyntaxSugar and EVMScriptRunner are not directly used by this contract, but are included so
 // that they are automatically usable by subclassing contracts
 contract AragonApp is AppStorage, Autopetrified, ACLSyntaxSugar, VaultRecoverable, EVMScriptRunner {

--- a/contracts/apps/UnsafeAragonApp.sol
+++ b/contracts/apps/UnsafeAragonApp.sol
@@ -7,8 +7,15 @@ pragma solidity ^0.4.18;
 import "./AragonApp.sol";
 
 
+// Using UnsafeAragonApp means you'll be playing with 🔥.
+// A number of safe defaults are provided with AragonApp, to help you avoid dangerous situations
+// and mistakes with how your contract's developed as well as how it's deployed.
+// UnsafeAragonApp turns off these safety features to give you greater control over you contract.
+// In particular, it allows you to:
+//   - Directly use deployed base contracts as apps, without a proxy
 contract UnsafeAragonApp is AragonApp {
     function UnsafeAragonApp() public {
+        // Removes auto petrifying
         delete initializationBlock;
     }
 }

--- a/contracts/apps/UnsafeAragonApp.sol
+++ b/contracts/apps/UnsafeAragonApp.sol
@@ -10,9 +10,9 @@ import "./AragonApp.sol";
 // Using UnsafeAragonApp means you'll be playing with 🔥.
 // A number of safe defaults are provided with AragonApp, to help you avoid dangerous situations
 // and mistakes with how your contract's developed as well as how it's deployed.
-// UnsafeAragonApp turns off these safety features to give you greater control over you contract.
+// UnsafeAragonApp turns off these safety features to give you greater control over your contract.
 // In particular, it allows you to:
-//   - Directly use deployed base contracts as apps, without a proxy
+//   - Use deployed base contracts as apps directly, without a proxy
 contract UnsafeAragonApp is AragonApp {
     function UnsafeAragonApp() public {
         // Removes auto petrifying

--- a/contracts/apps/UnsafeAragonApp.sol
+++ b/contracts/apps/UnsafeAragonApp.sol
@@ -1,0 +1,14 @@
+/*
+ * SPDX-License-Identitifer:    MIT
+ */
+
+pragma solidity ^0.4.18;
+
+import "./AragonApp.sol";
+
+
+contract UnsafeAragonApp is AragonApp {
+    function UnsafeAragonApp() public {
+        delete initializationBlock;
+    }
+}

--- a/contracts/common/Autopetrified.sol
+++ b/contracts/common/Autopetrified.sol
@@ -9,8 +9,8 @@ import "./Petrifiable.sol";
 
 contract Autopetrified is Petrifiable {
     function Autopetrified() public {
-        // Petrify base instances of subclasses from Autopetrified.
-        // This renders the bases uninitializable (and unusable without a proxy).
+        // Petrify deployed (non-proxy) instances of subclasses from Autopetrified.
+        // This renders the base deployments uninitializable (and unusable without a proxy).
         petrify();
     }
 }

--- a/contracts/common/Autopetrified.sol
+++ b/contracts/common/Autopetrified.sol
@@ -1,0 +1,16 @@
+/*
+ * SPDX-License-Identitifer:    MIT
+ */
+
+pragma solidity ^0.4.18;
+
+import "./Petrifiable.sol";
+
+
+contract Autopetrified is Petrifiable {
+    function Autopetrified() public {
+        // Petrify base instances of subclasses from Autopetrified.
+        // This renders the bases uninitializable (and unusable without a proxy).
+        petrify();
+    }
+}

--- a/contracts/common/Petrifiable.sol
+++ b/contracts/common/Petrifiable.sol
@@ -11,15 +11,15 @@ contract Petrifiable is Initializable {
     // Use block UINT256_MAX (which should be never) as the initializable date
     uint256 constant internal PETRIFIED_DATE = uint256(-1);
 
+    function isPetrified() public view returns (bool) {
+        return initializationBlock == PETRIFIED_DATE;
+    }
+
     /**
     * @dev Function to be called by top level contract to prevent being initialized.
     *      Useful for freezing base contracts when they're used behind proxies.
     */
     function petrify() internal onlyInit {
         initializedAt(PETRIFIED_DATE);
-    }
-
-    function isPetrified() public returns (bool) {
-        return initializationBlock == PETRIFIED_DATE;
     }
 }

--- a/contracts/common/Petrifiable.sol
+++ b/contracts/common/Petrifiable.sol
@@ -9,10 +9,10 @@ import "./Initializable.sol";
 
 contract Petrifiable is Initializable {
     // Use block UINT256_MAX (which should be never) as the initializable date
-    uint256 constant internal PETRIFIED_DATE = uint256(-1);
+    uint256 constant internal PETRIFIED_BLOCK = uint256(-1);
 
     function isPetrified() public view returns (bool) {
-        return initializationBlock == PETRIFIED_DATE;
+        return initializationBlock == PETRIFIED_BLOCK;
     }
 
     /**
@@ -20,6 +20,6 @@ contract Petrifiable is Initializable {
     *      Useful for freezing base contracts when they're used behind proxies.
     */
     function petrify() internal onlyInit {
-        initializedAt(PETRIFIED_DATE);
+        initializedAt(PETRIFIED_BLOCK);
     }
 }

--- a/contracts/evmscript/EVMScriptRegistry.sol
+++ b/contracts/evmscript/EVMScriptRegistry.sol
@@ -1,8 +1,6 @@
 pragma solidity 0.4.18;
 
 import "../apps/AragonApp.sol";
-import "../kernel/IKernel.sol";
-
 import "./ScriptHelpers.sol";
 import "./IEVMScriptExecutor.sol";
 import "./IEVMScriptRegistry.sol";
@@ -23,12 +21,6 @@ contract EVMScriptRegistry is IEVMScriptRegistry, EVMScriptRegistryConstants, Ar
     }
 
     ExecutorEntry[] public executors;
-
-    /**
-    * @dev Constructor that allows a deployer to choose if the base instance should be connected to
-    *      a kernel or petrified immediately.
-    */
-    function EVMScriptRegistry(IKernel _kernel) AragonApp(_kernel) public {}
 
     function initialize() public onlyInit {
         initialized();

--- a/contracts/evmscript/EVMScriptRunner.sol
+++ b/contracts/evmscript/EVMScriptRunner.sol
@@ -9,9 +9,10 @@ import "./IEVMScriptExecutor.sol";
 import "./IEVMScriptRegistry.sol";
 
 import "../apps/AppStorage.sol";
+import "../common/Initializable.sol";
 
 
-contract EVMScriptRunner is AppStorage, EVMScriptRegistryConstants {
+contract EVMScriptRunner is AppStorage, Initializable, EVMScriptRegistryConstants {
     using ScriptHelpers for bytes;
 
     event ScriptResult(address indexed executor, bytes script, bytes input, bytes returnData);
@@ -20,7 +21,12 @@ contract EVMScriptRunner is AppStorage, EVMScriptRegistryConstants {
         return IEVMScriptExecutor(getExecutorRegistry().getScriptExecutor(_script));
     }
 
-    function runScript(bytes _script, bytes _input, address[] _blacklist) internal protectState returns (bytes output) {
+    function runScript(bytes _script, bytes _input, address[] _blacklist)
+        internal
+        isInitialized
+        protectState
+        returns (bytes output)
+    {
         // TODO: Too much data flying around, maybe extracting spec id here is cheaper
         IEVMScriptExecutor executor = getExecutor(_script);
         require(address(executor) != address(0));

--- a/contracts/evmscript/executors/BaseEVMScriptExecutor.sol
+++ b/contracts/evmscript/executors/BaseEVMScriptExecutor.sol
@@ -6,8 +6,9 @@ pragma solidity ^0.4.18;
 
 import "../../common/Autopetrified.sol";
 import "../ScriptHelpers.sol";
+import "../IEVMScriptExecutor.sol";
 
 
-contract BaseEVMScriptExecutor is Autopetrified {
+contract BaseEVMScriptExecutor is IEVMScriptExecutor, Autopetrified {
     uint256 constant internal SCRIPT_START_LOCATION = 4;
 }

--- a/contracts/evmscript/executors/BaseEVMScriptExecutor.sol
+++ b/contracts/evmscript/executors/BaseEVMScriptExecutor.sol
@@ -5,7 +5,6 @@
 pragma solidity ^0.4.18;
 
 import "../../common/Autopetrified.sol";
-import "../ScriptHelpers.sol";
 import "../IEVMScriptExecutor.sol";
 
 

--- a/contracts/evmscript/executors/BaseEVMScriptExecutor.sol
+++ b/contracts/evmscript/executors/BaseEVMScriptExecutor.sol
@@ -1,0 +1,13 @@
+/*
+ * SPDX-License-Identitifer:    MIT
+ */
+
+pragma solidity ^0.4.18;
+
+import "../../common/Autopetrified.sol";
+import "../ScriptHelpers.sol";
+
+
+contract BaseEVMScriptExecutor is Autopetrified {
+    uint256 constant internal SCRIPT_START_LOCATION = 4;
+}

--- a/contracts/evmscript/executors/CallsScript.sol
+++ b/contracts/evmscript/executors/CallsScript.sol
@@ -3,10 +3,10 @@ pragma solidity 0.4.18;
 // Inspired by https://github.com/reverendus/tx-manager
 
 import "../ScriptHelpers.sol";
-import "../IEVMScriptExecutor.sol";
+import "./BaseEVMScriptExecutor.sol";
 
 
-contract CallsScript is IEVMScriptExecutor {
+contract CallsScript is BaseEVMScriptExecutor {
     using ScriptHelpers for bytes;
 
     uint256 constant internal SCRIPT_START_LOCATION = 4;
@@ -21,7 +21,7 @@ contract CallsScript is IEVMScriptExecutor {
     * @param _blacklist Addresses the script cannot call to, or will revert.
     * @return always returns empty byte array
     */
-    function execScript(bytes _script, bytes _input, address[] _blacklist) external returns (bytes) {
+    function execScript(bytes _script, bytes _input, address[] _blacklist) external isInitialized returns (bytes) {
         uint256 location = SCRIPT_START_LOCATION; // first 32 bits are spec id
         while (location < _script.length) {
             address contractAddress = _script.addressAt(location);

--- a/contracts/evmscript/executors/CallsScript.sol
+++ b/contracts/evmscript/executors/CallsScript.sol
@@ -9,8 +9,6 @@ import "./BaseEVMScriptExecutor.sol";
 contract CallsScript is BaseEVMScriptExecutor {
     using ScriptHelpers for bytes;
 
-    uint256 constant internal SCRIPT_START_LOCATION = 4;
-
     event LogScriptCall(address indexed sender, address indexed src, address indexed dst);
 
     /**

--- a/contracts/factory/EVMScriptRegistryFactory.sol
+++ b/contracts/factory/EVMScriptRegistryFactory.sol
@@ -6,7 +6,6 @@ import "../evmscript/EVMScriptRegistry.sol";
 import "../evmscript/executors/CallsScript.sol";
 
 import "./AppProxyFactory.sol";
-import "../kernel/IKernel.sol";
 import "../kernel/Kernel.sol";
 import "../acl/ACL.sol";
 
@@ -16,7 +15,7 @@ contract EVMScriptRegistryFactory is AppProxyFactory, EVMScriptRegistryConstants
     IEVMScriptExecutor public baseCallScript;
 
     function EVMScriptRegistryFactory() public {
-        baseReg = new EVMScriptRegistry(IKernel(0)); // Immediately petrify this base instance
+        baseReg = new EVMScriptRegistry();
         baseCallScript = IEVMScriptExecutor(new CallsScript());
     }
 


### PR DESCRIPTION
Experiments with #355, adding a few ideas:

1. `AragonApp` (c5806bf): default behaviour is to petrify immediately on deployment
1. `UnsafeAragonApp` (6ac3cb4): freestyle mode, for app developers. Removes all safety defaults (only `initializationBlock` for now) and lets the developer play with fire. Useful for mocking in tests too.
1. `Autopetrified` (ee28768): provide helper to petrify immediately on deployment
1. `EVMScriptExecutor` (17b12c1): petrify the executors, so that they can't be used outside of a `delegatecall` originating from an initialized contract (ideally an `EVMScriptRunner`).

Comments and tests to be adjusted.