### PR TITLE
Fix scripts for aOS 4

### DIFF
--- a/scripts/deploy-beta-apm.js
+++ b/scripts/deploy-beta-apm.js
@@ -12,9 +12,13 @@ const tld = namehash('eth')
 const label = '0x'+keccak256('aragonpm')
 
 const getContract = name => artifacts.require(name)
-const deployBases = async baseNames => {
-  const baseContracts = await Promise.all(baseNames.map(c => getContract(c).new()))
 
+const baseInitArguments = {
+  Kernel: [ true ] // petrify
+}
+
+const deployBases = async baseNames => {
+  const baseContracts = await Promise.all(baseNames.map(c => getContract(c).new(...(baseInitArguments[c] || []))))
   return baseContracts.map(c => c.address)
 }
 

--- a/scripts/deploy-beta-apm.js
+++ b/scripts/deploy-beta-apm.js
@@ -53,6 +53,7 @@ module.exports = async callback => {
   const apmAddr = receipt.logs.filter(l => l.event == 'DeployAPM')[0].args.apm
   console.log('deployed APM:', apmAddr)
   console.log(apmAddr)
+  callback()
 }
 
 // Rinkeby APM: 0x700569b6c99b8b5fa17b7976a26ae2f0d5fd145c

--- a/scripts/deploy-beta-ens.js
+++ b/scripts/deploy-beta-ens.js
@@ -13,6 +13,7 @@ module.exports = async callback => {
   console.log('Deployed ENS:', ens)
 
   console.log(ens)
+  callback()
 }
 
 // Rinkeby ENS: 0xfbae32d1cde62858bc45f51efc8cc4fa1415447e


### PR DESCRIPTION
- Scripts were no longer exiting unless the callback is executed
- The `Kernel` contract needs the constructor parameter for petrifying