### PR TITLE
Kernel: use explicit mapping for namespaces rather than hash

### DIFF
--- a/contracts/apps/AppProxyBase.sol
+++ b/contracts/apps/AppProxyBase.sol
@@ -2,7 +2,7 @@ pragma solidity 0.4.24;
 
 import "./AppStorage.sol";
 import "../common/DepositableDelegateProxy.sol";
-import "../kernel/KernelStorage.sol";
+import "../kernel/KernelConstants.sol";
 import "../kernel/IKernel.sol";
 
 
@@ -33,6 +33,6 @@ contract AppProxyBase is AppStorage, DepositableDelegateProxy, KernelConstants {
     }
 
     function getAppBase(bytes32 _appId) internal view returns (address) {
-        return kernel().getApp(keccak256(abi.encodePacked(APP_BASES_NAMESPACE, _appId)));
+        return kernel().getApp(APP_BASES_NAMESPACE, _appId);
     }
 }

--- a/contracts/evmscript/EVMScriptRunner.sol
+++ b/contracts/evmscript/EVMScriptRunner.sol
@@ -8,10 +8,11 @@ import "./IEVMScriptExecutor.sol";
 import "./IEVMScriptRegistry.sol";
 
 import "../apps/AppStorage.sol";
+import "../kernel/KernelConstants.sol";
 import "../common/Initializable.sol";
 
 
-contract EVMScriptRunner is AppStorage, Initializable, EVMScriptRegistryConstants {
+contract EVMScriptRunner is AppStorage, Initializable, EVMScriptRegistryConstants, KernelConstants {
     event ScriptResult(address indexed executor, bytes script, bytes input, bytes returnData);
 
     function getExecutor(bytes _script) public view returns (IEVMScriptExecutor) {
@@ -40,7 +41,7 @@ contract EVMScriptRunner is AppStorage, Initializable, EVMScriptRegistryConstant
     }
 
     function getExecutorRegistry() internal view returns (IEVMScriptRegistry) {
-        address registryAddr = kernel().getApp(EVMSCRIPT_REGISTRY_APP);
+        address registryAddr = kernel().getApp(APP_ADDR_NAMESPACE, EVMSCRIPT_REGISTRY_APP_ID);
         return IEVMScriptRegistry(registryAddr);
     }
 

--- a/contracts/evmscript/IEVMScriptRegistry.sol
+++ b/contracts/evmscript/IEVMScriptRegistry.sol
@@ -9,13 +9,9 @@ import "./IEVMScriptExecutor.sol";
 
 contract EVMScriptRegistryConstants {
     /* Hardcoded constants to save gas
-    bytes32 constant public APP_ADDR_NAMESPACE = keccak256("app");
-
     bytes32 constant public EVMSCRIPT_REGISTRY_APP_ID = apmNamehash("evmreg");
-    bytes32 constant public EVMSCRIPT_REGISTRY_APP = keccak256(APP_ADDR_NAMESPACE, EVMSCRIPT_REGISTRY_APP_ID);
     */
     bytes32 constant public EVMSCRIPT_REGISTRY_APP_ID = 0xddbcfd564f642ab5627cf68b9b7d374fb4f8a36e941a75d89c87998cef03bd61;
-    bytes32 constant public EVMSCRIPT_REGISTRY_APP = 0x34f01c17e9be6ddbf2c61f37b5b1fb9f1a090a975006581ad19bda1c4d382871;
 }
 
 

--- a/contracts/kernel/IKernel.sol
+++ b/contracts/kernel/IKernel.sol
@@ -10,11 +10,11 @@ import "../common/IVaultRecoverable.sol";
 
 // This should be an interface, but interfaces can't inherit yet :(
 contract IKernel is IVaultRecoverable {
-    event SetApp(bytes32 indexed namespace, bytes32 indexed name, bytes32 indexed id, address app);
+    event SetApp(bytes32 indexed namespace, bytes32 indexed appId, address app);
 
     function acl() public view returns (IACL);
     function hasPermission(address who, address where, bytes32 what, bytes how) public view returns (bool);
 
-    function setApp(bytes32 namespace, bytes32 name, address app) public returns (bytes32 id);
-    function getApp(bytes32 id) public view returns (address);
+    function setApp(bytes32 namespace, bytes32 appId, address app) public;
+    function getApp(bytes32 namespace, bytes32 appId) public view returns (address);
 }

--- a/contracts/kernel/Kernel.sol
+++ b/contracts/kernel/Kernel.sol
@@ -37,12 +37,13 @@ contract Kernel is IKernel, KernelStorage, Petrifiable, IsContract, VaultRecover
     function initialize(IACL _baseAcl, address _permissionsCreator) public onlyInit {
         initialized();
 
-        IACL acl = IACL(newAppProxy(this, ACL_APP_ID));
-
+        // Set ACL base
         _setApp(APP_BASES_NAMESPACE, ACL_APP_ID, _baseAcl);
-        _setApp(APP_ADDR_NAMESPACE, ACL_APP_ID, acl);
 
+        // Create ACL instance and attach it as the default ACL app
+        IACL acl = IACL(newAppProxy(this, ACL_APP_ID));
         acl.initialize(_permissionsCreator);
+        _setApp(APP_ADDR_NAMESPACE, ACL_APP_ID, acl);
 
         recoveryVaultId = DEFAULT_VAULT_APP_ID;
     }

--- a/contracts/kernel/Kernel.sol
+++ b/contracts/kernel/Kernel.sol
@@ -45,7 +45,7 @@ contract Kernel is IKernel, KernelStorage, Petrifiable, IsContract, VaultRecover
         acl.initialize(_permissionsCreator);
         _setApp(APP_ADDR_NAMESPACE, ACL_APP_ID, acl);
 
-        recoveryVaultId = DEFAULT_VAULT_APP_ID;
+        recoveryVaultAppId = DEFAULT_VAULT_APP_ID;
     }
 
     /**
@@ -140,13 +140,13 @@ contract Kernel is IKernel, KernelStorage, Petrifiable, IsContract, VaultRecover
 
     /**
     * @dev Set the default vault id for the escape hatch mechanism
-    * @param _recoveryVaultId Identifier of the recovery vault app
+    * @param _recoveryVaultAppId Identifier of the recovery vault app
     */
-    function setRecoveryVaultId(bytes32 _recoveryVaultId)
+    function setRecoveryVaultAppId(bytes32 _recoveryVaultAppId)
         public
-        auth(APP_MANAGER_ROLE, arr(APP_ADDR_NAMESPACE, _recoveryVaultId))
+        auth(APP_MANAGER_ROLE, arr(APP_ADDR_NAMESPACE, _recoveryVaultAppId))
     {
-        recoveryVaultId = _recoveryVaultId;
+        recoveryVaultAppId = _recoveryVaultAppId;
     }
 
     /**
@@ -164,7 +164,7 @@ contract Kernel is IKernel, KernelStorage, Petrifiable, IsContract, VaultRecover
     * @return Address of the Vault
     */
     function getRecoveryVault() public view returns (address) {
-        return apps[APP_ADDR_NAMESPACE][recoveryVaultId];
+        return apps[APP_ADDR_NAMESPACE][recoveryVaultAppId];
     }
 
     /**

--- a/contracts/kernel/KernelConstants.sol
+++ b/contracts/kernel/KernelConstants.sol
@@ -1,0 +1,19 @@
+pragma solidity 0.4.24;
+
+
+contract KernelConstants {
+    /*
+    bytes32 constant public CORE_NAMESPACE = keccak256("core");
+    bytes32 constant public APP_BASES_NAMESPACE = keccak256("base");
+    bytes32 constant public APP_ADDR_NAMESPACE = keccak256("app");
+
+    bytes32 constant public KERNEL_APP_ID = apmNamehash("kernel");
+    bytes32 constant public ACL_APP_ID = apmNamehash("acl");
+    */
+    bytes32 constant public CORE_NAMESPACE = 0xc681a85306374a5ab27f0bbc385296a54bcd314a1948b6cf61c4ea1bc44bb9f8;
+    bytes32 constant public APP_BASES_NAMESPACE = 0xf1f3eb40f5bc1ad1344716ced8b8a0431d840b5783aea1fd01786bc26f35ac0f;
+    bytes32 constant public APP_ADDR_NAMESPACE = 0xd6f028ca0e8edb4a8c9757ca4fdccab25fa1e0317da1188108f7d2dee14902fb;
+
+    bytes32 constant public KERNEL_APP_ID = 0x3b4bf6bf3ad5000ecf0f989d5befde585c6860fea3e574a4fab4c49d1c177d9c;
+    bytes32 constant public ACL_APP_ID = 0xe3262375f45a6e2026b7e7b18c2b807434f2508fe1a2a3dfb493c7df8f4aad6a;
+}

--- a/contracts/kernel/KernelProxy.sol
+++ b/contracts/kernel/KernelProxy.sol
@@ -14,7 +14,7 @@ contract KernelProxy is KernelStorage, IsContract, DepositableDelegateProxy {
     */
     constructor(IKernel _kernelImpl) public {
         require(isContract(address(_kernelImpl)));
-        apps[KERNEL_APP] = _kernelImpl;
+        apps[CORE_NAMESPACE][KERNEL_APP_ID] = _kernelImpl;
     }
 
     /**
@@ -28,6 +28,6 @@ contract KernelProxy is KernelStorage, IsContract, DepositableDelegateProxy {
     * @dev ERC897, the address the proxy would delegate calls to
     */
     function implementation() public view returns (address) {
-        return apps[KERNEL_APP];
+        return apps[CORE_NAMESPACE][KERNEL_APP_ID];
     }
 }

--- a/contracts/kernel/KernelStorage.sol
+++ b/contracts/kernel/KernelStorage.sol
@@ -1,32 +1,9 @@
 pragma solidity 0.4.24;
 
-
-contract KernelConstants {
-    /*
-    bytes32 constant public CORE_NAMESPACE = keccak256("core");
-    bytes32 constant public APP_BASES_NAMESPACE = keccak256("base");
-    bytes32 constant public APP_ADDR_NAMESPACE = keccak256("app");
-
-    bytes32 constant public KERNEL_APP_ID = apmNamehash("kernel");
-    bytes32 constant public KERNEL_APP = keccak256(CORE_NAMESPACE, KERNEL_APP_ID);
-
-    bytes32 constant public ACL_APP_ID = apmNamehash("acl");
-    bytes32 constant public ACL_APP = keccak256(APP_ADDR_NAMESPACE, ACL_APP_ID);
-    */
-    bytes32 constant public CORE_NAMESPACE = 0xc681a85306374a5ab27f0bbc385296a54bcd314a1948b6cf61c4ea1bc44bb9f8;
-    bytes32 constant public APP_BASES_NAMESPACE = 0xf1f3eb40f5bc1ad1344716ced8b8a0431d840b5783aea1fd01786bc26f35ac0f;
-    bytes32 constant public APP_ADDR_NAMESPACE = 0xd6f028ca0e8edb4a8c9757ca4fdccab25fa1e0317da1188108f7d2dee14902fb;
-
-    bytes32 constant public KERNEL_APP_ID = 0x3b4bf6bf3ad5000ecf0f989d5befde585c6860fea3e574a4fab4c49d1c177d9c;
-    bytes32 constant public KERNEL_APP = 0x2b7d19d0575c228f8d9326801e14149d284dc5bb7b1541c5ad712ae4b2fcaadb;
-
-    bytes32 constant public ACL_APP_ID = 0xe3262375f45a6e2026b7e7b18c2b807434f2508fe1a2a3dfb493c7df8f4aad6a;
-    bytes32 constant public ACL_APP = 0x4b8e03a458a6ccec5d9077c2490964c1333dd3c72e2db408d7d9a7a36ef5c41a;
-
-}
+import "./KernelConstants.sol";
 
 
 contract KernelStorage is KernelConstants {
-    mapping (bytes32 => address) public apps;
+    mapping (bytes32 => mapping (bytes32 => address)) public apps;
     bytes32 public recoveryVaultId;
 }

--- a/contracts/kernel/KernelStorage.sol
+++ b/contracts/kernel/KernelStorage.sol
@@ -5,5 +5,5 @@ import "./KernelConstants.sol";
 
 contract KernelStorage is KernelConstants {
     mapping (bytes32 => mapping (bytes32 => address)) public apps;
-    bytes32 public recoveryVaultId;
+    bytes32 public recoveryVaultAppId;
 }

--- a/contracts/test/mocks/KeccakConstants.sol
+++ b/contracts/test/mocks/KeccakConstants.sol
@@ -12,18 +12,11 @@ contract KeccakConstants is APMNamehash {
     bytes32 constant public APP_ADDR_NAMESPACE = keccak256(abi.encodePacked("app"));
 
     bytes32 constant public KERNEL_APP_ID = keccak256(abi.encodePacked(APM_NODE, keccak256("kernel")));
-    bytes32 constant public KERNEL_APP = keccak256(abi.encodePacked(CORE_NAMESPACE, KERNEL_APP_ID));
-
     bytes32 constant public ACL_APP_ID = keccak256(abi.encodePacked(APM_NODE, keccak256("acl")));
-    bytes32 constant public ACL_APP = keccak256(abi.encodePacked(APP_ADDR_NAMESPACE, ACL_APP_ID));
 
     bytes32 constant public APP_MANAGER_ROLE = keccak256(abi.encodePacked("APP_MANAGER_ROLE"));
 
-    bytes32 constant public DEFAULT_VAULT_ID = keccak256(
-        abi.encodePacked(
-            APP_ADDR_NAMESPACE, keccak256(abi.encodePacked(APM_NODE, keccak256("vault")))
-        )
-    );
+    bytes32 constant public DEFAULT_VAULT_APP_ID = keccak256(abi.encodePacked(APM_NODE, keccak256("vault")));
 
     // ENS
     bytes32 constant public ENS_ROOT = bytes32(0);
@@ -46,7 +39,6 @@ contract KeccakConstants is APMNamehash {
 
     // EVMScriptRegistry
     bytes32 constant public EVMSCRIPT_REGISTRY_APP_ID = keccak256(abi.encodePacked(APM_NODE, keccak256("evmreg")));
-    bytes32 constant public EVMSCRIPT_REGISTRY_APP = keccak256(abi.encodePacked(APP_ADDR_NAMESPACE, EVMSCRIPT_REGISTRY_APP_ID));
     bytes32 constant public REGISTRY_ADD_EXECUTOR_ROLE = keccak256("REGISTRY_ADD_EXECUTOR_ROLE");
     bytes32 constant public REGISTRY_MANAGER_ROLE = keccak256(abi.encodePacked("REGISTRY_MANAGER_ROLE"));
 

--- a/contracts/test/mocks/KernelSetAppMock.sol
+++ b/contracts/test/mocks/KernelSetAppMock.sol
@@ -7,8 +7,7 @@ contract KernelSetAppMock is Kernel {
     }
 
     // Overloaded mock to bypass the auth and isContract checks
-    function setApp(bytes32 _namespace, bytes32 _name, address _app) public returns (bytes32 id) {
-        id = keccak256(abi.encodePacked(_namespace, _name));
-        apps[id] = _app;
+    function setApp(bytes32 _namespace, bytes32 _appId, address _app) public {
+        apps[_namespace][_appId] = _app;
     }
 }

--- a/test/keccak_constants.js
+++ b/test/keccak_constants.js
@@ -19,14 +19,11 @@ contract('Constants', accounts => {
     assert.equal(await kernelConstants.APP_ADDR_NAMESPACE(), await keccakConstants.APP_ADDR_NAMESPACE(), "app namespace doesn't match")
 
     assert.equal(await kernelConstants.KERNEL_APP_ID(), await keccakConstants.KERNEL_APP_ID(), "kernel app id doesn't match")
-    assert.equal(await kernelConstants.KERNEL_APP(), await keccakConstants.KERNEL_APP(), "kernel app doesn't match")
-
     assert.equal(await kernelConstants.ACL_APP_ID(), await keccakConstants.ACL_APP_ID(), "acl app id doesn't match")
-    assert.equal(await kernelConstants.ACL_APP(), await keccakConstants.ACL_APP(), "acl app doesn't match")
 
     const kernel = await getContract('Kernel').new(false)
     assert.equal(await kernel.APP_MANAGER_ROLE(), await keccakConstants.APP_MANAGER_ROLE(), "app manager role doesn't match")
-    assert.equal(await kernel.DEFAULT_VAULT_ID(), await keccakConstants.DEFAULT_VAULT_ID(), "default vault id doesn't match")
+    assert.equal(await kernel.DEFAULT_VAULT_APP_ID(), await keccakConstants.DEFAULT_VAULT_APP_ID(), "default vault id doesn't match")
   })
 
   it('checks ENS constants', async () => {
@@ -63,7 +60,6 @@ contract('Constants', accounts => {
     const evmScriptConstants = await getContract('EVMScriptRegistryConstants').new()
 
     assert.equal(await evmScriptConstants.EVMSCRIPT_REGISTRY_APP_ID(), await keccakConstants.EVMSCRIPT_REGISTRY_APP_ID(), "app id doesn't match")
-    assert.equal(await evmScriptConstants.EVMSCRIPT_REGISTRY_APP(), await keccakConstants.EVMSCRIPT_REGISTRY_APP(), "app doesn't match")
   })
 
   it('checks EVM Script executor types', async () => {

--- a/test/kernel_apps.js
+++ b/test/kernel_apps.js
@@ -2,7 +2,6 @@ const { assertRevert } = require('./helpers/assertThrow')
 const { onlyIf } = require('./helpers/onlyIf')
 const { getBalance } = require('./helpers/web3')
 const { hash } = require('eth-ens-namehash')
-const { soliditySha3 } = require('web3-utils')
 
 const ACL = artifacts.require('ACL')
 const Kernel = artifacts.require('Kernel')
@@ -23,7 +22,6 @@ const EMPTY_BYTES = '0x'
 contract('Kernel apps', accounts => {
     let aclBase, appBase1, appBase2
     let APP_BASES_NAMESPACE, APP_ADDR_NAMESPACE
-    let APP_SET_ID, APP_DEFAULT_ID
     let UPGRADEABLE, FORWARDING
 
     const permissionsRoot = accounts[0]
@@ -39,8 +37,6 @@ contract('Kernel apps', accounts => {
         APP_BASES_NAMESPACE = await kernel.APP_BASES_NAMESPACE()
         APP_ADDR_NAMESPACE = await kernel.APP_ADDR_NAMESPACE()
         APP_MANAGER_ROLE = await kernel.APP_MANAGER_ROLE()
-        APP_SET_ID = soliditySha3(APP_BASES_NAMESPACE, APP_ID)
-        APP_DEFAULT_ID = soliditySha3(APP_ADDR_NAMESPACE, APP_ID)
 
         const ercProxyMock = await ERCProxyMock.new()
         UPGRADEABLE = (await ercProxyMock.UPGRADEABLE()).toString()
@@ -130,10 +126,10 @@ contract('Kernel apps', accounts => {
                     )
 
                     it('sets the app base when not previously registered', async() => {
-                        assert.equal(ZERO_ADDR, await kernel.getApp(APP_SET_ID))
+                        assert.equal(ZERO_ADDR, await kernel.getApp(APP_BASES_NAMESPACE, APP_ID))
 
                         await kernel[newInstanceFn](APP_ID, appBase1.address)
-                        assert.equal(appBase1.address, await kernel.getApp(APP_SET_ID))
+                        assert.equal(appBase1.address, await kernel.getApp(APP_BASES_NAMESPACE, APP_ID))
                     })
 
                     it("doesn't set the app base when already set", async() => {
@@ -154,8 +150,8 @@ contract('Kernel apps', accounts => {
                         })
 
                         // Check that both the app base and default app are set
-                        assert.equal(await kernel.getApp(APP_SET_ID), appBase1.address)
-                        assert.equal(await kernel.getApp(APP_DEFAULT_ID), appProxyAddr)
+                        assert.equal(await kernel.getApp(APP_BASES_NAMESPACE, APP_ID), appBase1.address)
+                        assert.equal(await kernel.getApp(APP_ADDR_NAMESPACE, APP_ID), appProxyAddr)
                     })
 
                     it("fails if the app base is not given", async() => {

--- a/test/kernel_lifecycle.js
+++ b/test/kernel_lifecycle.js
@@ -24,7 +24,7 @@ contract('Kernel lifecycle', accounts => {
     await assertRevert(() => kernel.newAppInstance(APP_ID, appBase.address))
     await assertRevert(() => kernel.newPinnedAppInstance(APP_ID, appBase.address))
     await assertRevert(() => kernel.setApp(APP_BASES_NAMESPACE, APP_ID, appBase.address))
-    await assertRevert(() => kernel.setRecoveryVaultId(VAULT_ID))
+    await assertRevert(() => kernel.setRecoveryVaultAppId(VAULT_ID))
   }
 
   const testUsability = async (kernel) => {

--- a/test/kernel_lifecycle.js
+++ b/test/kernel_lifecycle.js
@@ -146,10 +146,10 @@ contract('Kernel lifecycle', accounts => {
         const ACLAppLog = setAppLogs[1]
 
         assert.equal(ACLBaseLog.args.namespace, APP_BASES_NAMESPACE, 'should set base acl first')
-        assert.equal(ACLBaseLog.args.name, ACL_APP_ID, 'should set base acl first')
+        assert.equal(ACLBaseLog.args.appId, ACL_APP_ID, 'should set base acl first')
         assert.equal(ACLBaseLog.args.app, aclBase.address, 'should set base acl first')
         assert.equal(ACLAppLog.args.namespace, APP_ADDR_NAMESPACE, 'should set default acl second')
-        assert.equal(ACLAppLog.args.name, ACL_APP_ID, 'should set default acl second')
+        assert.equal(ACLAppLog.args.appId, ACL_APP_ID, 'should set default acl second')
         assert.equal(ACLAppLog.args.app, acl.address, 'should set default acl second')
       })
 

--- a/test/proxy_recover_funds.js
+++ b/test/proxy_recover_funds.js
@@ -54,7 +54,7 @@ contract('Proxy funds', accounts => {
     const amount = 1
     const vaultId = hash('vaultfake.aragonpm.test')
     const initialBalance = await getBalance(target.address)
-    await kernel.setRecoveryVaultId(vaultId)
+    await kernel.setRecoveryVaultAppId(vaultId)
     const r = await target.sendTransaction({ value: 1, gas: 31000 })
     assert.equal((await getBalance(target.address)).valueOf(), initialBalance.plus(amount))
     return assertRevert(async () => {
@@ -130,7 +130,7 @@ contract('Proxy funds', accounts => {
               vault = VaultMock.at(vaultProxyAddress)
             }
             await kernel.setApp(APP_ADDR_NAMESPACE, vaultId, vault.address)
-            await kernel.setRecoveryVaultId(vaultId)
+            await kernel.setRecoveryVaultAppId(vaultId)
           })
 
           onlyBaseKernel(() => {


### PR DESCRIPTION
Fixes #337.

I've opted to keep the "app identifier" nomenclature rather than "app name" due to it breaking less external interfaces (e.g. events). A name and an identifier are pretty similar anyway, we just shouldn't have both concepts.