### PR TITLE
IsContract: convert to library instead

### DIFF
--- a/contracts/apps/AppProxyBase.sol
+++ b/contracts/apps/AppProxyBase.sol
@@ -2,10 +2,13 @@ pragma solidity 0.4.18;
 
 import "./AppStorage.sol";
 import "../common/DepositableDelegateProxy.sol";
+import "../common/IsContract.sol";
 import "../kernel/KernelStorage.sol";
 
 
 contract AppProxyBase is AppStorage, DepositableDelegateProxy, KernelConstants {
+    using IsContract for address;
+
     /**
     * @dev Initialize AppProxy
     * @param _kernel Reference to organization kernel for the app
@@ -24,7 +27,7 @@ contract AppProxyBase is AppStorage, DepositableDelegateProxy, KernelConstants {
 
         // If initialize payload is provided, it will be executed
         if (_initializePayload.length > 0) {
-            require(isContract(appCode));
+            require(appCode.isContract());
             // Cannot make delegatecall as a delegateproxy.delegatedFwd as it
             // returns ending execution context and halts contract deployment
             require(appCode.delegatecall(_initializePayload));

--- a/contracts/common/DelegateProxy.sol
+++ b/contracts/common/DelegateProxy.sol
@@ -4,7 +4,9 @@ import "../common/IsContract.sol";
 import "../lib/misc/ERCProxy.sol";
 
 
-contract DelegateProxy is ERCProxy, IsContract {
+contract DelegateProxy is ERCProxy {
+    using IsContract for address;
+
     uint256 constant public FWD_GAS_LIMIT = 10000;
 
     /**
@@ -13,7 +15,7 @@ contract DelegateProxy is ERCProxy, IsContract {
     * @param _calldata Calldata for the delegatecall
     */
     function delegatedFwd(address _dst, bytes _calldata) internal {
-        require(isContract(_dst));
+        require(_dst.isContract());
         uint256 fwdGasLimit = FWD_GAS_LIMIT;
 
         assembly {

--- a/contracts/common/IsContract.sol
+++ b/contracts/common/IsContract.sol
@@ -5,7 +5,7 @@
 pragma solidity ^0.4.18;
 
 
-contract IsContract {
+library IsContract {
     function isContract(address _target) internal view returns (bool) {
         if (_target == address(0)) {
             return false;

--- a/contracts/common/VaultRecoverable.sol
+++ b/contracts/common/VaultRecoverable.sol
@@ -10,7 +10,9 @@ import "./IVaultRecoverable.sol";
 import "../lib/zeppelin/token/ERC20.sol";
 
 
-contract VaultRecoverable is IVaultRecoverable, EtherTokenConstant, IsContract {
+contract VaultRecoverable is IVaultRecoverable, EtherTokenConstant {
+    using IsContract for address;
+
     /**
      * @notice Send funds to recovery Vault. This contract should never receive funds,
      *         but in case it does, this function allows one to recover them.
@@ -19,7 +21,7 @@ contract VaultRecoverable is IVaultRecoverable, EtherTokenConstant, IsContract {
     function transferToVault(address _token) external {
         require(allowRecoverability(_token));
         address vault = getRecoveryVault();
-        require(isContract(vault));
+        require(vault.isContract());
 
         if (_token == ETH) {
             vault.transfer(this.balance);

--- a/contracts/kernel/Kernel.sol
+++ b/contracts/kernel/Kernel.sol
@@ -11,7 +11,9 @@ import "../common/VaultRecoverable.sol";
 import "../factory/AppProxyFactory.sol";
 
 
-contract Kernel is IKernel, KernelStorage, Initializable, IsContract, AppProxyFactory, ACLSyntaxSugar, VaultRecoverable {
+contract Kernel is IKernel, KernelStorage, Initializable, AppProxyFactory, ACLSyntaxSugar, VaultRecoverable {
+    using IsContract for address;
+
     // Hardcode constant to save gas
     //bytes32 constant public APP_MANAGER_ROLE = keccak256("APP_MANAGER_ROLE");
     //bytes32 constant public DEFAULT_VAULT_ID = keccak256(APP_ADDR_NAMESPACE, apmNamehash("vault"));
@@ -174,14 +176,14 @@ contract Kernel is IKernel, KernelStorage, Initializable, IsContract, AppProxyFa
     }
 
     function _setApp(bytes32 _namespace, bytes32 _name, address _app) internal returns (bytes32 id) {
-        require(isContract(_app));
+        require(_app.isContract());
         id = keccak256(_namespace, _name);
         apps[id] = _app;
         SetApp(_namespace, _name, id, _app);
     }
 
     function _setAppIfNew(bytes32 _namespace, bytes32 _name, address _app) internal returns (bytes32 id) {
-        require(isContract(_app));
+        require(_app.isContract());
 
         id = keccak256(_namespace, _name);
 

--- a/test/TestDelegateProxy.sol
+++ b/test/TestDelegateProxy.sol
@@ -4,6 +4,7 @@ import "truffle/Assert.sol";
 import "./helpers/ThrowProxy.sol";
 
 import "../contracts/common/DelegateProxy.sol";
+import "../contracts/common/IsContract.sol";
 import "../contracts/evmscript/ScriptHelpers.sol";
 
 
@@ -15,6 +16,7 @@ contract Target {
 
 
 contract TestDelegateProxy is DelegateProxy {
+    using IsContract for address;
     using ScriptHelpers for *;
 
     Target target;
@@ -57,13 +59,13 @@ contract TestDelegateProxy is DelegateProxy {
     }
 
     function testIsContractZero() public {
-        bool result = isContract(address(0));
+        bool result = address(0).isContract();
         Assert.isFalse(result, "should return false");
     }
 
     function testIsContractAddress() public {
         address nonContract = 0x1234;
-        bool result = isContract(nonContract);
+        bool result = nonContract.isContract();
         Assert.isFalse(result, "should return false");
     }
 


### PR DESCRIPTION
Mainly simplifies the inheritance graphs, and also might be more aesthetically pleasing.

Does make the contract _slightly_ larger (Kernel.sol is ~150 bytes more and AppProxyUpgradeable is ~40 bytes more), meaning more gas to deploy them.