### PR TITLE
Petrifiable: add tests

### DIFF
--- a/migrations/2_apm.js
+++ b/migrations/2_apm.js
@@ -21,7 +21,7 @@ module.exports = function (deployer, network, accounts, arts = null) {
     const APMRegistryFactory = getContract('APMRegistryFactory')
     const ensAddr = '0x0' // so ensfactory creates one
 
-    const kernelBase = await getContract('Kernel').new()
+    const kernelBase = await getContract('Kernel').new(true) // immediately petrify
     const aclBase = await getContract('ACL').new()
     const daoFactory = await getContract('DAOFactory').new(kernelBase.address, aclBase.address, '0x00')
 

--- a/migrations/3_factory.js
+++ b/migrations/3_factory.js
@@ -7,7 +7,7 @@ module.exports = function (deployer, network, accounts, arts = null) {
     const DAOFactory = artifacts.require('DAOFactory')
     const EVMScriptRegistryFactory = artifacts.require('EVMScriptRegistryFactory')
 
-    const kernelBase = await getContract('Kernel').new()
+    const kernelBase = await getContract('Kernel').new(true) // immediately petrify
     const aclBase = await getContract('ACL').new()
 
     const regFact = await EVMScriptRegistryFactory.new()

--- a/test/apm_registry.js
+++ b/test/apm_registry.js
@@ -3,16 +3,24 @@ const namehash = require('eth-ens-namehash').hash
 const keccak256 = require('js-sha3').keccak_256
 
 const ENS = artifacts.require('ENS')
-const Repo = artifacts.require('Repo')
-const APMRegistry = artifacts.require('APMRegistry')
+const ENSFactory = artifacts.require('ENSFactory')
 const PublicResolver = artifacts.require('PublicResolver')
+
 const Kernel = artifacts.require('Kernel')
 const ACL = artifacts.require('ACL')
+const DAOFactory = artifacts.require('DAOFactory')
 
-const getContract = name => artifacts.require(name)
+const APMRegistry = artifacts.require('APMRegistry')
+const ENSSubdomainRegistrar = artifacts.require('ENSSubdomainRegistrar')
+const Repo = artifacts.require('Repo')
+const APMRegistryFactory = artifacts.require('APMRegistryFactory')
+
+const APMRegistryFactoryMock = artifacts.require('APMRegistryFactoryMock')
+
+const getRepoFromLog = receipt => receipt.logs.filter(x => x.event == 'NewRepo')[0].args.repo
 
 contract('APMRegistry', accounts => {
-    let ensFactory, ens, apmFactory, apmFactoryMock, registry, baseDeployed, baseAddrs, dao, acl, daoFactory = {}
+    let baseDeployed, baseAddrs, ensFactory, apmFactory, daoFactory, ens, registry, acl
     const ensOwner = accounts[0]
     const apmOwner = accounts[1]
     const repoDev  = accounts[2]
@@ -22,32 +30,44 @@ contract('APMRegistry', accounts => {
     const testNode = namehash('test.aragonpm.eth')
 
     before(async () => {
-        const bases = ['APMRegistry', 'Repo', 'ENSSubdomainRegistrar']
-        baseDeployed = await Promise.all(bases.map(c => getContract(c).new()))
+        const bases = [APMRegistry, Repo, ENSSubdomainRegistrar]
+        baseDeployed = await Promise.all(bases.map(base => base.new()))
         baseAddrs = baseDeployed.map(c => c.address)
 
-        ensFactory = await getContract('ENSFactory').new()
+        ensFactory = await ENSFactory.new()
 
-        const kernelBase = await getContract('Kernel').new()
-        const aclBase = await getContract('ACL').new()
-        daoFactory = await getContract('DAOFactory').new(kernelBase.address, aclBase.address, '0x00')
+        const kernelBase = await Kernel.new(true) // petrify immediately
+        const aclBase = await ACL.new()
+        daoFactory = await DAOFactory.new(kernelBase.address, aclBase.address, '0x00')
     })
 
     beforeEach(async () => {
-        apmFactory = await getContract('APMRegistryFactory').new(daoFactory.address, ...baseAddrs, '0x0', ensFactory.address)
-        apmFactoryMock = await getContract('APMRegistryFactoryMock').new(daoFactory.address, ...baseAddrs, '0x0', ensFactory.address)
+        apmFactory = await APMRegistryFactory.new(daoFactory.address, ...baseAddrs, '0x0', ensFactory.address)
         ens = ENS.at(await apmFactory.ens())
 
         const receipt = await apmFactory.newAPM(namehash('eth'), '0x'+keccak256('aragonpm'), apmOwner)
         const apmAddr = receipt.logs.filter(l => l.event == 'DeployAPM')[0].args.apm
         registry = APMRegistry.at(apmAddr)
 
-        dao = Kernel.at(await registry.kernel())
+        const dao = Kernel.at(await registry.kernel())
         acl = ACL.at(await dao.acl())
         const subdomainRegistrar = baseDeployed[2]
 
         // Get permission to delete names after each test case
         await acl.createPermission(apmOwner, await registry.registrar(), await subdomainRegistrar.DELETE_NAME_ROLE(), apmOwner, { from: apmOwner })
+    })
+
+    it('inits with existing ENS deployment', async () => {
+        const receipt = await ensFactory.newENS(accounts[0])
+        const ens2 = ENS.at(receipt.logs.filter(l => l.event == 'DeployENS')[0].args.ens)
+        const newFactory = await APMRegistryFactory.new(daoFactory.address, ...baseAddrs, ens2.address, '0x00')
+
+        await ens2.setSubnodeOwner(namehash('eth'), '0x'+keccak256('aragonpm'), newFactory.address)
+        const receipt2 = await newFactory.newAPM(namehash('eth'), '0x'+keccak256('aragonpm'), apmOwner)
+        const apmAddr = receipt2.logs.filter(l => l.event == 'DeployAPM')[0].args.apm
+        const resolver = PublicResolver.at(await ens2.resolver(rootNode))
+
+        assert.equal(await resolver.addr(rootNode), apmAddr, 'rootnode should be resolve')
     })
 
     it('aragonpm.eth should resolve to registry', async () => {
@@ -60,38 +80,28 @@ contract('APMRegistry', accounts => {
         assert.equal(await ens.owner(rootNode), await registry.registrar(), 'rootnode should be owned correctly')
     })
 
+    it('can create repo with version and dev can create new versions', async () => {
+        const receipt = await registry.newRepoWithVersion('test', repoDev, [1, 0, 0], '0x00', '0x00', { from: apmOwner })
+        const repo = Repo.at(getRepoFromLog(receipt))
+
+        assert.equal(await repo.getVersionsCount(), 1, 'should have created version')
+
+        await repo.newVersion([2, 0, 0], '0x00', '0x00', { from: repoDev })
+
+        assert.equal(await repo.getVersionsCount(), 2, 'should have created version')
+    })
+
     it('fails to create empty repo name', async () => {
         return assertRevert(async () => {
             await registry.newRepo('', repoDev, { from: apmOwner })
         })
     })
 
-    it('fails if factory doesnt give permission to create permissions', async () => {
+    it('fails to create repo if not in ACL', async () => {
         return assertRevert(async () => {
-            await apmFactoryMock.newBadAPM(namehash('eth'), '0x'+keccak256('aragonpm'), apmOwner, true)
+            await registry.newRepo('test', repoDev, { from: notOwner })
         })
     })
-
-    it('fails if factory doesnt give permission to create names', async () => {
-        return assertRevert(async () => {
-            await apmFactoryMock.newBadAPM(namehash('eth'), '0x'+keccak256('aragonpm'), apmOwner, false)
-        })
-    })
-
-    it('inits with existing ENS deployment', async () => {
-        const receipt = await ensFactory.newENS(accounts[0])
-        const ens2 = ENS.at(receipt.logs.filter(l => l.event == 'DeployENS')[0].args.ens)
-        const newFactory = await getContract('APMRegistryFactory').new(daoFactory.address, ...baseAddrs, ens2.address, '0x00')
-
-        await ens2.setSubnodeOwner(namehash('eth'), '0x'+keccak256('aragonpm'), newFactory.address)
-        const receipt2 = await newFactory.newAPM(namehash('eth'), '0x'+keccak256('aragonpm'), apmOwner)
-        const apmAddr = receipt2.logs.filter(l => l.event == 'DeployAPM')[0].args.apm
-        const resolver = PublicResolver.at(await ens2.resolver(rootNode))
-
-        assert.equal(await resolver.addr(rootNode), apmAddr, 'rootnode should be resolve')
-    })
-
-    const getRepoFromLog = receipt => receipt.logs.filter(x => x.event == 'NewRepo')[0].args.repo
 
     context('creating test.aragonpm.eth repo', () => {
         let repo = {}
@@ -154,20 +164,23 @@ contract('APMRegistry', accounts => {
         })
     })
 
-    it('can create repo with version and dev can create new versions', async () => {
-        const receipt = await registry.newRepoWithVersion('test', repoDev, [1, 0, 0], '0x00', '0x00', { from: apmOwner })
-        const repo = Repo.at(getRepoFromLog(receipt))
+    context('APMRegistry created with lacking permissions', () => {
+        let apmFactoryMock
 
-        assert.equal(await repo.getVersionsCount(), 1, 'should have created version')
+        before(async () => {
+            apmFactoryMock = await APMRegistryFactoryMock.new(daoFactory.address, ...baseAddrs, '0x0', ensFactory.address)
+        })
 
-        await repo.newVersion([2, 0, 0], '0x00', '0x00', { from: repoDev })
+        it('fails if factory doesnt give permission to create permissions', async () => {
+            return assertRevert(async () => {
+                await apmFactoryMock.newBadAPM(namehash('eth'), '0x'+keccak256('aragonpm'), apmOwner, true)
+            })
+        })
 
-        assert.equal(await repo.getVersionsCount(), 2, 'should have created version')
-    })
-
-    it('cannot create repo if not in ACL', async () => {
-        return assertRevert(async () => {
-            await registry.newRepo('test', repoDev, { from: notOwner })
+        it('fails if factory doesnt give permission to create names', async () => {
+            return assertRevert(async () => {
+                await apmFactoryMock.newBadAPM(namehash('eth'), '0x'+keccak256('aragonpm'), apmOwner, false)
+            })
         })
     })
 })

--- a/test/apm_repo.js
+++ b/test/apm_repo.js
@@ -93,7 +93,7 @@ contract('Repo', accounts => {
             })
         })
 
-        context('adding new version', async () => {
+        context('adding new version', () => {
             const newCode = accounts[9] // random addr, irrelevant
             const newContent = '0x13'
 

--- a/test/apm_repo.js
+++ b/test/apm_repo.js
@@ -1,13 +1,14 @@
 const { assertRevert } = require('./helpers/assertThrow')
 
-const Repo = artifacts.require('Repo')
-const getContract = artifacts.require
+
+const Repo = artifacts.require('UnsafeRepo')
 
 contract('Repo', accounts => {
-    let repo = {}
+    let repo
 
     beforeEach(async () => {
         repo = await Repo.new()
+        repo.initialize();
     })
 
     it('computes correct valid bumps', async () => {

--- a/test/app_acl.js
+++ b/test/app_acl.js
@@ -1,0 +1,148 @@
+const { assertRevert } = require('./helpers/assertThrow')
+const { onlyIf } = require('./helpers/onlyIf')
+const { hash } = require('eth-ens-namehash')
+
+const ACL = artifacts.require('ACL')
+const Kernel = artifacts.require('Kernel')
+const KernelProxy = artifacts.require('KernelProxy')
+const AppProxyUpgradeable = artifacts.require('AppProxyUpgradeable')
+const AppProxyPinned = artifacts.require('AppProxyPinned')
+
+// Mocks
+const AppStub = artifacts.require('AppStub')
+const UnsafeAppStub = artifacts.require('UnsafeAppStub')
+
+const APP_ID = hash('stub.aragonpm.test')
+const EMPTY_BYTES = '0x'
+
+contract('App ACL', accounts => {
+  let aclBase, kernelBase, acl, kernel
+  let APP_BASES_NAMESPACE, APP_ROLE
+
+  const permissionsRoot = accounts[0]
+  const unauthorized = accounts[1]
+
+  // Initial setup
+  before(async () => {
+    kernelBase = await Kernel.new(true) // petrify immediately
+    aclBase = await ACL.new()
+
+    // Setup constants
+    APP_BASES_NAMESPACE = await kernelBase.APP_BASES_NAMESPACE()
+
+    const app = await AppStub.new()
+    APP_ROLE = await app.ROLE()
+  })
+
+  beforeEach(async () => {
+    kernel = Kernel.at((await KernelProxy.new(kernelBase.address)).address)
+    await kernel.initialize(aclBase.address, permissionsRoot)
+    acl = ACL.at(await kernel.acl())
+
+    // Set up app management permissions
+    const APP_MANAGER_ROLE = await kernelBase.APP_MANAGER_ROLE()
+    await acl.createPermission(permissionsRoot, kernel.address, APP_MANAGER_ROLE, permissionsRoot)
+  })
+
+  // Test the app itself and when it's behind the proxies to make sure their behaviours are the same
+  const appProxyTypes = ['AppProxyUpgradeable', 'AppProxyPinned']
+  for (const appType of ['App', ...appProxyTypes]) {
+    context(`> ${appType}`, () => {
+      let appBase, app
+
+      const onlyAppProxyUpgradeable = onlyIf(() => appType === 'AppProxyUpgradeable')
+
+      before(async () => {
+        if (appProxyTypes.includes(appType)) {
+          // We can reuse the same app base for the proxies
+          appBase = await AppStub.new()
+        }
+      })
+
+      beforeEach(async () => {
+        if (appType === 'App') {
+          // Use the unsafe version to use directly without a proxy
+          app = await UnsafeAppStub.new(kernel.address)
+        } else {
+          await kernel.setApp(APP_BASES_NAMESPACE, APP_ID, appBase.address)
+          let appProxy
+          if (appType === 'AppProxyUpgradeable') {
+            appProxy = await AppProxyUpgradeable.new(kernel.address, APP_ID, EMPTY_BYTES)
+          } else if (appType === 'AppProxyPinned') {
+            appProxy = await AppProxyPinned.new(kernel.address, APP_ID, EMPTY_BYTES)
+          }
+          app = AppStub.at(appProxy.address)
+        }
+
+        await app.initialize()
+
+        // assign app permissions
+        await acl.createPermission(permissionsRoot, app.address, APP_ROLE, permissionsRoot)
+      })
+
+      it('should return values correctly', async () => {
+        assert.equal(await app.stringTest(), 'hola', 'string test')
+      })
+
+      it('protected call works from authed entity', async () => {
+        await app.setValue(10)
+        assert.equal(await app.getValue(), 10, 'should have returned correct value')
+      })
+
+      it('parametrized call works from authed entity if no params set', async () => {
+        await app.setValueParam(11)
+        assert.equal(await app.getValue(), 11, 'should have returned correct value')
+      })
+
+      it('fails when called by unauthorized entity', async () => {
+        return assertRevert(async () => {
+          await app.setValue(10, { from: unauthorized })
+        })
+      })
+
+      onlyAppProxyUpgradeable(() =>
+        it('fails if using app proxy without reference in kernel', async () => {
+          const unknownId = hash('unknown.aragonpm.test')
+          const appProxy = await AppProxyUpgradeable.new(kernel.address, unknownId, EMPTY_BYTES)
+          const app = AppStub.at(appProxy.address)
+
+          return assertRevert(async () => {
+            await app.setValue(10)
+          })
+        })
+      )
+
+      context('> Parametrized calls', () => {
+        const paramsGrantee = accounts[2]
+        const paramValue = 5
+        const succeedValue = paramValue + 1
+        const failValue = paramValue - 1
+
+        beforeEach(async () => {
+          const argId = '0x00' // arg 0
+          const op = '03'    // greater than
+          const value = `00000000000000000000000000000000000000000000000000000000000${paramValue}` // 5
+          const param = new web3.BigNumber(`${argId}${op}${value}`)
+
+          await acl.grantPermissionP(paramsGrantee, app.address, APP_ROLE, [param], { from: permissionsRoot })
+        })
+
+        it('parametrized call succeeds if param eval succeeds', async () => {
+          await app.setValueParam(succeedValue, { from: paramsGrantee })
+        })
+
+        it('parametrized call works from entity with no params set', async () => {
+          // Fail value should still work for the entity who didn't have restrictions placed
+          await app.setValueParam(failValue)
+          assert.equal(await app.getValue(), failValue, 'should have returned correct value')
+        })
+
+        it('parametrized app call fails if param eval fails', async () => {
+          return assertRevert(async () => {
+            await app.setValueParam(failValue, { from: paramsGrantee })
+          })
+        })
+      })
+    })
+  }
+})

--- a/test/app_base_lifecycle.js
+++ b/test/app_base_lifecycle.js
@@ -1,0 +1,127 @@
+const { assertRevert } = require('./helpers/assertThrow')
+const { getBlockNumber } = require('./helpers/web3')
+const { hash } = require('eth-ens-namehash')
+const { soliditySha3 } = require('web3-utils')
+
+const ACL = artifacts.require('ACL')
+const Kernel = artifacts.require('Kernel')
+const KernelProxy = artifacts.require('KernelProxy')
+
+const AragonApp = artifacts.require('AragonApp')
+const AppProxyUpgradeable = artifacts.require('AppProxyUpgradeable')
+
+// Mocks
+const UnsafeAragonAppMock = artifacts.require('UnsafeAragonAppMock')
+
+const APP_ID = hash('app.aragonpm.test')
+const FAKE_ROLE = soliditySha3('FAKE_ROLE')
+const ZERO_ADDR = '0x0000000000000000000000000000000000000000'
+
+contract('App base lifecycle', accounts => {
+  let aclBase, kernelBase
+  const permissionsRoot = accounts[0]
+
+  before(async () => {
+    kernelBase = await Kernel.new(true) // petrify immediately
+    aclBase = await ACL.new()
+  })
+
+  context('> AragonApp', () => {
+    let app
+
+    beforeEach(async () => {
+      app = await AragonApp.new()
+    })
+
+    it('is not initialized', async () => {
+      assert.isFalse(await app.hasInitialized(), 'should not be initialized')
+    })
+
+    it('is petrified', async () => {
+      assert.isTrue(await app.isPetrified(), 'should be petrified')
+    })
+
+    it('does not have initialization function', async () => {
+      assert.isNotFunction(app.initialize, 'base AragonApp should not have initialize')
+    })
+
+    it('should not be usable', async () => {
+      assert.isFalse(await app.canPerform(permissionsRoot, FAKE_ROLE, []))
+    })
+  })
+
+  context('> UnsafeAragonApp', () => {
+    let app
+
+    beforeEach(async () => {
+      // Use the mock so we can initialize and set the kernel
+      app = await UnsafeAragonAppMock.new()
+    })
+
+    it('is not initialized by default', async () => {
+      assert.isFalse(await app.hasInitialized(), 'should not be initialized')
+    })
+
+    it('is not petrified by default', async () => {
+      assert.isFalse(await app.isPetrified(), 'should not be petrified')
+    })
+
+    it('should not be usable yet', async () => {
+      assert.isFalse(await app.canPerform(permissionsRoot, FAKE_ROLE, []))
+    })
+
+    context('> Initialized', () => {
+      beforeEach(async () => {
+        await app.initialize()
+      })
+
+      it('is now initialized', async () => {
+        assert.isTrue(await app.hasInitialized(), 'should be initialized')
+      })
+
+      it('is still not petrified', async () => {
+        assert.isFalse(await app.isPetrified(), 'should not be petrified')
+      })
+
+      it('has correct initialization block', async () => {
+        assert.equal(await app.getInitializationBlock(), await getBlockNumber(), 'initialization block should be correct')
+      })
+
+      it('throws on reinitialization', async () => {
+        return assertRevert(async () => {
+          await app.initialize()
+        })
+      })
+
+      it('should still not be usable without a kernel', async () => {
+        assert.equal(await app.getKernel(), ZERO_ADDR, 'app should still be missing kernel reference')
+
+        assert.isFalse(await app.canPerform(permissionsRoot, FAKE_ROLE, []))
+      })
+
+      context('> Set kernel', () => {
+        let acl, kernel
+
+        beforeEach(async () => {
+          const kernelProxy = await KernelProxy.new(kernelBase.address)
+          kernel = Kernel.at(kernelProxy.address)
+          await kernel.initialize(aclBase.address, permissionsRoot)
+          acl = ACL.at(await kernel.acl())
+
+          await app.setKernelOnMock(kernel.address)
+        })
+
+        it('should not be usable if no permission is granted', async () => {
+          assert.isFalse(await app.canPerform(permissionsRoot, FAKE_ROLE, []))
+        })
+
+        it('should be usable after initialization, setting a kernel, and setting a permission', async () => {
+          // Setup permissions
+          await acl.createPermission(permissionsRoot, app.address, FAKE_ROLE, permissionsRoot)
+
+          assert.isTrue(await app.canPerform(permissionsRoot, FAKE_ROLE, []))
+        })
+      })
+    })
+  })
+})

--- a/test/app_proxy.js
+++ b/test/app_proxy.js
@@ -1,0 +1,261 @@
+const { assertRevert } = require('./helpers/assertThrow')
+const { onlyIf } = require('./helpers/onlyIf')
+const { getBlockNumber } = require('./helpers/web3')
+const { hash } = require('eth-ens-namehash')
+
+const ACL = artifacts.require('ACL')
+const Kernel = artifacts.require('Kernel')
+const KernelProxy = artifacts.require('KernelProxy')
+const AppProxyUpgradeable = artifacts.require('AppProxyUpgradeable')
+const AppProxyPinned = artifacts.require('AppProxyPinned')
+
+// Mocks
+const AppStub = artifacts.require('AppStub')
+const AppStub2 = artifacts.require('AppStub2')
+const ERCProxyMock = artifacts.require('ERCProxyMock')
+
+const APP_ID = hash('stub.aragonpm.test')
+const ZERO_ADDR = '0x0000000000000000000000000000000000000000'
+const EMPTY_BYTES = '0x'
+
+contract('App proxy', accounts => {
+  let aclBase, appBase1, appBase2, kernelBase, acl, kernel
+  let APP_BASES_NAMESPACE, APP_ROLE
+  let UPGRADEABLE, FORWARDING
+
+  const permissionsRoot = accounts[0]
+
+  // Initial setup
+  before(async () => {
+    appBase1 = await AppStub.new()
+    appBase2 = await AppStub2.new()
+
+    kernelBase = await Kernel.new(true) // petrify immediately
+    aclBase = await ACL.new()
+
+    // Setup constants
+    APP_BASES_NAMESPACE = await kernelBase.APP_BASES_NAMESPACE()
+    APP_ROLE = await appBase1.ROLE()
+
+    const ercProxyMock = await ERCProxyMock.new()
+    UPGRADEABLE = (await ercProxyMock.UPGRADEABLE()).toString()
+    FORWARDING = (await ercProxyMock.FORWARDING()).toString()
+  })
+
+  beforeEach(async () => {
+    kernel = Kernel.at((await KernelProxy.new(kernelBase.address)).address)
+    await kernel.initialize(aclBase.address, permissionsRoot)
+    acl = ACL.at(await kernel.acl())
+
+    // Set up app management permissions
+    const APP_MANAGER_ROLE = await kernelBase.APP_MANAGER_ROLE()
+    await acl.createPermission(permissionsRoot, kernel.address, APP_MANAGER_ROLE, permissionsRoot)
+  })
+
+  const appProxyContractMapping = {
+    'AppProxyUpgradeable': AppProxyUpgradeable,
+    'AppProxyPinned': AppProxyPinned,
+  }
+  for (const appProxyType of Object.keys(appProxyContractMapping)) {
+    const appProxyContract = appProxyContractMapping[appProxyType]
+
+    const onlyAppProxyUpgradeable = onlyIf(() => appProxyType === 'AppProxyUpgradeable')
+    const onlyAppProxyPinned = onlyIf(() => appProxyType === 'AppProxyPinned')
+
+    context(`> ${appProxyType}`, () => {
+      let app
+
+      // Suite of basic tests for each proxy type
+      checkProxyType = () => {
+        it('checks ERC897 functions', async () => {
+          const proxy = appProxyContract.at(app.address)
+          const implementation = await proxy.implementation()
+          assert.equal(implementation, appBase1.address, 'app address should match base')
+
+          const proxyType = (await proxy.proxyType.call()).toString()
+
+          if (appProxyType === 'AppProxyUpgradeable') {
+            assert.equal(proxyType, UPGRADEABLE, 'proxy type should be upgradeable')
+          } else if (appProxyType === 'AppProxyPinned') {
+            assert.equal(proxyType, FORWARDING, 'proxy type should be forwarding')
+          }
+        })
+
+        if (appProxyType === 'AppProxyUpgradeable') {
+          it('is upgradeable', async () => {
+            const proxy = appProxyContract.at(app.address)
+            assert.equal((await proxy.proxyType.call()).toString(), UPGRADEABLE, 'app should be upgradeable')
+          })
+        } else if (appProxyType === 'AppProxyPinned') {
+          it('is not upgradeable', async () => {
+            const proxy = appProxyContract.at(app.address)
+            assert.notEqual((await proxy.proxyType.call()).toString(), UPGRADEABLE, 'app should not be upgradeable')
+          })
+        }
+      }
+
+      onlyAppProxyUpgradeable(() => {
+        it("allows creating proxy if code hasn't been set and not initializing on constructor", async () => {
+          await AppProxyUpgradeable.new(kernel.address, APP_ID, EMPTY_BYTES)
+        })
+
+        it('fails if initializing on constructor before setting app code', async () => {
+          const initializationPayload = appBase1.contract.initialize.getData()
+
+          return assertRevert(async () => {
+            await AppProxyUpgradeable.new(kernel.address, APP_ID, initializationPayload)
+          })
+        })
+      })
+
+      onlyAppProxyPinned(() => {
+        it("fails if code hasn't been set yet", async () => {
+          const fakeAppId = hash('fake.aragonpm.test')
+          return assertRevert(async () => {
+            await AppProxyPinned.new(kernel.address, fakeAppId, EMPTY_BYTES)
+          })
+        })
+      })
+
+      context('> Fails on bad kernel', () => {
+        beforeEach(async () => {
+          await kernel.setApp(APP_BASES_NAMESPACE, APP_ID, appBase1.address)
+        })
+
+        it('fails if kernel address is 0', async () => {
+          return assertRevert(async () => {
+            await appProxyContract.new(ZERO_ADDR, APP_ID, EMPTY_BYTES)
+          })
+        })
+
+        it('fails if kernel address is not a contract', async () => {
+          return assertRevert(async () => {
+            await appProxyContract.new('0x1234', APP_ID, EMPTY_BYTES)
+          })
+        })
+      })
+
+      context('> Initialized on proxy constructor', () => {
+        beforeEach(async () => {
+          await kernel.setApp(APP_BASES_NAMESPACE, APP_ID, appBase1.address)
+
+          const initializationPayload = appBase1.contract.initialize.getData()
+          const appProxy = await appProxyContract.new(kernel.address, APP_ID, initializationPayload)
+          app = AppStub.at(appProxy.address)
+        })
+
+        // Run generic checks for proxy type
+        checkProxyType()
+
+        it('is initialized', async () => {
+          assert.isTrue(await app.hasInitialized(), 'app should have been initialized')
+        })
+
+        it('is not petrified', async () => {
+          assert.isFalse(await app.isPetrified(), 'app should not have been petrified')
+        })
+
+        it('has correct initialization block', async () => {
+            assert.equal(await app.getInitializationBlock(), await getBlockNumber(), 'initialization block should be correct')
+        })
+
+        it('cannot reinitialize', async () => {
+          return assertRevert(async () => {
+            await app.initialize()
+          })
+        })
+
+        it('fails if init fails', async () => {
+          const badInit = '0x1234'
+          return assertRevert(async () => {
+            await appProxyContract.new(kernel.address, APP_ID, badInit)
+          })
+        })
+
+        it('should return values correctly', async () => {
+          assert.equal(await app.stringTest(), 'hola', 'string test')
+        })
+      })
+
+      context('> Not initialized on proxy constructor', () => {
+        beforeEach(async () => {
+          await kernel.setApp(APP_BASES_NAMESPACE, APP_ID, appBase1.address)
+
+          const initializationPayload = EMPTY_BYTES // don't initialize
+          const appProxy = await appProxyContract.new(kernel.address, APP_ID, initializationPayload)
+          app = AppStub.at(appProxy.address)
+        })
+
+        // Run generic checks for proxy type
+        checkProxyType()
+
+        it('is not initialized', async () => {
+          assert.isFalse(await app.hasInitialized(), 'app should not have been initialized')
+          assert.isFalse(await app.isPetrified(), 'app should not have been petrified')
+        })
+
+        it('can initialize', async () => {
+          await app.initialize()
+          assert.isTrue(await app.hasInitialized(), 'app should have been initialized')
+          assert.isFalse(await app.isPetrified(), 'app should not have been petrified')
+        })
+
+        it("fails calling functionality requiring initialization (if it's not)", async () => {
+          return assertRevert(async () => {
+            await app.requiresInitialization()
+          })
+        })
+
+        it('allows calling functionality requiring initialization after initializing', async () => {
+          await app.initialize()
+          const result = await app.requiresInitialization()
+          assert.equal(result, true, "should return correct result")
+        })
+      })
+
+      context('> Updating app', () => {
+        beforeEach(async () => {
+          await kernel.setApp(APP_BASES_NAMESPACE, APP_ID, appBase1.address)
+
+          const initializationPayload = appBase1.contract.initialize.getData()
+          const appProxy = await appProxyContract.new(kernel.address, APP_ID, initializationPayload)
+          app = AppStub.at(appProxy.address)
+
+          // Assign app permissions
+          await acl.createPermission(permissionsRoot, appProxy.address, APP_ROLE, permissionsRoot)
+        })
+
+        onlyAppProxyUpgradeable(() => {
+          it('storage is preserved', async () => {
+            await app.setValue(10)
+            await kernel.setApp(APP_BASES_NAMESPACE, APP_ID, appBase2.address)
+
+            // The upgraded app (AppStub2) returns the double of the value in storage
+            assert.equal(await app.getValue(), 20, 'app should have returned correct value after upgrading')
+          })
+
+          it('removed functions throw', async () => {
+            await app.setValue(10)
+            await kernel.setApp(APP_BASES_NAMESPACE, APP_ID, appBase2.address)
+
+            // The upgraded app (AppStub2) doesn't have `setValue()` anymore
+            return assertRevert(async () => {
+              await app.setValue(10)
+            })
+          })
+        })
+
+        onlyAppProxyPinned(() =>
+          it('can update app code and pinned proxy continues using former version', async () => {
+            await app.setValue(10)
+            await app.setValue(11)
+            await kernel.setApp(APP_BASES_NAMESPACE, APP_ID, appBase2.address)
+
+            // The upgraded app (AppStub2) would return the double of the value in storage
+            assert.equal(await app.getValue(), 11, 'app should have returned correct original value')
+          })
+        )
+      })
+    })
+  }
+})

--- a/test/evm_script.js
+++ b/test/evm_script.js
@@ -4,26 +4,23 @@ const { soliditySha3 } = require('web3-utils')
 const { assertRevert } = require('./helpers/assertThrow')
 const { encodeCallScript } = require('./helpers/evmScript')
 
-const ExecutionTarget = artifacts.require('ExecutionTarget')
-const Executor = artifacts.require('Executor')
-
 const Kernel = artifacts.require('Kernel')
 const ACL = artifacts.require('ACL')
 const DAOFactory = artifacts.require('DAOFactory')
 const EVMScriptRegistryFactory = artifacts.require('EVMScriptRegistryFactory')
 const EVMScriptRegistry = artifacts.require('EVMScriptRegistry')
-const EVMScriptRegistryConstants = artifacts.require('EVMScriptRegistryConstants')
+const CallsScript = artifacts.require('CallsScript')
 const IEVMScriptExecutor = artifacts.require('IEVMScriptExecutor')
 
-const keccak256 = require('js-sha3').keccak_256
-const APP_BASE_NAMESPACE = '0x'+keccak256('base')
+// Mocks
+const ExecutionTarget = artifacts.require('ExecutionTarget')
+const EVMScriptExecutor = artifacts.require('EVMScriptExecutor')
+
 const ZERO_ADDR = '0x0000000000000000000000000000000000000000'
 
-
-const getContract = artifacts.require
-
 contract('EVM Script', accounts => {
-    let executor, executionTarget, dao, daoFact, reg, constants, acl, baseExecutor
+    let callsScriptBase, executorBase, executor, executionTarget, dao, daoFact, reg, acl
+    let APP_BASES_NAMESPACE
 
     const boss = accounts[1]
 
@@ -31,12 +28,13 @@ contract('EVM Script', accounts => {
 
     before(async () => {
         const regFact = await EVMScriptRegistryFactory.new()
+        callsScriptBase = CallsScript.at(await regFact.baseCallScript())
 
-        const kernelBase = await getContract('Kernel').new()
-        const aclBase = await getContract('ACL').new()
+        const kernelBase = await Kernel.new(true) // petrify immediately
+        const aclBase = await ACL.new()
         daoFact = await DAOFactory.new(kernelBase.address, aclBase.address, regFact.address)
 
-        constants = await EVMScriptRegistryConstants.new()
+        APP_BASES_NAMESPACE = await kernelBase.APP_BASES_NAMESPACE()
     })
 
     beforeEach(async () => {
@@ -46,8 +44,8 @@ contract('EVM Script', accounts => {
         reg = EVMScriptRegistry.at(receipt.logs.filter(l => l.event == 'DeployEVMScriptRegistry')[0].args.reg)
 
         await acl.createPermission(boss, dao.address, await dao.APP_MANAGER_ROLE(), boss, { from: boss })
-        baseExecutor = await Executor.new()
-        await dao.setApp(APP_BASE_NAMESPACE, executorAppId, baseExecutor.address, { from: boss })
+        executorBase = await EVMScriptExecutor.new()
+        await dao.setApp(APP_BASES_NAMESPACE, executorAppId, executorBase.address, { from: boss })
     })
 
     it('factory registered just 1 script executor', async () => {
@@ -62,10 +60,35 @@ contract('EVM Script', accounts => {
         })
     })
 
-    context('executor', () => {
+    it('fails if directly calling base executor', async () => {
+        const executionTarget = await ExecutionTarget.new()
+        const action = { to: executionTarget.address, calldata: executionTarget.contract.execute.getData() }
+        const script = encodeCallScript([action])
+
+        assertRevert(() => callsScriptBase.execScript(script, '0x', []))
+    })
+
+    context('> Uninitialized executor', () => {
         beforeEach(async () => {
-            const receipt = await dao.newAppInstance(executorAppId, baseExecutor.address, { from: boss })
-            executor = Executor.at(receipt.logs.filter(l => l.event == 'NewAppProxy')[0].args.proxy)
+            const receipt = await dao.newAppInstance(executorAppId, executorBase.address, { from: boss })
+            executor = EVMScriptExecutor.at(receipt.logs.filter(l => l.event == 'NewAppProxy')[0].args.proxy)
+            // Explicitly don't initialize the executor
+            executionTarget = await ExecutionTarget.new()
+        })
+
+        it('fails to execute any executor', async () => {
+            const action = { to: executionTarget.address, calldata: executionTarget.contract.execute.getData() }
+            const script = encodeCallScript([action])
+
+            await assertRevert(() => executor.execute(script))
+        })
+    })
+
+    context('> Executor', () => {
+        beforeEach(async () => {
+            const receipt = await dao.newAppInstance(executorAppId, executorBase.address, { from: boss })
+            executor = EVMScriptExecutor.at(receipt.logs.filter(l => l.event == 'NewAppProxy')[0].args.proxy)
+            await executor.initialize()
             executionTarget = await ExecutionTarget.new()
         })
 
@@ -91,7 +114,7 @@ contract('EVM Script', accounts => {
             })
         })
 
-        context('spec ID 1', () => {
+        context('> Spec ID 1', () => {
             it('is the correct executor type', async () => {
                 const CALLS_SCRIPT_TYPE = soliditySha3('CALLS_SCRIPT')
                 const executor = IEVMScriptExecutor.at(await reg.getScriptExecutor('0x00000001'))
@@ -124,7 +147,7 @@ contract('EVM Script', accounts => {
                 })
             })
 
-            it('can execute if call doesnt cointain blacklist addresses', async () => {
+            it("can execute if call doesn't contain blacklist addresses", async () => {
                 const action = { to: executionTarget.address, calldata: executionTarget.contract.execute.getData() }
                 const script = encodeCallScript([action])
 
@@ -180,7 +203,7 @@ contract('EVM Script', accounts => {
                 await executor.execute(encodeCallScript([]))
             })
 
-            context('script overflow', async () => {
+            context('> Script overflow', async () => {
                 const encodeCallScriptBad = actions => {
                     return actions.reduce((script, { to, calldata }) => {
                         const addr = rawEncode(['address'], [to]).toString('hex')

--- a/test/helpers/assertThrow.js
+++ b/test/helpers/assertThrow.js
@@ -1,5 +1,5 @@
 function assertError(error, s, message) {
-    assert.isAbove(error.message.search(s), -1, message);
+    assert.isAbove(error.message.search(s), -1, `${message}\n\t(error: ${error})`);
 }
 
 async function assertThrows(codeBlock, message, errorCode) {

--- a/test/helpers/onlyIf.js
+++ b/test/helpers/onlyIf.js
@@ -1,0 +1,12 @@
+// Only runs given test block when the condition passes
+const onlyIf = condition => {
+    return testBlock => {
+        if (condition()) {
+            return testBlock()
+        }
+    }
+}
+
+module.exports = {
+  onlyIf
+}

--- a/test/kernel_acl.js
+++ b/test/kernel_acl.js
@@ -1,295 +1,311 @@
-const { assertRevert } = require('./helpers/assertThrow')
-const { getBlockNumber } = require('./helpers/web3')
-const { soliditySha3 } = require('web3-utils')
 const assertEvent = require('./helpers/assertEvent')
+const { assertRevert } = require('./helpers/assertThrow')
+const { hash } = require('eth-ens-namehash')
+const { soliditySha3 } = require('web3-utils')
 
-const DAOFactory = artifacts.require('DAOFactory')
 const ACL = artifacts.require('ACL')
 const Kernel = artifacts.require('Kernel')
 const KernelProxy = artifacts.require('KernelProxy')
 
+// Mocks
+const AppStub = artifacts.require('AppStub')
+const APP_ID = hash('stub.aragonpm.test')
+
 contract('Kernel ACL', accounts => {
-    let kernel, app, factory, acl = {}
+    let aclBase, appBase
+    let APP_MANAGER_ROLE, APP_BASES_NAMESPACE, ANY_ENTITY
 
     const permissionsRoot = accounts[0]
     const granted = accounts[1]
     const child = accounts[2]
+    const noPermissions = accounts[8]
 
-    let role = null
-
+    // Initial setup
     before(async () => {
-        const kernelBase = await Kernel.new()
-        const aclBase = await ACL.new()
-        factory = await DAOFactory.new(kernelBase.address, aclBase.address, '0x00')
+        aclBase = await ACL.new()
+        appBase = await AppStub.new()
+
+        // Setup constants
+        const kernel = await Kernel.new(true)
+        APP_BASES_NAMESPACE = await kernel.APP_BASES_NAMESPACE()
+        APP_MANAGER_ROLE = await kernel.APP_MANAGER_ROLE()
+        ANY_ENTITY = await aclBase.ANY_ENTITY()
     })
 
-    beforeEach(async () => {
-        const receipt = await factory.newDAO(permissionsRoot)
-        app = receipt.logs.filter(l => l.event == 'DeployDAO')[0].args.dao
+    // Test both the Kernel itself and the KernelProxy to make sure their behaviours are the same
+    for (const kernelType of ['Kernel', 'KernelProxy']) {
+        context(`> ${kernelType}`, () => {
+            let kernelBase, acl, kernel, kernelAddr
 
-        kernel = Kernel.at(app)
-
-        // events for kernel.createPermission permission
-        //assertEvent(receipt, 'SetPermission')
-        //assertEvent(receipt, 'ChangePermissionManager')
-
-        role = await kernel.APP_MANAGER_ROLE()
-        acl = ACL.at(await kernel.acl())
-    })
-
-    it('cannot initialize ACL outside of Kernel', async () => {
-        const acl = await ACL.new()
-        return assertRevert(async () => {
-            await acl.initialize('0x1234')
-        })
-    })
-
-    it('has correct initialization block', async () => {
-        assert.equal(await kernel.getInitializationBlock(), await getBlockNumber(), 'initialization block should be correct')
-    })
-
-    it('throws on reinitialization', async () => {
-        return assertRevert(async () => {
-            await kernel.initialize(accounts[0], accounts[0])
-        })
-    })
-
-
-    it('actions cannot be performed by default', async () => {
-        assert.isFalse(await acl.hasPermission(permissionsRoot, app, role))
-    })
-
-    it('actions cannot be performed if uninitialized', async () => {
-        const newKernelProxy = await KernelProxy.new(await factory.baseKernel())
-        const newKernel = Kernel.at(newKernelProxy.address)
-        return assertRevert(async () => {
-          const result = await newKernel.hasPermission(permissionsRoot, app, role, '0x00')
-        })
-    })
-
-    it('protected actions fail if not allowed', async () => {
-        return assertRevert(async () => {
-            await kernel.setApp('0x0', '0x1234', accounts[0])
-        })
-    })
-
-    it('create permission action can be performed by root by default', async () => {
-        const createPermissionRole = await acl.CREATE_PERMISSIONS_ROLE()
-        assert.isTrue(await acl.hasPermission(permissionsRoot, acl.address, createPermissionRole))
-    })
-
-    it('cannot create permissions without permission', async () => {
-        return assertRevert(async () => {
-            await acl.createPermission(granted, app, role, granted, { from: accounts[8] })
-        })
-    })
-
-    context('creating permission', () => {
-        beforeEach(async () => {
-            const receipt = await acl.createPermission(granted, app, role, granted, { from: permissionsRoot })
-            assertEvent(receipt, 'SetPermission')
-            assertEvent(receipt, 'SetPermissionParams', 0) // should not have emitted this
-            assertEvent(receipt, 'ChangePermissionManager')
-        })
-
-        it('can grant permission with params', async () => {
-            // app id != 0 (kernel)
-            // param hash 0x68b4adfe8175b29530f1c715f147337823f4ae55693be119bef69129637d681f
-            const argId = '0x00' // arg 0
-            const op = '02'      // not equal
-            const value = '000000000000000000000000000000000000000000000000000000000000'  // namespace 0
-            const param = new web3.BigNumber(`${argId}${op}${value}`)
-
-            const r1 = await acl.grantPermissionP(accounts[3], app, role, [param], { from: granted })
-
-            // retrieve the params back with the getters
-            const numParams = await acl.getPermissionParamsLength(accounts[3], app, role)
-            assert.equal(numParams, 1, 'There should be just 1 param')
-            const returnedParam = await acl.getPermissionParam(accounts[3], app, role, 0)
-            assert.equal(returnedParam[0].valueOf(), parseInt(argId, 16), 'param id should match')
-            assert.equal(returnedParam[1].valueOf(), parseInt(op, 10), 'param op should match')
-            assert.equal(returnedParam[2].valueOf(), parseInt(value, 10), 'param value should match')
-
-            // Assert that the right events have been emitted with the right args
-            assertEvent(r1, 'SetPermission')
-            assertEvent(r1, 'SetPermissionParams')
-            const setParamsHash = r1.logs.filter(l => l.event == 'SetPermissionParams')[0].args.paramsHash
-            assert.equal(setParamsHash, soliditySha3(param))
-
-            // grants again without re-saving params
-            const r2 = await acl.grantPermissionP(accounts[4], app, role, [param], { from: granted })
-
-            assert.isBelow(r2.receipt.gasUsed, r1.receipt.gasUsed, 'should have used less gas because of cache')
-            // Allow setting code for namespace other than 0
-            // acl is used here just to provide an address which is a contract
-            const receipt = await kernel.setApp('0x121212', '0x00', acl.address, { from: accounts[4] })
-
-            assertEvent(receipt, 'SetApp')
-            return assertRevert(async () => {
-                // Fail if setting code for appId 0
-                await kernel.setApp('0x0', '0x0', acl.address, { from: accounts[3] })
+            before(async () => {
+                if (kernelType === 'KernelProxy') {
+                    // We can reuse the same kernel base for the proxies
+                    kernelBase = await Kernel.new(true) // petrify immediately
+                }
             })
-        })
-
-        it('can grant a public permission', async () => {
-            const anyEntity = "0xffffffffffffffffffffffffffffffffffffffff"
-
-            const receipt = await acl.grantPermission(anyEntity, app, role, { from: granted })
-            assertEvent(receipt, 'SetPermission')
-            assertEvent(receipt, 'SetPermissionParams', 0) // should not have emitted this
-
-            // many entities can succesfully perform action
-            // acl is used here just to provide an address which is a contract
-            await kernel.setApp('0x121212', '0x00', acl.address, { from: accounts[4] })
-            await kernel.setApp('0x121212', '0x00', acl.address, { from: accounts[6] })
-            await kernel.setApp('0x121212', '0x00', acl.address, { from: accounts[8] })
-            assert.isTrue(await acl.hasPermission(accounts[6], app, role), 'should have perm')
-        })
-
-        it('returns created permission', async () => {
-            const allowed = await acl.hasPermission(granted, app, role)
-            const manager = await acl.getPermissionManager(app, role)
-
-            assert.isTrue(allowed, 'entity should be allowed to perform role actions')
-            assert.equal(manager, granted, 'permission parent should be correct')
-        })
-
-        it('can perform action', async () => {
-            assert.isTrue(await acl.hasPermission(granted, app, role))
-        })
-
-        it('can execute action', async () => {
-            // acl is used here just to provide an address which is a contract
-            const receipt = await kernel.setApp('0x1234', '0x1234', acl.address, { from: granted })
-            assertEvent(receipt, 'SetApp')
-        })
-
-        it('root cannot revoke permission', async () => {
-            return assertRevert(async () => {
-                await acl.revokePermission(granted, app, role, { from: permissionsRoot })
-            })
-        })
-
-        it('root cannot re-create permission', async () => {
-            return assertRevert(async () => {
-                await acl.createPermission(granted, app, role, granted, { from: permissionsRoot })
-            })
-        })
-
-        it('root cannot grant permission', async () => {
-            // Make sure grandchild doesn't have permission yet
-            assert.isFalse(await acl.hasPermission(child, app, role))
-            return assertRevert(async () => {
-                await acl.grantPermission(child, app, role, { from: permissionsRoot })
-            })
-        })
-
-        context('transferring managership', () => {
-            const newManager = accounts[8]
-            assert.notEqual(newManager, granted, 'newManager should not be the same as granted')
 
             beforeEach(async () => {
-                const receipt = await acl.setPermissionManager(newManager, app, role, { from: granted })
-                assertEvent(receipt, 'ChangePermissionManager')
+                if (kernelType === 'Kernel') {
+                    kernel = await Kernel.new(false) // don't petrify so it can be used
+                } else if (kernelType === 'KernelProxy') {
+                    kernel = Kernel.at((await KernelProxy.new(kernelBase.address)).address)
+                }
+
+                await kernel.initialize(aclBase.address, permissionsRoot);
+                acl = ACL.at(await kernel.acl())
+                kernelAddr = kernel.address
             })
 
-            it('changes manager', async () => {
-                const manager = await acl.getPermissionManager(app, role)
-                assert.equal(manager, newManager, 'manager should have changed')
-            })
-
-            it('can grant permission', async () => {
-                const receipt = await acl.grantPermission(newManager, app, role, { from: newManager })
-                assertEvent(receipt, 'SetPermission')
-            })
-
-            it('old manager lost power', async () => {
-                // Make sure new manager doesn't have permission yet
-                assert.isFalse(await acl.hasPermission(newManager, app, role))
+            it('cannot initialize ACL outside of Kernel', async () => {
+                const acl = await ACL.new()
                 return assertRevert(async () => {
-                    await acl.grantPermission(newManager, app, role, { from: granted })
-                })
-            })
-        })
-
-        context('removing managership', () => {
-            const newManager = accounts[4]
-            assert.notEqual(newManager, granted, 'newManager should not be the same as granted')
-
-            beforeEach(async () => {
-                const receipt = await acl.removePermissionManager(app, role, { from: granted })
-                assertEvent(receipt, 'ChangePermissionManager')
-            })
-
-            it('removes manager', async () => {
-                const noManager = await acl.getPermissionManager(app, role)
-                assert.equal('0x0000000000000000000000000000000000000000', noManager, 'manager should have been removed')
-            })
-
-            it('can recreate permission', async () => {
-                const createReceipt = await acl.createPermission(newManager, app, role, newManager, { from: permissionsRoot })
-                assertEvent(createReceipt, 'SetPermission')
-                assertEvent(createReceipt, 'ChangePermissionManager')
-
-                const grantReceipt = await acl.grantPermission(granted, app, role, { from: newManager })
-                assertEvent(grantReceipt, 'SetPermission')
-            })
-
-            it('old manager lost power', async () => {
-                // Make sure new manager doesn't have permission yet
-                assert.isFalse(await acl.hasPermission(newManager, app, role))
-                return assertRevert(async () => {
-                    await acl.grantPermission(newManager, app, role, { from: granted })
-                })
-            })
-        })
-
-        context('self-revokes permission', () => {
-            beforeEach(async () => {
-                const receipt = await acl.revokePermission(granted, app, role, { from: granted })
-                assertEvent(receipt, 'SetPermission')
-            })
-
-            it('can no longer perform action', async () => {
-                assert.isFalse(await acl.hasPermission(granted, app, role))
-            })
-
-            it('permissions root cannot re-create', async () => {
-                return assertRevert(async () => {
-                    await acl.createPermission(granted, app, role, granted, { from: permissionsRoot })
+                    await acl.initialize(permissionsRoot)
                 })
             })
 
-            it('permission manager can grant the permission', async () => {
-                await acl.grantPermission(granted, app, role, { from: granted })
-                assert.isTrue(await acl.hasPermission(granted, app, role))
-            })
-        })
-
-        context('re-grants to child', () => {
-            beforeEach(async () => {
-                const receipt = await acl.grantPermission(child, app, role, { from: granted })
-                assertEvent(receipt, 'SetPermission')
+            it('cannot perform actions by default', async () => {
+                assert.isFalse(await acl.hasPermission(permissionsRoot, noPermissions, APP_MANAGER_ROLE))
             })
 
-            it('child entity can perform action', async () => {
-                assert.isTrue(await acl.hasPermission(child, app, role))
-            })
-
-            it('child cannot re-grant permission', async () => {
-                const grandchild = accounts[7]
-                // Make sure grandchild doesn't have permission yet
-                assert.isFalse(await acl.hasPermission(grandchild, app, role))
+            it('cannot perform protected actions if not allowed', async () => {
                 return assertRevert(async () => {
-                    await acl.grantPermission(grandchild, app, role, { from: child })
+                    await kernel.setApp(APP_BASES_NAMESPACE, APP_ID, appBase.address, { from: noPermissions })
                 })
             })
 
-            it('parent can revoke permission', async () => {
-                const receipt = await acl.revokePermission(child, app, role, { from: granted })
-                assert.isFalse(await acl.hasPermission(child, app, role))
-                assertEvent(receipt, 'SetPermission')
+            it('create permission action can be performed by root by default', async () => {
+                const createPermissionRole = await acl.CREATE_PERMISSIONS_ROLE()
+                assert.isTrue(await acl.hasPermission(permissionsRoot, acl.address, createPermissionRole))
+            })
+
+            it('cannot create permissions without permission', async () => {
+                return assertRevert(async () => {
+                    await acl.createPermission(granted, noPermissions, APP_MANAGER_ROLE, granted, { from: noPermissions })
+                })
+            })
+
+            context('> creating permission', () => {
+                beforeEach(async () => {
+                    const receipt = await acl.createPermission(granted, kernelAddr, APP_MANAGER_ROLE, granted, { from: permissionsRoot })
+                    assertEvent(receipt, 'SetPermission')
+                    assertEvent(receipt, 'SetPermissionParams', 0) // should not have emitted this
+                    assertEvent(receipt, 'ChangePermissionManager')
+                })
+
+                it('has permission', async () => {
+                    assert.isTrue(await acl.hasPermission(granted, kernelAddr, APP_MANAGER_ROLE))
+                })
+
+                it('can execute action', async () => {
+                    const receipt = await kernel.setApp('0x1234', APP_ID, appBase.address, { from: granted })
+                    assertEvent(receipt, 'SetApp')
+                })
+
+                it('can grant permission with params', async () => {
+                    const secondChild = accounts[3]
+
+                    // Set role such that the first param cannot be equal to 0
+                    // For APP_MANAGER_ROLE, this is the namespace
+                    // param hash 0x68b4adfe8175b29530f1c715f147337823f4ae55693be119bef69129637d681f
+                    const argId = '0x00' // arg 0
+                    const op = '02'      // not equal
+                    const value = '000000000000000000000000000000000000000000000000000000000000'  // namespace 0
+                    const param = new web3.BigNumber(`${argId}${op}${value}`)
+
+                    const grantChildReceipt = await acl.grantPermissionP(child, kernelAddr, APP_MANAGER_ROLE, [param], { from: granted })
+
+                    // Retrieve the params back with the getters
+                    const numParams = await acl.getPermissionParamsLength(child, kernelAddr, APP_MANAGER_ROLE)
+                    assert.equal(numParams, 1, 'There should be just 1 param')
+                    const returnedParam = await acl.getPermissionParam(child, kernelAddr, APP_MANAGER_ROLE, 0)
+                    assert.equal(returnedParam[0].valueOf(), parseInt(argId, 16), 'param id should match')
+                    assert.equal(returnedParam[1].valueOf(), parseInt(op, 10), 'param op should match')
+                    assert.equal(returnedParam[2].valueOf(), parseInt(value, 10), 'param value should match')
+
+                    // Assert that the right events have been emitted with the right args
+                    assertEvent(grantChildReceipt, 'SetPermission')
+                    assertEvent(grantChildReceipt, 'SetPermissionParams')
+                    const setParamsHash = grantChildReceipt.logs.filter(l => l.event == 'SetPermissionParams')[0].args.paramsHash
+                    assert.equal(setParamsHash, soliditySha3(param))
+
+                    // Grants again without re-saving params (saves gas)
+                    const grantSecondChildReceipt = await acl.grantPermissionP(secondChild, kernelAddr, APP_MANAGER_ROLE, [param], { from: granted })
+                    assert.isBelow(
+                        grantSecondChildReceipt.receipt.gasUsed,
+                        grantChildReceipt.receipt.gasUsed,
+                        'should have used less gas because of cache'
+                    )
+
+                    // Allows setting code for namespace other than 0
+                    for (grantee of [child, secondChild]) {
+                        const receipt = await kernel.setApp('0x121212', '0x0', appBase.address, { from: grantee })
+                        assertEvent(receipt, 'SetApp')
+                    }
+
+                    // Fail if setting code for namespace 0
+                    for (grantee of [child, secondChild]) {
+                        await assertRevert(async () => {
+                            await kernel.setApp('0x0', APP_ID, appBase.address, { from: grantee })
+                        })
+                    }
+                })
+
+                it('can grant a public permission', async () => {
+                    const receipt = await acl.grantPermission(ANY_ENTITY, kernelAddr, APP_MANAGER_ROLE, { from: granted })
+                    assertEvent(receipt, 'SetPermission')
+                    assertEvent(receipt, 'SetPermissionParams', 0) // should not have emitted this
+
+                    // Any entity can succesfully perform action
+                    for (granteeIndex of [4, 5, 6]) {
+                        const grantee = accounts[granteeIndex]
+                        assert.isTrue(await acl.hasPermission(grantee, kernelAddr, APP_MANAGER_ROLE), `account[${granteeIndex}] should have perm`)
+                        const setReceipt = await kernel.setApp('0x121212', APP_ID, appBase.address, { from: grantee })
+                        assertEvent(setReceipt, 'SetApp')
+                    }
+                })
+
+                it('returns created permission', async () => {
+                    const allowed = await acl.hasPermission(granted, kernelAddr, APP_MANAGER_ROLE)
+                    const manager = await acl.getPermissionManager(kernelAddr, APP_MANAGER_ROLE)
+
+                    assert.isTrue(allowed, 'entity should be allowed to perform role actions')
+                    assert.equal(manager, granted, 'permission parent should be correct')
+                })
+
+                it('root cannot revoke permission', async () => {
+                    return assertRevert(async () => {
+                        await acl.revokePermission(granted, kernelAddr, APP_MANAGER_ROLE, { from: permissionsRoot })
+                    })
+                })
+
+                it('root cannot re-create permission', async () => {
+                    return assertRevert(async () => {
+                        await acl.createPermission(granted, kernelAddr, APP_MANAGER_ROLE, granted, { from: permissionsRoot })
+                    })
+                })
+
+                it('root cannot grant permission', async () => {
+                    // Make sure child doesn't have permission yet
+                    assert.isFalse(await acl.hasPermission(child, kernelAddr, APP_MANAGER_ROLE))
+                    return assertRevert(async () => {
+                        await acl.grantPermission(child, kernelAddr, APP_MANAGER_ROLE, { from: permissionsRoot })
+                    })
+                })
+
+                context('> transferring managership', () => {
+                    const newManager = accounts[3]
+                    assert.notEqual(newManager, granted, 'newManager should not be the same as granted')
+
+                    beforeEach(async () => {
+                        const receipt = await acl.setPermissionManager(newManager, kernelAddr, APP_MANAGER_ROLE, { from: granted })
+                        assertEvent(receipt, 'ChangePermissionManager')
+                    })
+
+                    it('changes manager', async () => {
+                        const manager = await acl.getPermissionManager(kernelAddr, APP_MANAGER_ROLE)
+                        assert.equal(manager, newManager, 'manager should have changed')
+                    })
+
+                    it('can grant permission', async () => {
+                        const receipt = await acl.grantPermission(newManager, kernelAddr, APP_MANAGER_ROLE, { from: newManager })
+                        assertEvent(receipt, 'SetPermission')
+                    })
+
+                    it("new manager doesn't have permission yet", async () => {
+                        // It's only the manager–it hasn't granted itself permissions yet
+                        assert.isFalse(await acl.hasPermission(newManager, kernelAddr, APP_MANAGER_ROLE))
+                    })
+
+                    it('old manager lost power', async () => {
+                        return assertRevert(async () => {
+                            await acl.grantPermission(newManager, kernelAddr, APP_MANAGER_ROLE, { from: granted })
+                        })
+                    })
+                })
+
+                context('> removing managership', () => {
+                    const newManager = accounts[3]
+                    assert.notEqual(newManager, granted, 'newManager should not be the same as granted')
+
+                    beforeEach(async () => {
+                        const receipt = await acl.removePermissionManager(kernelAddr, APP_MANAGER_ROLE, { from: granted })
+                        assertEvent(receipt, 'ChangePermissionManager')
+                    })
+
+                    it('removes manager', async () => {
+                        const noManager = await acl.getPermissionManager(kernelAddr, APP_MANAGER_ROLE)
+                        assert.equal('0x0000000000000000000000000000000000000000', noManager, 'manager should have been removed')
+                    })
+
+                    it('old manager lost power', async () => {
+                        return assertRevert(async () => {
+                            await acl.grantPermission(newManager, kernelAddr, APP_MANAGER_ROLE, { from: granted })
+                        })
+                    })
+
+                    it('can recreate permission', async () => {
+                        const createReceipt = await acl.createPermission(newManager, kernelAddr, APP_MANAGER_ROLE, newManager, { from: permissionsRoot })
+                        assertEvent(createReceipt, 'SetPermission')
+                        assertEvent(createReceipt, 'ChangePermissionManager')
+
+                        const grantReceipt = await acl.grantPermission(granted, kernelAddr, APP_MANAGER_ROLE, { from: newManager })
+                        assertEvent(grantReceipt, 'SetPermission')
+                    })
+                })
+
+                context('> self-revokes permission', () => {
+                    beforeEach(async () => {
+                        const receipt = await acl.revokePermission(granted, kernelAddr, APP_MANAGER_ROLE, { from: granted })
+                        assertEvent(receipt, 'SetPermission')
+                    })
+
+                    it('can no longer perform action', async () => {
+                        assert.isFalse(await acl.hasPermission(granted, kernelAddr, APP_MANAGER_ROLE))
+                        await assertRevert(async () => {
+                            await kernel.setApp(APP_BASES_NAMESPACE, APP_ID, appBase.address, { from: granted })
+                        })
+                    })
+
+                    it('permissions root cannot re-create', async () => {
+                        return assertRevert(async () => {
+                            await acl.createPermission(granted, kernelAddr, APP_MANAGER_ROLE, granted, { from: permissionsRoot })
+                        })
+                    })
+
+                    it('permission manager can grant the permission', async () => {
+                        await acl.grantPermission(granted, kernelAddr, APP_MANAGER_ROLE, { from: granted })
+                        assert.isTrue(await acl.hasPermission(granted, kernelAddr, APP_MANAGER_ROLE))
+                    })
+                })
+
+                context('> re-grants to child', () => {
+                    beforeEach(async () => {
+                        const receipt = await acl.grantPermission(child, kernelAddr, APP_MANAGER_ROLE, { from: granted })
+                        assertEvent(receipt, 'SetPermission')
+                    })
+
+                    it('child entity can perform action', async () => {
+                        assert.isTrue(await acl.hasPermission(child, kernelAddr, APP_MANAGER_ROLE))
+                        const receipt = await kernel.setApp(APP_BASES_NAMESPACE, APP_ID, appBase.address, { from: child })
+                        assertEvent(receipt, 'SetApp')
+                    })
+
+                    it('child cannot re-grant permission', async () => {
+                        const grandchild = accounts[3]
+                        // Make sure grandchild doesn't have permission yet
+                        assert.isFalse(await acl.hasPermission(grandchild, kernelAddr, APP_MANAGER_ROLE))
+                        return assertRevert(async () => {
+                            await acl.grantPermission(grandchild, kernelAddr, APP_MANAGER_ROLE, { from: child })
+                        })
+                    })
+
+                    it('parent can revoke permission', async () => {
+                        const receipt = await acl.revokePermission(child, kernelAddr, APP_MANAGER_ROLE, { from: granted })
+                        assertEvent(receipt, 'SetPermission')
+                        assert.isFalse(await acl.hasPermission(child, kernelAddr, APP_MANAGER_ROLE))
+                    })
+                })
             })
         })
-    })
+    }
 })

--- a/test/kernel_apps.js
+++ b/test/kernel_apps.js
@@ -1,386 +1,181 @@
 const { assertRevert } = require('./helpers/assertThrow')
+const { onlyIf } = require('./helpers/onlyIf')
 const { getBalance } = require('./helpers/web3')
 const { hash } = require('eth-ens-namehash')
 const { soliditySha3 } = require('web3-utils')
+
 const ACL = artifacts.require('ACL')
 const Kernel = artifacts.require('Kernel')
 const KernelProxy = artifacts.require('KernelProxy')
 const AppProxyUpgradeable = artifacts.require('AppProxyUpgradeable')
 const AppProxyPinned = artifacts.require('AppProxyPinned')
-const AppProxyFactory = artifacts.require('AppProxyFactory')
 
 // Mocks
 const AppStub = artifacts.require('AppStub')
 const AppStub2 = artifacts.require('AppStub2')
+const ERCProxyMock = artifacts.require('ERCProxyMock')
 const KernelMock = artifacts.require('KernelMock')
 
 const APP_ID = hash('stub.aragonpm.test')
 const ZERO_ADDR = '0x0000000000000000000000000000000000000000'
-
-// Test both the Kernel itself and the KernelProxy to make sure their behaviours are the same
-for (const kernelType of ['Kernel', 'KernelProxy']) {
-    contract(`${kernelType} apps`, accounts => {
-        let acl, aclBase, kernel, kernelBase, app, appProxy, appCode1, appCode2
-        let APP_BASES_NAMESPACE, APP_ADDR_NAMESPACE
-        let APP_SET_ID, APP_DEFAULT_ID
-        let UPGRADEABLE, FORWARDING
-
-        const permissionsRoot = accounts[0]
-
-        const withAppManagerPermission = async (contractAddr, fn) => {
-            const r = await kernel.APP_MANAGER_ROLE()
-            await acl.grantPermission(contractAddr, kernel.address, r)
-            const ret = await fn()
-            await acl.revokePermission(contractAddr, kernel.address, r)
-
-            return ret
-        }
-
-        before(async () => {
-            // We can reuse the same kernel base for the proxies
-            kernelBase = await Kernel.new()
-
-            aclBase = await ACL.new()
-            appCode1 = await AppStub.new()
-            appCode2 = await AppStub2.new()
-
-            APP_BASES_NAMESPACE = await kernelBase.APP_BASES_NAMESPACE()
-            APP_ADDR_NAMESPACE = await kernelBase.APP_ADDR_NAMESPACE()
-
-            APP_SET_ID = soliditySha3(APP_BASES_NAMESPACE, APP_ID)
-            APP_DEFAULT_ID = soliditySha3(APP_ADDR_NAMESPACE, APP_ID)
-        })
-
-        beforeEach(async () => {
-            if (kernelType === 'Kernel') {
-                kernel = await Kernel.new()
-            } else if (kernelType === 'KernelProxy') {
-                kernel = Kernel.at((await KernelProxy.new(kernelBase.address)).address)
-            }
-
-            await kernel.initialize(aclBase.address, permissionsRoot);
-            acl = ACL.at(await kernel.acl())
-            const r = await kernel.APP_MANAGER_ROLE()
-            await acl.createPermission(permissionsRoot, kernel.address, r, permissionsRoot)
-        })
-
-        /********
-        * TESTS *
-        *********/
-        it('fails if initializing on constructor before setting app code', async () => {
-            const initializationPayload = appCode1.contract.initialize.getData()
-
-            return assertRevert(async () => {
-                await AppProxyUpgradeable.new(kernel.address, APP_ID, initializationPayload)
-            })
-        })
-
-        context('upgradeable proxies', () => {
-            it('fails if code hasnt been set and initializes', async () => {
-                return assertRevert(async () => {
-                    await AppProxyUpgradeable.new(kernel.address, APP_ID, appCode1.contract.initialize.getData(), { gas: 6e6 })
-                })
-            })
-
-            it('doesnt fail if code hasnt been set and doesnt initialize', async () => {
-                await AppProxyUpgradeable.new(kernel.address, APP_ID, '0x', { gas: 6e6 })
-            })
-
-            context('initializing on proxy constructor', () => {
-                beforeEach(async () => {
-                    await kernel.setApp(APP_BASES_NAMESPACE, APP_ID, appCode1.address)
-
-                    const initializationPayload = appCode1.contract.initialize.getData()
-                    appProxy = await AppProxyUpgradeable.new(kernel.address, APP_ID, initializationPayload, { gas: 6e6 })
-                    app = AppStub.at(appProxy.address)
-                    UPGRADEABLE = (await appProxy.UPGRADEABLE()).toString()
-                })
-
-                it('checks ERC897 functions', async () => {
-                    const implementation = await appProxy.implementation()
-                    assert.equal(implementation, appCode1.address, "App address should match")
-                    const proxyType = (await appProxy.proxyType.call()).toString()
-                    assert.equal(proxyType, UPGRADEABLE, "Proxy type should be upgradeable")
-                })
-
-                it('fails if kernel addr is not a kernel', async () => {
-                    return assertRevert(async () => {
-                        await AppProxyUpgradeable.new('0x1234', APP_ID, '0x', { gas: 6e6 })
-                    })
-                })
-
-                it('fails if kernel addr is 0', async () => {
-                    return assertRevert(async () => {
-                        await AppProxyUpgradeable.new('0x0', APP_ID, '0x', { gas: 6e6 })
-                    })
-                })
-
-                it('fails if init fails', async () => {
-                    const badInit = '0x1234'
-                    return assertRevert(async () => {
-                        await AppProxyUpgradeable.new(kernel.address, APP_ID, badInit, { gas: 6e6 })
-                    })
-                })
-
-                it('was initialized on constructor', async () => {
-                    assert.isAbove(await app.getInitializationBlock(), 0, 'app should have been initialized')
-                })
-
-                it('is upgradeable', async () => {
-                    assert.equal((await appProxy.proxyType.call()).toString(), UPGRADEABLE, 'appproxy should be upgradeable')
-                })
-
-                it('cannot reinitialize', async () => {
-                    return assertRevert(async () => {
-                        await app.initialize()
-                    })
-                })
-
-                it('should return values', async () => {
-                    assert.equal(await app.stringTest(), 'hola', 'string test')
-                })
-            })
-
-            context('not initializing on proxy constructor', () => {
-                let r2 = {}
-                beforeEach(async () => {
-                    const initializationPayload = '0x' // dont initialize
-                    appProxy = await AppProxyUpgradeable.new(kernel.address, APP_ID, initializationPayload)
-                    app = AppStub.at(appProxy.address)
-
-                    // assign app permissions
-                    r2 = await appCode1.ROLE()
-                    await acl.createPermission(permissionsRoot, appProxy.address, r2, permissionsRoot)
-                })
-
-                it('throws if using app without reference in kernel', async () => {
-                    return assertRevert(async () => {
-                        await app.setValue(10)
-                    })
-                })
-
-                context('setting app code in kernel', async () => {
-                    beforeEach(async () => {
-                        await kernel.setApp(APP_BASES_NAMESPACE, APP_ID, appCode1.address)
-                    })
-
-                    it('fails calling function with isInitialized (if it\'s not)', async () => {
-                        return assertRevert(async () => {
-                            await app.requiresInitialization()
-                        })
-                    })
-
-                    it('can initialize', async () => {
-                        await app.initialize()
-
-                        assert.isAbove(await app.getInitializationBlock(), 0, 'app should have been initialized')
-                    })
-
-                    it('allows calls with isInitialized modifier', async () => {
-                        await app.initialize()
-                        const result = await app.requiresInitialization()
-                        assert.equal(result, true, "Should return true")
-                    })
-
-                    it('app call works if sent from authed entity', async () => {
-                        await app.setValue(10)
-                        assert.equal(await app.getValue(), 10, 'should have returned correct value')
-                    })
-
-                    it('parametrized app call works if no params', async () => {
-                        await app.setValueParam(11)
-                        assert.equal(await app.getValue(), 11, 'should have returned correct value')
-                    })
-
-                    context('parametrized calls', () => {
-                        beforeEach(async () => {
-                            const argId = '0x00' // arg 0
-                            const op = '03'      // greater than
-                            const value = '000000000000000000000000000000000000000000000000000000000005'  // 5
-                            const param = new web3.BigNumber(`${argId}${op}${value}`)
-
-                            await acl.grantPermissionP(accounts[2], appProxy.address, r2, [param], { from: permissionsRoot })
-                        })
-
-                        it('parametrized app call fails if param eval fails', async () => {
-                            return assertRevert(async () => {
-                                await app.setValueParam(4, { from: accounts[2]})
-                            })
-                        })
-
-                        it('parametrized app call succeeds if param eval succeeds', async () => {
-                            await app.setValueParam(6, { from: accounts[2]})
-                        })
-                    })
-
-                    it('fails when called by unauthorized entity', async () => {
-                        return assertRevert(async () => {
-                            await app.setValue(10, { from: accounts[1] })
-                        })
-                    })
-
-                    it('fails if updated app is not a contract', async () => {
-                        return assertRevert(async () => {
-                            await kernel.setApp(APP_BASES_NAMESPACE, APP_ID, '0x1234')
-                        })
-                    })
-
-                    it('can update app code and storage is preserved', async () => {
-                        await app.setValue(10)
-                        await kernel.setApp(APP_BASES_NAMESPACE, APP_ID, appCode2.address)
-                        // app2 returns the double of the value in storage
-                        assert.equal(await app.getValue(), 20, 'app 2 should have returned correct value')
-                    })
-
-                    it('can update app code and removed functions throw', async () => {
-                        await app.setValue(10)
-                        await kernel.setApp(APP_BASES_NAMESPACE, APP_ID, appCode2.address)
-                        return assertRevert(async () => {
-                            await app.setValue(10)
-                        })
-                    })
-                })
-            })
-        })
-
-        context('pinned proxies', () => {
-            beforeEach(async () => {
-                await kernel.setApp(APP_BASES_NAMESPACE, APP_ID, appCode1.address)
-
-                const initializationPayload = appCode1.contract.initialize.getData()
-                appProxy = await AppProxyPinned.new(kernel.address, APP_ID, initializationPayload, { gas: 6e6 })
-                app = AppStub.at(appProxy.address)
-                FORWARDING = (await appProxy.FORWARDING()).toString()
-
-                // assign app permissions
-                const r2 = await appCode1.ROLE()
-                await acl.createPermission(permissionsRoot, appProxy.address, r2, permissionsRoot)
-            })
-
-            it('checks ERC897 functions', async () => {
-                const implementation = await appProxy.implementation()
-                assert.equal(implementation, appCode1.address, "App address should match")
-                const proxyType = (await appProxy.proxyType.call()).toString()
-                assert.equal(proxyType, FORWARDING, "Proxy type should be forwarding")
-            })
-
-            it('fails if app set is not a contract', async () => {
-                return assertRevert(async () => {
-                    await kernel.setApp(APP_BASES_NAMESPACE, APP_ID, '0x0')
-                })
-            })
-
-            it('is not upgradeable', async () => {
-                assert.equal((await appProxy.proxyType.call()).toString(), FORWARDING, 'appproxy should not be upgradeable')
-            })
-
-            it('can update app code and pinned proxy continues using former version', async () => {
-                await app.setValue(10)
-                await app.setValue(11)
-                await kernel.setApp(APP_BASES_NAMESPACE, APP_ID, appCode2.address)
-
-                // app2 would return the double of the value in storage
-                assert.equal(await app.getValue(), 11, 'app 2 should have returned correct value')
-            })
-        })
-
-        const newAppProxyMapping = {
-            'AppProxy': 'newAppInstance',
-            'AppProxyPinned': 'newPinnedAppInstance',
-        }
-        for (const appProxyType of Object.keys(newAppProxyMapping)) {
-            const newInstanceFn = newAppProxyMapping[appProxyType]
-
-            const onlyAppProxy = test => {
-                if (appProxyType === 'AppProxy') {
-                    return test()
-                }
-            }
-
-            const onlyAppProxyPinned = test => {
-                if (appProxyType === 'AppProxyPinned') {
-                    return test()
-                }
-            }
-
-            context(`new ${appProxyType} instances`, () => {
-                onlyAppProxy(() =>
-                    it('creates a new upgradeable app proxy instance', async () => {
-                        const receipt = await kernel.newAppInstance(APP_ID, appCode1.address)
-                        const appProxy = AppProxyUpgradeable.at(receipt.logs.filter(l => l.event == 'NewAppProxy')[0].args.proxy)
-                        UPGRADEABLE = (await appProxy.UPGRADEABLE()).toString()
-                        assert.equal((await appProxy.proxyType.call()).toString(), UPGRADEABLE, 'new appProxy instance should be upgradeable')
-                        assert.equal(await appProxy.kernel(), kernel.address, "new appProxy instance's kernel should be set to the originating kernel")
-                        assert.equal(await appProxy.implementation(), appCode1.address, 'new appProxy instance should be resolving to implementation address')
-                    })
-                )
-
-                onlyAppProxyPinned(() =>
-                    it('creates a new non upgradeable app proxy instance', async () => {
-                        const receipt = await kernel.newPinnedAppInstance(APP_ID, appCode1.address)
-                        const appProxy = AppProxyPinned.at(receipt.logs.filter(l => l.event == 'NewAppProxy')[0].args.proxy)
-                        FORWARDING = (await appProxy.FORWARDING()).toString()
-                        assert.equal((await appProxy.proxyType.call()).toString(), FORWARDING, 'new appProxy instance should be not upgradeable')
-                        assert.equal(await appProxy.kernel(), kernel.address, "new appProxy instance's kernel should be set to the originating kernel")
-                        assert.equal(await appProxy.implementation(), appCode1.address, 'new appProxy instance should be resolving to implementation address')
-                    })
-                )
-
-                it('sets the app base when not previously registered', async() => {
-                    assert.equal(ZERO_ADDR, await kernel.getApp(APP_SET_ID))
-
-                    await kernel[newInstanceFn](APP_ID, appCode1.address)
-                    assert.equal(appCode1.address, await kernel.getApp(APP_SET_ID))
-                })
-
-                it("doesn't set the app base when already set", async() => {
-                    await kernel.setApp(APP_BASES_NAMESPACE, APP_ID, appCode1.address)
-                    const receipt = await kernel[newInstanceFn](APP_ID, appCode1.address)
-                    assert.isFalse(receipt.logs.includes(l => l.event == 'SetApp'))
-                })
-
-                it("also sets the default app when using the overloaded version", async () => {
-                    let appProxyAddr
-
-                    // Create KernelMock instance so we can use the overloaded version
-                    const kernelMock = await KernelMock.new(kernel.address)
-
-                    await withAppManagerPermission(kernelMock.address, async () => {
-                        const receipt = await kernelMock[newInstanceFn](APP_ID, appCode1.address, true)
-                        appProxyAddr = receipt.logs.filter(l => l.event == 'NewAppProxy')[0].args.proxy
-                    })
-
-                    // Check that both the app base and default app are set
-                    assert.equal(await kernel.getApp(APP_SET_ID), appCode1.address)
-                    assert.equal(await kernel.getApp(APP_DEFAULT_ID), appProxyAddr)
-                })
-
-                it("fails if the app base is not given", async() => {
-                    await kernel.setApp(APP_BASES_NAMESPACE, APP_ID, appCode1.address)
-                    assert.equal(appCode1.address, await kernel.getApp(APP_SET_ID))
-
-                    return assertRevert(async () => {
-                        await kernel[newInstanceFn](APP_ID, '0x0')
-                    })
-                })
-
-                it('fails if the given app base is different than the existing one', async() => {
-                    await kernel.setApp(APP_BASES_NAMESPACE, APP_ID, appCode1.address)
-                    return assertRevert(async () => {
-                        await kernel[newInstanceFn](APP_ID, appCode2.address)
-                    })
-                })
-
-                onlyAppProxyPinned(() =>
-                    it('fails if app id does not have code set to it yet', async () => {
-                        const fakeAppId = hash('fake.aragonpm.test')
-                        const appFact = await AppProxyFactory.new()
-                        return assertRevert(async () => {
-                            await appFact.newAppProxyPinned(kernel.address, fakeAppId, '')
-                        })
-                    })
-                )
-            })
-        }
+const EMPTY_BYTES = '0x'
+
+contract('Kernel apps', accounts => {
+    let aclBase, appBase1, appBase2
+    let APP_BASES_NAMESPACE, APP_ADDR_NAMESPACE
+    let APP_SET_ID, APP_DEFAULT_ID
+    let UPGRADEABLE, FORWARDING
+
+    const permissionsRoot = accounts[0]
+
+    // Initial setup
+    before(async () => {
+        aclBase = await ACL.new()
+        appBase1 = await AppStub.new()
+        appBase2 = await AppStub2.new()
+
+        // Setup constants
+        const kernel = await Kernel.new(true)
+        APP_BASES_NAMESPACE = await kernel.APP_BASES_NAMESPACE()
+        APP_ADDR_NAMESPACE = await kernel.APP_ADDR_NAMESPACE()
+        APP_MANAGER_ROLE = await kernel.APP_MANAGER_ROLE()
+        APP_SET_ID = soliditySha3(APP_BASES_NAMESPACE, APP_ID)
+        APP_DEFAULT_ID = soliditySha3(APP_ADDR_NAMESPACE, APP_ID)
+
+        const ercProxyMock = await ERCProxyMock.new()
+        UPGRADEABLE = (await ercProxyMock.UPGRADEABLE()).toString()
+        FORWARDING = (await ercProxyMock.FORWARDING()).toString()
     })
-}
+
+    // Test both the Kernel itself and the KernelProxy to make sure their behaviours are the same
+    for (const kernelType of ['Kernel', 'KernelProxy']) {
+        context(`> ${kernelType}`, () => {
+            let acl, kernel, kernelBase, app, appProxy
+
+            const withAppManagerPermission = async (contractAddr, fn) => {
+                await acl.grantPermission(contractAddr, kernel.address, APP_MANAGER_ROLE)
+                const ret = await fn()
+                await acl.revokePermission(contractAddr, kernel.address, APP_MANAGER_ROLE)
+
+                return ret
+            }
+
+            before(async () => {
+                if (kernelType === 'KernelProxy') {
+                    // We can reuse the same kernel base for the proxies
+                    kernelBase = await Kernel.new(true) // petrify immediately
+                }
+            })
+
+            beforeEach(async () => {
+                if (kernelType === 'Kernel') {
+                    kernel = await Kernel.new(false)  // don't petrify so it can be used
+                } else if (kernelType === 'KernelProxy') {
+                    kernel = Kernel.at((await KernelProxy.new(kernelBase.address)).address)
+                }
+
+                await kernel.initialize(aclBase.address, permissionsRoot);
+                acl = ACL.at(await kernel.acl())
+                await acl.createPermission(permissionsRoot, kernel.address, APP_MANAGER_ROLE, permissionsRoot)
+            })
+
+            /********
+            * TESTS *
+            *********/
+            it('fails if setting app to 0 address', async () => {
+                return assertRevert(async () => {
+                    await kernel.setApp(APP_BASES_NAMESPACE, APP_ID, ZERO_ADDR)
+                })
+            })
+
+            it('fails if setting app to non-contract address', async () => {
+                return assertRevert(async () => {
+                    await kernel.setApp(APP_BASES_NAMESPACE, APP_ID, '0x1234')
+                })
+            })
+
+            const newAppProxyMapping = {
+                'AppProxy': 'newAppInstance',
+                'AppProxyPinned': 'newPinnedAppInstance',
+            }
+            for (const appProxyType of Object.keys(newAppProxyMapping)) {
+                const newInstanceFn = newAppProxyMapping[appProxyType]
+
+                const onlyAppProxy = onlyIf(() => appProxyType === 'AppProxy')
+                const onlyAppProxyPinned = onlyIf(() => appProxyType === 'AppProxyPinned')
+
+                context(`> new ${appProxyType} instances`, () => {
+                    onlyAppProxy(() =>
+                        it('creates a new upgradeable app proxy instance', async () => {
+                            const receipt = await kernel.newAppInstance(APP_ID, appBase1.address)
+                            const appProxy = AppProxyUpgradeable.at(receipt.logs.filter(l => l.event == 'NewAppProxy')[0].args.proxy)
+                            assert.equal(await appProxy.kernel(), kernel.address, "new appProxy instance's kernel should be set to the originating kernel")
+
+                            // Checks ERC897 functionality
+                            assert.equal((await appProxy.proxyType.call()).toString(), UPGRADEABLE, 'new appProxy instance should be upgradeable')
+                            assert.equal(await appProxy.implementation(), appBase1.address, 'new appProxy instance should be resolving to implementation address')
+                        })
+                    )
+
+                    onlyAppProxyPinned(() =>
+                        it('creates a new non upgradeable app proxy instance', async () => {
+                            const receipt = await kernel.newPinnedAppInstance(APP_ID, appBase1.address)
+                            const appProxy = AppProxyPinned.at(receipt.logs.filter(l => l.event == 'NewAppProxy')[0].args.proxy)
+                            assert.equal(await appProxy.kernel(), kernel.address, "new appProxy instance's kernel should be set to the originating kernel")
+
+                            // Checks ERC897 functionality
+                            assert.equal((await appProxy.proxyType.call()).toString(), FORWARDING, 'new appProxy instance should be not upgradeable')
+                            assert.equal(await appProxy.implementation(), appBase1.address, 'new appProxy instance should be resolving to implementation address')
+                        })
+                    )
+
+                    it('sets the app base when not previously registered', async() => {
+                        assert.equal(ZERO_ADDR, await kernel.getApp(APP_SET_ID))
+
+                        await kernel[newInstanceFn](APP_ID, appBase1.address)
+                        assert.equal(appBase1.address, await kernel.getApp(APP_SET_ID))
+                    })
+
+                    it("doesn't set the app base when already set", async() => {
+                        await kernel.setApp(APP_BASES_NAMESPACE, APP_ID, appBase1.address)
+                        const receipt = await kernel[newInstanceFn](APP_ID, appBase1.address)
+                        assert.isFalse(receipt.logs.includes(l => l.event == 'SetApp'))
+                    })
+
+                    it("also sets the default app when using the overloaded version", async () => {
+                        let appProxyAddr
+
+                        // Create KernelMock instance so we can use the overloaded version
+                        const kernelMock = await KernelMock.new(kernel.address)
+
+                        await withAppManagerPermission(kernelMock.address, async () => {
+                            const receipt = await kernelMock[newInstanceFn](APP_ID, appBase1.address, true)
+                            appProxyAddr = receipt.logs.filter(l => l.event == 'NewAppProxy')[0].args.proxy
+                        })
+
+                        // Check that both the app base and default app are set
+                        assert.equal(await kernel.getApp(APP_SET_ID), appBase1.address)
+                        assert.equal(await kernel.getApp(APP_DEFAULT_ID), appProxyAddr)
+                    })
+
+                    it("fails if the app base is not given", async() => {
+                        return assertRevert(async () => {
+                            await kernel[newInstanceFn](APP_ID, ZERO_ADDR)
+                        })
+                    })
+
+                    it('fails if the given app base is different than the existing one', async() => {
+                        const existingBase = appBase1.address
+                        const differentBase = appBase2.address
+                        assert.notEqual(existingBase, differentBase, 'appBase1 and appBase2 should have different addresses')
+
+                        await kernel.setApp(APP_BASES_NAMESPACE, APP_ID, existingBase)
+                        return assertRevert(async () => {
+                            await kernel[newInstanceFn](APP_ID, differentBase)
+                        })
+                    })
+                })
+            }
+        })
+    }
+})

--- a/test/kernel_lifecycle.js
+++ b/test/kernel_lifecycle.js
@@ -1,0 +1,179 @@
+const assertEvent = require('./helpers/assertEvent')
+const { assertRevert } = require('./helpers/assertThrow')
+const { getBlockNumber } = require('./helpers/web3')
+const { hash } = require('eth-ens-namehash')
+
+const ACL = artifacts.require('ACL')
+const Kernel = artifacts.require('Kernel')
+const KernelProxy = artifacts.require('KernelProxy')
+
+// Mocks
+const AppStub = artifacts.require('AppStub')
+const APP_ID = hash('stub.aragonpm.test')
+const VAULT_ID = hash('vault.aragonpm.test')
+
+contract('Kernel lifecycle', accounts => {
+  let aclBase, appBase
+  let ACL_APP_ID, APP_BASES_NAMESPACE, APP_ADDR_NAMESPACE, APP_MANAGER_ROLE
+
+  const testUnaccessibleFunctionalityWhenUninitialized = async (kernel) => {
+    // hasPermission should always return false when unintialized
+    assert.isFalse(await kernel.hasPermission(accounts[0], kernel.address, APP_MANAGER_ROLE, '0x'))
+    assert.isFalse(await kernel.hasPermission(accounts[1], kernel.address, APP_MANAGER_ROLE, '0x'))
+
+    await assertRevert(() => kernel.newAppInstance(APP_ID, appBase.address))
+    await assertRevert(() => kernel.newPinnedAppInstance(APP_ID, appBase.address))
+    await assertRevert(() => kernel.setApp(APP_BASES_NAMESPACE, APP_ID, appBase.address))
+    await assertRevert(() => kernel.setRecoveryVaultId(VAULT_ID))
+  }
+
+  const testUsability = async (kernel) => {
+    // Make sure we haven't already setup the required permission
+    assert.isFalse(await kernel.hasPermission(accounts[0], kernel.address, APP_MANAGER_ROLE, '0x'))
+    assert.isFalse(await kernel.hasPermission(accounts[1], kernel.address, APP_MANAGER_ROLE, '0x'))
+
+    // Then set the required permission
+    const acl = ACL.at(await kernel.acl())
+    await acl.createPermission(accounts[0], kernel.address, APP_MANAGER_ROLE, accounts[0])
+    assert.isTrue(await kernel.hasPermission(accounts[0], kernel.address, APP_MANAGER_ROLE, '0x'))
+    assert.isFalse(await kernel.hasPermission(accounts[1], kernel.address, APP_MANAGER_ROLE, '0x'))
+
+    // And finally test functionality
+    await kernel.newAppInstance(APP_ID, appBase.address)
+  }
+
+  // Initial setup
+  before(async () => {
+    aclBase = await ACL.new()
+    appBase = await AppStub.new()
+
+    // Setup constants
+    const kernel = await Kernel.new(true)
+    ACL_APP_ID = await kernel.ACL_APP_ID()
+    APP_BASES_NAMESPACE = await kernel.APP_BASES_NAMESPACE()
+    APP_ADDR_NAMESPACE = await kernel.APP_ADDR_NAMESPACE()
+    APP_MANAGER_ROLE = await kernel.APP_MANAGER_ROLE()
+  })
+
+  context('> Kernel base', () => {
+    context('> Petrified', () => {
+      let kernelBase
+
+      beforeEach(async () => {
+        kernelBase = await Kernel.new(true) // petrify immediately
+      })
+
+      it('is not initialized', async () => {
+        assert.isFalse(await kernelBase.hasInitialized(), 'should not be initialized')
+      })
+
+      it('is petrified', async () => {
+        assert.isTrue(await kernelBase.isPetrified(), 'should be petrified')
+      })
+
+      it('throws on initialization', async () => {
+        await assertRevert(async () => {
+          await kernelBase.initialize(accounts[0], accounts[0])
+        })
+      })
+
+      it('should not be usable', async () => {
+        await testUnaccessibleFunctionalityWhenUninitialized(kernelBase)
+      })
+    })
+
+    context('> Directly used', () => {
+      let kernel
+
+      beforeEach(async () => {
+        kernel = await Kernel.new(false) // allow base to be used directly
+      })
+
+      it('is not initialized by default', async () => {
+        assert.isFalse(await kernel.hasInitialized(), 'should not be initialized')
+      })
+
+      it('is not petrified by default', async () => {
+        assert.isFalse(await kernel.isPetrified(), 'should not be petrified')
+      })
+
+      it('is initializable and usable', async () => {
+        await kernel.initialize(aclBase.address, accounts[0])
+        assert.isTrue(await kernel.hasInitialized(), 'should be initialized')
+        assert.isFalse(await kernel.isPetrified(), 'should not be petrified')
+
+        await testUsability(kernel)
+      })
+    })
+  })
+
+  context('> KernelProxy', () => {
+    let kernelBase, kernel
+
+    before(async () => {
+      kernelBase = await Kernel.new(true) // petrify immediately
+    })
+
+    beforeEach(async () => {
+      const kernelProxy = await KernelProxy.new(kernelBase.address)
+      kernel = Kernel.at(kernelProxy.address)
+    })
+
+    it('is not initialized by default', async () => {
+      assert.isFalse(await kernel.hasInitialized(), 'should not be initialized')
+    })
+
+    it('is not petrified by default', async () => {
+      assert.isFalse(await kernel.isPetrified(), 'should not be petrified')
+    })
+
+    it('should not be usable yet', async () => {
+      await testUnaccessibleFunctionalityWhenUninitialized(kernel)
+    })
+
+    context('> Initialized', () => {
+      let initReceipt
+
+      beforeEach(async () => {
+        initReceipt = await kernel.initialize(aclBase.address, accounts[0])
+        acl = ACL.at(await kernel.acl())
+      })
+
+      it('set the ACL correctly', async () => {
+        assertEvent(initReceipt, 'SetApp', 2)
+        const setAppLogs = initReceipt.logs.filter(l => l.event == 'SetApp')
+        const ACLBaseLog = setAppLogs[0]
+        const ACLAppLog = setAppLogs[1]
+
+        assert.equal(ACLBaseLog.args.namespace, APP_BASES_NAMESPACE, 'should set base acl first')
+        assert.equal(ACLBaseLog.args.name, ACL_APP_ID, 'should set base acl first')
+        assert.equal(ACLBaseLog.args.app, aclBase.address, 'should set base acl first')
+        assert.equal(ACLAppLog.args.namespace, APP_ADDR_NAMESPACE, 'should set default acl second')
+        assert.equal(ACLAppLog.args.name, ACL_APP_ID, 'should set default acl second')
+        assert.equal(ACLAppLog.args.app, acl.address, 'should set default acl second')
+      })
+
+      it('is now initialized', async () => {
+        assert.isTrue(await kernel.hasInitialized(), 'should be initialized')
+      })
+
+      it('is still not petrified', async () => {
+        assert.isFalse(await kernel.isPetrified(), 'should not be petrified')
+      })
+
+      it('has correct initialization block', async () => {
+        assert.equal(await kernel.getInitializationBlock(), await getBlockNumber(), 'initialization block should be correct')
+      })
+
+      it('throws on reinitialization', async () => {
+        return assertRevert(async () => {
+          await kernel.initialize(accounts[0], accounts[0])
+        })
+      })
+
+      it('should now be usable', async () => {
+        await testUsability(kernel)
+      })
+    })
+  })
+})

--- a/test/kernel_lifecycle.js
+++ b/test/kernel_lifecycle.js
@@ -17,7 +17,7 @@ contract('Kernel lifecycle', accounts => {
   let ACL_APP_ID, APP_BASES_NAMESPACE, APP_ADDR_NAMESPACE, APP_MANAGER_ROLE
 
   const testUnaccessibleFunctionalityWhenUninitialized = async (kernel) => {
-    // hasPermission should always return false when unintialized
+    // hasPermission should always return false when uninitialized
     assert.isFalse(await kernel.hasPermission(accounts[0], kernel.address, APP_MANAGER_ROLE, '0x'))
     assert.isFalse(await kernel.hasPermission(accounts[1], kernel.address, APP_MANAGER_ROLE, '0x'))
 

--- a/test/lifecycle.js
+++ b/test/lifecycle.js
@@ -1,0 +1,59 @@
+const { assertRevert } = require('./helpers/assertThrow')
+const { getBlockNumber } = require('./helpers/web3')
+
+// Mocks
+const LifecycleMock = artifacts.require('LifecycleMock')
+
+contract('Lifecycle', accounts => {
+  let lifecycle
+
+  beforeEach(async () => {
+    lifecycle = await LifecycleMock.new()
+  })
+
+  it('is not initialized', async () => {
+    assert.isFalse(await lifecycle.hasInitialized(), 'should not be initialized')
+  })
+
+  it('is not petrified', async () => {
+    assert.isFalse(await lifecycle.isPetrified(), 'should not be petrified')
+  })
+
+  context('> Initialized', () => {
+    beforeEach(async () => {
+      await lifecycle.initializeMock()
+    })
+
+    it('is initialized', async () => {
+      assert.isTrue(await lifecycle.hasInitialized(), 'should be initialized')
+    })
+
+    it('is not petrified', async () => {
+      assert.isFalse(await lifecycle.isPetrified(), 'should not be petrified')
+    })
+
+    it('has correct initialization block', async () => {
+      assert.equal(await lifecycle.getInitializationBlock(), await getBlockNumber(), 'initialization block should be correct')
+    })
+  })
+
+  context('> Petrified', () => {
+    beforeEach(async () => {
+      await lifecycle.petrifyMock()
+    })
+
+    it('is not initialized', async () => {
+      assert.isFalse(await lifecycle.hasInitialized(), 'should not be initialized')
+    })
+
+    it('is petrified', async () => {
+      assert.isTrue(await lifecycle.isPetrified(), 'should be petrified')
+    })
+
+    it('has initialization block in the future', async () => {
+      const petrifiedBlock = await lifecycle.getInitializationBlock()
+      const blockNumber = await getBlockNumber()
+      assert.isTrue(petrifiedBlock.greaterThan(blockNumber), 'petrified block should be in the future')
+    })
+  })
+})

--- a/test/mocks/APMRegistryFactoryMock.sol
+++ b/test/mocks/APMRegistryFactoryMock.sol
@@ -1,6 +1,6 @@
 pragma solidity 0.4.18;
 
-// without all permissions
+// Mock that doesn't grant enough permissions
 // external ENS
 
 import "../../contracts/factory/APMRegistryFactory.sol";

--- a/test/mocks/AppStub.sol
+++ b/test/mocks/AppStub.sol
@@ -1,6 +1,8 @@
 pragma solidity 0.4.18;
 
 import "../../contracts/apps/AragonApp.sol";
+import "../../contracts/apps/UnsafeAragonApp.sol";
+import "../../contracts/kernel/IKernel.sol";
 
 contract AppSt {
     uint a;
@@ -8,7 +10,7 @@ contract AppSt {
 }
 
 contract AppStub is AragonApp, AppSt {
-    bytes32 constant public ROLE = bytes32(1);
+    bytes32 constant public ROLE = keccak256("ROLE");
 
     function initialize() onlyInit public {
         initialized();
@@ -35,5 +37,11 @@ contract AppStub is AragonApp, AppSt {
 contract AppStub2 is AragonApp, AppSt {
     function getValue() public constant returns (uint) {
         return a * 2;
+    }
+}
+
+contract UnsafeAppStub is AppStub, UnsafeAragonApp {
+    function UnsafeAppStub(IKernel _kernel) {
+        setKernel(_kernel);
     }
 }

--- a/test/mocks/AppStubConditionalRecovery.sol
+++ b/test/mocks/AppStubConditionalRecovery.sol
@@ -8,4 +8,4 @@ contract AppStubConditionalRecovery is AragonApp {
 		// Doesn't allow to recover ether
 		return token != address(0);
 	}
-} 
+}

--- a/test/mocks/AppStubStorage.sol
+++ b/test/mocks/AppStubStorage.sol
@@ -1,9 +1,10 @@
 pragma solidity 0.4.18;
 
-import "../../contracts/apps/AragonApp.sol";
+import "../../contracts/apps/UnsafeAragonApp.sol";
 
 
-contract AppStubStorage is AragonApp {
+// Need to use UnsafeAragonApp to allow initialization
+contract AppStubStorage is UnsafeAragonApp {
     function initialize() onlyInit public {
         initialized();
     }

--- a/test/mocks/ERCProxyMock.sol
+++ b/test/mocks/ERCProxyMock.sol
@@ -1,0 +1,17 @@
+pragma solidity 0.4.18;
+
+import "../../contracts/lib/misc/ERCProxy.sol";
+
+
+contract ERCProxyMock is ERCProxy {
+    uint256 constant public FORWARDING = 1;
+    uint256 constant public UPGRADEABLE = 2;
+
+    function proxyType() public pure returns (uint256 proxyTypeId) {
+        return 0;
+    }
+
+    function implementation() public view returns (address codeAddr) {
+        return address(0);
+    }
+}

--- a/test/mocks/EVMScriptExecutor.sol
+++ b/test/mocks/EVMScriptExecutor.sol
@@ -3,12 +3,12 @@ pragma solidity 0.4.18;
 import "../../contracts/apps/AragonApp.sol";
 
 
-contract ExecutorStorage is AragonApp {
-    uint256 public randomNumber;
-}
+contract EVMScriptExecutor is AragonApp {
+    // Initialization is required to access any of the real executors
+    function initialize() public {
+        initialized();
+    }
 
-// TODO: Rename
-contract Executor is ExecutorStorage {
     function execute(bytes script) public {
         runScript(script, new bytes(0), new address[](0));
     }

--- a/test/mocks/LifecycleMock.sol
+++ b/test/mocks/LifecycleMock.sol
@@ -1,0 +1,15 @@
+pragma solidity 0.4.18;
+
+import "../../contracts/common/Initializable.sol";
+import "../../contracts/common/Petrifiable.sol";
+
+
+contract LifecycleMock is Initializable, Petrifiable {
+    function initializeMock() public {
+        initialized();
+    }
+
+    function petrifyMock() public {
+        petrify();
+    }
+}

--- a/test/mocks/MockScriptExecutorApp.sol
+++ b/test/mocks/MockScriptExecutorApp.sol
@@ -3,7 +3,7 @@ pragma solidity 0.4.18;
 import "../../contracts/apps/AragonApp.sol";
 
 
-contract EVMScriptExecutor is AragonApp {
+contract MockScriptExecutorApp is AragonApp {
     // Initialization is required to access any of the real executors
     function initialize() public {
         initialized();

--- a/test/mocks/UnsafeAragonAppMock.sol
+++ b/test/mocks/UnsafeAragonAppMock.sol
@@ -1,0 +1,19 @@
+pragma solidity 0.4.18;
+
+import "../../contracts/apps/UnsafeAragonApp.sol";
+import "../../contracts/kernel/IKernel.sol";
+
+
+contract UnsafeAragonAppMock is UnsafeAragonApp {
+    function initialize() public {
+        initialized();
+    }
+
+    function getKernel() public view returns (IKernel) {
+        return kernel();
+    }
+
+    function setKernelOnMock(IKernel _kernel) public {
+        setKernel(_kernel);
+    }
+}

--- a/test/mocks/UnsafeRepo.sol
+++ b/test/mocks/UnsafeRepo.sol
@@ -1,0 +1,13 @@
+pragma solidity 0.4.18;
+
+import "../../contracts/apm/Repo.sol";
+import "../../contracts/apps/UnsafeAragonApp.sol";
+
+
+// Allows Repo to be used without a proxy or access controls
+contract UnsafeRepo is Repo, UnsafeAragonApp {
+    // Protected actions are always performable
+    function canPerform(address _sender, bytes32 _role, uint256[] _params) public view returns (bool) {
+        return true;
+    }
+}

--- a/test/mocks/UpgradedKernel.sol
+++ b/test/mocks/UpgradedKernel.sol
@@ -4,6 +4,9 @@ import "../../contracts/kernel/Kernel.sol";
 
 
 contract UpgradedKernel is Kernel {
+    function UpgradedKernel(bool _shouldPetrify) Kernel(_shouldPetrify) public {
+    }
+
     // just adds one more function to the kernel implementation.
     // calling this function on the previous instance will fail
     function isUpgraded() public constant returns (bool) {

--- a/test/proxy_recover_funds.js
+++ b/test/proxy_recover_funds.js
@@ -1,5 +1,6 @@
 const { assertRevert } = require('./helpers/assertThrow')
 const { skipCoverage } = require('./helpers/coverage')
+const { onlyIf } = require('./helpers/onlyIf')
 const { getBalance } = require('./helpers/web3')
 const { hash } = require('eth-ens-namehash')
 
@@ -17,13 +18,13 @@ const VaultMock = artifacts.require('VaultMock')
 
 const getEvent = (receipt, event, arg) => { return receipt.logs.filter(l => l.event == event)[0].args[arg] }
 
+const APP_ID = hash('stub.aragonpm.test')
+
 contract('Proxy funds', accounts => {
-  let APP_BASES_NAMESPACE, APP_ADDR_NAMESPACE
-  let kernel, kernelProxy, app, appProxy, ETH
+  let aclBase, appBase, appConditionalRecoveryBase
+  let APP_BASES_NAMESPACE, APP_ADDR_NAMESPACE, ETH
 
   const permissionsRoot = accounts[0]
-  const appId = hash('stub.aragonpm.test')
-  const zeroAddr = '0x0000000000000000000000000000000000000000'
 
   // Helpers
   const recoverEth = async (target, vault) => {
@@ -49,7 +50,7 @@ contract('Proxy funds', accounts => {
     assert.equal((await token.balanceOf(vault.address)).valueOf(), initialVaultBalance.plus(initialBalance).plus(amount).valueOf())
   }
 
-  const failWithoutVault = async (target, vault) => {
+  const failWithoutVault = async (target, kernel) => {
     const amount = 1
     const vaultId = hash('vaultfake.aragonpm.test')
     const initialBalance = await getBalance(target.address)
@@ -61,158 +62,180 @@ contract('Proxy funds', accounts => {
     })
   }
 
-  beforeEach(async () => {
-    const kernelBase = await Kernel.new()
-    const aclBase = await ACL.new()
+  // Initial setup
+  before(async () => {
+    aclBase = await ACL.new()
+    appBase = await AppStub.new()
+    appConditionalRecoveryBase = await AppStubConditionalRecovery.new()
 
-    APP_BASES_NAMESPACE = await kernelBase.APP_BASES_NAMESPACE()
-    APP_ADDR_NAMESPACE = await kernelBase.APP_ADDR_NAMESPACE()
-
-    const factory = await DAOFactory.new(kernelBase.address, aclBase.address, '0x00')
-
-    app = await AppStub.new()
-
-    const receipt = await factory.newDAO(permissionsRoot)
-    const kernelAddress = getEvent(receipt, 'DeployDAO', 'dao')
-
-    kernel = Kernel.at(kernelAddress)
-    kernelProxy = KernelProxy.at(kernelAddress)
-    const acl = ACL.at(await kernel.acl())
-
-    const r = await kernel.APP_MANAGER_ROLE()
-    await acl.createPermission(permissionsRoot, kernel.address, r, permissionsRoot)
-
-    // app
-    await kernel.setApp(APP_BASES_NAMESPACE, appId, app.address)
-    const initializationPayload = app.contract.initialize.getData()
-    appProxy = await AppProxyUpgradeable.new(kernel.address, appId, initializationPayload, { gas: 6e6 })
-
+    // Setup constants
+    const kernel = await Kernel.new(true)
+    APP_BASES_NAMESPACE = await kernel.APP_BASES_NAMESPACE()
+    APP_ADDR_NAMESPACE = await kernel.APP_ADDR_NAMESPACE()
     ETH = await kernel.ETH()
   })
 
-  // Test both the Vault itself and when it's behind a proxy to make sure their recovery behaviours are the same
-  for (const vaultTestType of ['Vault', 'VaultProxy']) {
-    const skipCoverageIfVaultProxy = test => {
-      // The VaultMock isn't instrumented during coverage, but the AppProxy is, and so transferring
-      // to the fallback fails when we're testing with the proxy
-      return vaultTestType === 'VaultProxy' ? skipCoverage(test) : test
-    }
+  // Test both the Kernel itself and the KernelProxy to make sure their behaviours are the same
+  for (const kernelType of ['Kernel', 'KernelProxy']) {
+    const onlyBaseKernel = onlyIf(() => kernelType === 'Kernel')
+    const onlyKernelProxy = onlyIf(() => kernelType === 'KernelProxy')
 
-    context(`> ${vaultTestType}`, () => {
-      let target, vault
+    context(`> ${kernelType}`, () => {
+      let kernelBase, kernel
+
+      before(async () => {
+        if (kernelType === 'KernelProxy') {
+          // We can reuse the same kernel base for the proxies
+          kernelBase = await Kernel.new(true) // petrify immediately
+        }
+      })
 
       beforeEach(async () => {
-        const vaultId = hash('vault.aragonpm.test')
-        const vaultBase = await VaultMock.new()
-
-        if (vaultTestType === 'Vault') {
-          vault = vaultBase
-        } else if (vaultTestType === 'VaultProxy') {
-          // This doesn't automatically set up the recovery address
-          const receipt = await kernel.newAppInstance(vaultId, vaultBase.address)
-          const vaultProxyAddress = getEvent(receipt, 'NewAppProxy', 'proxy')
-          vault = VaultMock.at(vaultProxyAddress)
+        if (kernelType === 'Kernel') {
+          kernel = await Kernel.new(false) // don't petrify so it can be used
+        } else if (kernelType === 'KernelProxy') {
+          kernel = Kernel.at((await KernelProxy.new(kernelBase.address)).address)
         }
-        await kernel.setApp(APP_ADDR_NAMESPACE, vaultId, vault.address)
-        await kernel.setRecoveryVaultId(vaultId)
+
+        await kernel.initialize(aclBase.address, permissionsRoot);
+        const acl = ACL.at(await kernel.acl())
+        const r = await kernel.APP_MANAGER_ROLE()
+        await acl.createPermission(permissionsRoot, kernel.address, r, permissionsRoot)
       })
 
-      context('> App without kernel', async () => {
-        beforeEach(() => {
-          target = app
+      // Test both the Vault itself and when it's behind a proxy to make sure their recovery behaviours are the same
+      for (const vaultType of ['Vault', 'VaultProxy']) {
+        const skipCoverageIfVaultProxy = test => {
+          // The VaultMock isn't instrumented during coverage, but the AppProxy is, and so transferring
+          // to the fallback fails when we're testing with the proxy
+          return vaultType === 'VaultProxy' ? skipCoverage(test) : test
+        }
+
+        context(`> ${vaultType}`, () => {
+          let target, vault
+
+          beforeEach(async () => {
+            const vaultId = hash('vault.aragonpm.test')
+            const vaultBase = await VaultMock.new()
+
+            if (vaultType === 'Vault') {
+              vault = vaultBase
+            } else if (vaultType === 'VaultProxy') {
+              // This doesn't automatically setup the recovery address
+              const receipt = await kernel.newAppInstance(vaultId, vaultBase.address)
+              const vaultProxyAddress = getEvent(receipt, 'NewAppProxy', 'proxy')
+              vault = VaultMock.at(vaultProxyAddress)
+            }
+            await kernel.setApp(APP_ADDR_NAMESPACE, vaultId, vault.address)
+            await kernel.setRecoveryVaultId(vaultId)
+          })
+
+          onlyBaseKernel(() => {
+            context('> Base kernel', async () => {
+              it('cannot receive ETH', skipCoverageIfVaultProxy(async () =>
+                assertRevert(
+                  () => kernel.sendTransaction({ value: 1, gas: 31000 })
+                )
+              ))
+
+              it('recovers tokens', async () => {
+                await recoverTokens(kernel, vault)
+              })
+            })
+          })
+
+          onlyKernelProxy(() => {
+            context('> KernelProxy', async () => {
+              beforeEach(() => {
+                target = kernel
+              })
+
+              it('recovers ETH', skipCoverageIfVaultProxy(async () =>
+                await recoverEth(target, vault)
+              ))
+
+              it('recovers tokens', async () => {
+                await recoverTokens(target, vault)
+              })
+
+              it('fails if vault is not contract', async () => {
+                await failWithoutVault(target, kernel)
+              })
+            })
+          })
+
+          context('> App without kernel', async () => {
+            beforeEach(async () => {
+              target = await AppStub.new()
+            })
+
+            it('does not recover ETH', skipCoverageIfVaultProxy(() =>
+              assertRevert(
+                () => recoverEth(target, vault)
+              )
+            ))
+
+            it('does not recover tokens', () =>
+              assertRevert(
+                () => recoverTokens(target, vault)
+              )
+            )
+          })
+
+          context('> Proxied app with kernel', async () => {
+            beforeEach(async () => {
+              // Setup app
+              const receipt = await kernel.newAppInstance(APP_ID, appBase.address)
+              const appProxy = getEvent(receipt, 'NewAppProxy', 'proxy')
+              target = AppStub.at(appProxy)
+            })
+
+            it('cannot sent 0 ETH to proxy', async () => {
+              await assertRevert(async () => {
+                await target.sendTransaction({ value: 0, gas: 31000 })
+              })
+            })
+
+            it('cannot sent ETH with data to proxy', async () => {
+              await assertRevert(async () => {
+                await target.sendTransaction({ value: 1, data: '0x1', gas: 31000 })
+              })
+            })
+
+            it('recovers ETH', skipCoverageIfVaultProxy(
+              async () => await recoverEth(target, vault)
+            ))
+
+            it('recovers tokens', async () => {
+              await recoverTokens(target, vault)
+            })
+
+            it('fails if vault is not contract', async () => {
+              await failWithoutVault(target, kernel)
+            })
+          })
+
+          context('> Conditional fund recovery', async () => {
+            beforeEach(async () => {
+              // Setup app with conditional recovery code
+              const receipt = await kernel.newAppInstance(APP_ID, appConditionalRecoveryBase.address)
+              const appProxy = getEvent(receipt, 'NewAppProxy', 'proxy')
+              target = AppStub.at(appProxy)
+            })
+
+            it('does not allow recovering ETH', skipCoverageIfVaultProxy(
+              // Conditional stub doesnt allow eth recoveries
+              () => assertRevert(
+                () => recoverEth(target, vault)
+              )
+            ))
+
+            it('allows recovering tokens', async () => {
+              await recoverTokens(target, vault)
+            })
+          })
         })
-
-        it('does not recover ETH', skipCoverageIfVaultProxy(() =>
-          assertRevert(
-            () => recoverEth(target, vault)
-          )
-        ))
-
-        it('does not recover tokens', () =>
-          assertRevert(
-            () => recoverTokens(target, vault)
-          )
-        )
-      })
-
-      context('> Proxied app with kernel', async () => {
-        beforeEach(() => {
-          target = AppStub.at(appProxy.address)
-        })
-
-        it('recovers ETH', skipCoverageIfVaultProxy(
-          async () => await recoverEth(target, vault)
-        ))
-
-        it('recovers tokens', async () => {
-          await recoverTokens(target, vault)
-        })
-
-        it('fails if vault is not contract', async () => {
-          await failWithoutVault(target, vault)
-        })
-      })
-
-      context('> Conditional fund recovery', async () => {
-        let conditionalRecoveryAppCode
-
-        before(async () => {
-          conditionalRecoveryAppCode = await AppStubConditionalRecovery.new()
-        })
-
-        beforeEach(async () => {
-          // upgrade app to stub with conditional recovery code
-          await kernel.setApp(APP_BASES_NAMESPACE, appId, conditionalRecoveryAppCode.address)
-          target = AppStub.at(appProxy.address)
-        })
-
-        it('does not allow recovering ETH', skipCoverageIfVaultProxy(
-          // conditional stub doesnt allow eth recoveries
-          () => assertRevert(
-            () => recoverEth(target, vault)
-          )
-        ))
-
-        it('allows recovering tokens', async () => {
-          await recoverTokens(target, vault)
-        })
-      })
-
-      context('> Kernel without proxy', async () => {
-        beforeEach(() => {
-          target = kernel
-        })
-
-        it('recovers ETH', skipCoverageIfVaultProxy(async () =>
-          await recoverEth(target, vault)
-        ))
-
-        it('recovers tokens', async () => {
-          await recoverTokens(target, vault)
-        })
-
-        it('fails if vault is not contract', async () => {
-          await failWithoutVault(target, vault)
-        })
-      })
-
-      context('> Kernel Proxy', async () => {
-        beforeEach(() => {
-          target = Kernel.at(kernelProxy.address)
-        })
-
-        it('recovers ETH', skipCoverageIfVaultProxy(async () =>
-          await recoverEth(target, vault)
-        ))
-
-        it('recovers tokens', async () => {
-          await recoverTokens(target, vault)
-        })
-
-        it('fails if vault is not contract', async () => {
-          await failWithoutVault(target, vault)
-        })
-      })
+      }
     })
   }
 })

--- a/test/unstructured_storage.js
+++ b/test/unstructured_storage.js
@@ -8,7 +8,7 @@ contract('Unstructured storage', accounts => {
   beforeEach(async () => {
     app = await AppStubStorage.new()
     appPinned = await AppStubPinnedStorage.new()
-    kernel = await Kernel.new()
+    kernel = await Kernel.new(true)
   })
 
   it('tests init block', async () => {


### PR DESCRIPTION
All the contract changes can be seen in #355.

Quite a lot of the tests have been revamped, mainly to support parametrization across different base / proxy targets. Also found a few tests that were outdated or completely broken (in terms of what they were testing) 😄.