### PR TITLE
Make time helper tests more robust by giving a bit of leeway

### DIFF
--- a/test/time_helpers.js
+++ b/test/time_helpers.js
@@ -10,7 +10,7 @@ contract('TimeHelpers test', accounts => {
     assert.equal((await timeHelpersMock.getBlockNumberExt.call()).toString(), (await timeHelpersMock.getBlockNumberDirect.call()).toString(), web3.eth.blockNumber, "block number should match with real one", "block number should match with real one")
   })
 
-  it.only('checks time stamp', async () => {
+  it('checks time stamp', async () => {
     const timestamp = await timeHelpersMock.getTimestampExt.call()
     const timestamp64 = await timeHelpersMock.getTimestamp64Ext.call()
     const timestampReal = await timeHelpersMock.getTimestampDirect.call()

--- a/test/time_helpers.js
+++ b/test/time_helpers.js
@@ -10,8 +10,14 @@ contract('TimeHelpers test', accounts => {
     assert.equal((await timeHelpersMock.getBlockNumberExt.call()).toString(), (await timeHelpersMock.getBlockNumberDirect.call()).toString(), web3.eth.blockNumber, "block number should match with real one", "block number should match with real one")
   })
 
-  it('checks time stamp', async () => {
-    assert.equal((await timeHelpersMock.getTimestampExt.call()).toString(), (await timeHelpersMock.getTimestamp64Ext.call()).toString(), "time stamps should match")
-    assert.equal((await timeHelpersMock.getTimestampExt.call()).toString(), (await timeHelpersMock.getTimestampDirect.call()).toString(), "time stamp should match with real one")
+  it.only('checks time stamp', async () => {
+    const timestamp = await timeHelpersMock.getTimestampExt.call()
+    const timestamp64 = await timeHelpersMock.getTimestamp64Ext.call()
+    const timestampReal = await timeHelpersMock.getTimestampDirect.call()
+
+    const timestamp64Diff = timestamp64.minus(timestamp)
+    const timestampRealDiff = timestampReal.minus(timestamp)
+    assert.isTrue(timestamp64Diff.lessThanOrEqualTo(1), "time stamps should match (or be very close to)")
+    assert.isTrue(timestampRealDiff.lessThanOrEqualTo(1), "time stamp should match with real one (or be very close to)")
   })
 })


### PR DESCRIPTION
I think if there's a split second change between the requests for time, we get back different values.

It should never be more than one second off.