### PR TITLE
IForwarder: change interfaces to public instead of external due to solidity bug

### DIFF
--- a/contracts/common/IForwarder.sol
+++ b/contracts/common/IForwarder.sol
@@ -7,6 +7,12 @@ pragma solidity ^0.4.24;
 
 interface IForwarder {
     function isForwarder() external pure returns (bool);
-    function canForward(address sender, bytes evmCallScript) external view returns (bool);
-    function forward(bytes evmCallScript) external;
+
+    // TODO: this should be external
+    // See https://github.com/ethereum/solidity/issues/4832
+    function canForward(address sender, bytes evmCallScript) public view returns (bool);
+
+    // TODO: this should be external
+    // See https://github.com/ethereum/solidity/issues/4832
+    function forward(bytes evmCallScript) public;
 }


### PR DESCRIPTION
See https://github.com/ethereum/solidity/issues/4832.

There are a few other cases in our interfaces where this applies (`bytes` or array parameter in an `external` interface), but implementations of those cases shouldn't require casting the visibility to `public`:

- `IACLOracle#canPerform()`
- `IEVMScriptExecutor#execScript()`