### PR TITLE
EVMScriptExecutor: add type for off-chain reading

### DIFF
--- a/contracts/evmscript/IEVMScriptExecutor.sol
+++ b/contracts/evmscript/IEVMScriptExecutor.sol
@@ -7,5 +7,5 @@ pragma solidity ^0.4.18;
 
 interface IEVMScriptExecutor {
     function execScript(bytes script, bytes input, address[] blacklist) external returns (bytes);
-    function executorType() external returns (bytes32);
+    function executorType() external pure returns (bytes32);
 }

--- a/contracts/evmscript/IEVMScriptExecutor.sol
+++ b/contracts/evmscript/IEVMScriptExecutor.sol
@@ -7,4 +7,5 @@ pragma solidity ^0.4.18;
 
 interface IEVMScriptExecutor {
     function execScript(bytes script, bytes input, address[] blacklist) external returns (bytes);
+    function executorType() external returns (bytes32);
 }

--- a/contracts/evmscript/executors/CallsScript.sol
+++ b/contracts/evmscript/executors/CallsScript.sol
@@ -51,7 +51,7 @@ contract CallsScript is IEVMScriptExecutor {
         }
     }
 
-    function executorType() external returns (bytes32) {
+    function executorType() external pure returns (bytes32) {
         return EXECUTOR_TYPE;
     }
 }

--- a/contracts/evmscript/executors/CallsScript.sol
+++ b/contracts/evmscript/executors/CallsScript.sol
@@ -9,6 +9,8 @@ import "../IEVMScriptExecutor.sol";
 contract CallsScript is IEVMScriptExecutor {
     using ScriptHelpers for bytes;
 
+    bytes32 constant internal EXECUTOR_TYPE = keccak256("CALLSCRIPT");
+
     uint256 constant internal SCRIPT_START_LOCATION = 4;
 
     event LogScriptCall(address indexed sender, address indexed src, address indexed dst);
@@ -47,5 +49,9 @@ contract CallsScript is IEVMScriptExecutor {
                 switch success case 0 { revert(0, 0) }
             }
         }
+    }
+
+    function executorType() external returns (bytes32) {
+        return EXECUTOR_TYPE;
     }
 }

--- a/contracts/evmscript/executors/CallsScript.sol
+++ b/contracts/evmscript/executors/CallsScript.sol
@@ -9,7 +9,8 @@ import "../IEVMScriptExecutor.sol";
 contract CallsScript is IEVMScriptExecutor {
     using ScriptHelpers for bytes;
 
-    bytes32 constant internal EXECUTOR_TYPE = keccak256("CALLSCRIPT");
+    // bytes32 constant internal EXECUTOR_TYPE = keccak256("CALLS_SCRIPT");
+    bytes32 constant internal EXECUTOR_TYPE = 0x2dc858a00f3e417be1394b87c07158e989ec681ce8cc68a9093680ac1a870302;
 
     uint256 constant internal SCRIPT_START_LOCATION = 4;
 

--- a/test/evm_script.js
+++ b/test/evm_script.js
@@ -95,7 +95,7 @@ contract('EVM Script', accounts => {
             it('is the correct executor type', async () => {
                 const CALLS_SCRIPT_TYPE = soliditySha3('CALLS_SCRIPT')
                 const executor = IEVMScriptExecutor.at(await reg.getScriptExecutor('0x00000001'))
-                assert.equal(await executor.executorType(), CALLS_SCRIPT_TYPE)
+                assert.equal(await executor.executorType.call(), CALLS_SCRIPT_TYPE)
             })
 
             it('executes single action script', async () => {

--- a/test/evm_script.js
+++ b/test/evm_script.js
@@ -1,4 +1,5 @@
 const { rawEncode } = require('ethereumjs-abi')
+const { soliditySha3 } = require('web3-utils')
 
 const { assertRevert } = require('./helpers/assertThrow')
 const { encodeCallScript } = require('./helpers/evmScript')
@@ -16,6 +17,8 @@ const IEVMScriptExecutor = artifacts.require('IEVMScriptExecutor')
 
 const keccak256 = require('js-sha3').keccak_256
 const APP_BASE_NAMESPACE = '0x'+keccak256('base')
+const ZERO_ADDR = '0x0000000000000000000000000000000000000000'
+
 
 const getContract = artifacts.require
 
@@ -48,11 +51,9 @@ contract('EVM Script', accounts => {
     })
 
     it('factory registered just 1 script executor', async () => {
-        const zeroAddr = '0x0000000000000000000000000000000000000000'
-
-        assert.equal(await reg.getScriptExecutor('0x00000000'), zeroAddr)
-        assert.notEqual(await reg.getScriptExecutor('0x00000001'), zeroAddr)
-        assert.equal(await reg.getScriptExecutor('0x00000002'), zeroAddr)
+        assert.equal(await reg.getScriptExecutor('0x00000000'), ZERO_ADDR)
+        assert.notEqual(await reg.getScriptExecutor('0x00000001'), ZERO_ADDR)
+        assert.equal(await reg.getScriptExecutor('0x00000002'), ZERO_ADDR)
     })
 
     it('fails if reinitializing registry', async () => {
@@ -83,12 +84,20 @@ contract('EVM Script', accounts => {
         it('can disable executors', async () => {
             await acl.grantPermission(boss, reg.address, await reg.REGISTRY_MANAGER_ROLE(), { from: boss })
             await reg.disableScriptExecutor(1, { from: boss })
+
+            assert.equal(await reg.getScriptExecutor('0x00000001'), ZERO_ADDR)
             return assertRevert(async () => {
                 await executor.execute(encodeCallScript([]))
             })
         })
 
         context('spec ID 1', () => {
+            it('is the correct executor type', async () => {
+                const CALLS_SCRIPT_TYPE = soliditySha3('CALLS_SCRIPT')
+                const executor = IEVMScriptExecutor.at(await reg.getScriptExecutor('0x00000001'))
+                assert.equal(await executor.executorType(), CALLS_SCRIPT_TYPE)
+            })
+
             it('executes single action script', async () => {
                 const action = { to: executionTarget.address, calldata: executionTarget.contract.execute.getData() }
                 const script = encodeCallScript([action])

--- a/test/keccak_constants.js
+++ b/test/keccak_constants.js
@@ -66,6 +66,12 @@ contract('Constants', accounts => {
     assert.equal(await evmScriptConstants.EVMSCRIPT_REGISTRY_APP(), await keccakConstants.EVMSCRIPT_REGISTRY_APP(), "app doesn't match")
   })
 
+  it('checks EVM Script executor types', async () => {
+    const callsScriptExecutor = await getContract('CallsScript').new()
+
+    assert.equal(await callsScriptExecutor.executorType(), await keccakConstants.EVMSCRIPT_EXECUTOR_CALLS_SCRIPT(), "callscript executor type doesn't match")
+  })
+
   it('checks EVMScriptRegistry constants', async () => {
     const evmScriptRegistry = await getContract('EVMScriptRegistry').new()
 

--- a/test/keccak_constants.js
+++ b/test/keccak_constants.js
@@ -69,7 +69,7 @@ contract('Constants', accounts => {
   it('checks EVM Script executor types', async () => {
     const callsScriptExecutor = await getContract('CallsScript').new()
 
-    assert.equal(await callsScriptExecutor.executorType(), await keccakConstants.EVMSCRIPT_EXECUTOR_CALLS_SCRIPT(), "callscript executor type doesn't match")
+    assert.equal(await callsScriptExecutor.executorType.call(), await keccakConstants.EVMSCRIPT_EXECUTOR_CALLS_SCRIPT(), "callscript executor type doesn't match")
   })
 
   it('checks EVMScriptRegistry constants', async () => {

--- a/test/mocks/KeccakConstants.sol
+++ b/test/mocks/KeccakConstants.sol
@@ -43,6 +43,9 @@ contract KeccakConstants is APMNamehash {
     bytes32 constant public EVMSCRIPT_REGISTRY_APP = keccak256(APP_ADDR_NAMESPACE, EVMSCRIPT_REGISTRY_APP_ID);
     bytes32 constant public REGISTRY_MANAGER_ROLE = keccak256("REGISTRY_MANAGER_ROLE");
 
+    // EVMScriptExecutor types
+    bytes32 constant public EVMSCRIPT_EXECUTOR_CALLS_SCRIPT = keccak256("CALLS_SCRIPT");
+
     // Repo
     bytes32 constant public CREATE_VERSION_ROLE = keccak256("CREATE_VERSION_ROLE");
 }


### PR DESCRIPTION
Was getting worried that we always assume in `aragon.js` that the first executor in an organization's `EVMScriptRegistry` is the callscript executor, rather than doing an on-chain confirmation.

**TODO**:

- [x] Add tests