### PR TITLE
Update linter for 0.4.24 features

### DIFF
--- a/.soliumrc.json
+++ b/.soliumrc.json
@@ -4,7 +4,6 @@
     "rules": {
         "security/no-low-level-calls": "off",
         "security/no-inline-assembly": "off",
-        "emit": "off",
         "error-reason": "off",
         "imports-on-top": "error",
         "variable-declarations": "error",
@@ -28,6 +27,7 @@
         "deprecated-suicide": "error",
         "pragma-on-top": "error",
         "function-order": "error",
+        "emit": "error",
         "no-constant": "error",
         "value-in-payable": "error",
         "max-len": "error",

--- a/contracts/evmscript/EVMScriptRegistry.sol
+++ b/contracts/evmscript/EVMScriptRegistry.sol
@@ -56,7 +56,7 @@ contract EVMScriptRegistry is IEVMScriptRegistry, EVMScriptRegistryConstants, Ar
         ExecutorEntry storage executorEntry = executors[_executorId];
         require(!executorEntry.enabled);
         executorEntry.enabled = true;
-        EnableExecutor(_executorId, executorEntry.executor);
+        emit EnableExecutor(_executorId, executorEntry.executor);
     }
 
     function getScriptExecutor(bytes _script) public view returns (IEVMScriptExecutor) {


### PR DESCRIPTION
Turns on `emit` lint errors.