### PR TITLE
Clean up truffle-config.js and lazy load providers

### DIFF
--- a/truffle-config.js
+++ b/truffle-config.js
@@ -61,7 +61,7 @@ module.exports = {
       port: 8545,
       gas: 6.9e6
     },
-    development: {
+    devnet: {
       network_id: 15,
       host: 'localhost',
       port: 8535,

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -1,26 +1,47 @@
+const homedir = require('homedir')
+const path = require('path')
+
 const HDWalletProvider = require('truffle-hdwallet-provider')
 const HDWalletProviderPrivkey = require('truffle-hdwallet-provider-privkey')
 
-let mnemonic
-try {
-  mnemonic = require(require('homedir')()+'/.aragon/mnemonic.json').mnemonic
-} catch (e) {
-  mnemonic = 'stumble story behind hurt patient ball whisper art swift tongue ice alien';
-}
+const DEFAULT_MNEMONIC = 'stumble story behind hurt patient ball whisper art swift tongue ice alien'
 
-let ropstenProvider, kovanProvider, rinkebyProvider = {}
+const defaultRPC = (network) =>
+  `https://${network}.infura.io`
 
-if (process.env.LIVE_NETWORKS) {
-  ropstenProvider = new HDWalletProvider(mnemonic, 'https://ropsten.infura.io/')
-  kovanProvider = new HDWalletProvider(mnemonic, 'https://kovan.infura.io')
+const configFilePath = (filename) =>
+  path.join(homedir(), `.aragon/${filename}`)
 
+const mnemonic = () => {
   try {
-    const { rpc, keys } = require(require('homedir')()+'/.aragon/rinkebykey.json')
-    rinkebyProvider = new HDWalletProviderPrivkey(keys, rpc)
+  return require(configFilePath('mnemonic.json').mnemonic)
   } catch (e) {
-    rinkebyProvider = new HDWalletProvider(mnemonic, 'https://rinkeby.infura.io')
+    return DEFAULT_MNEMONIC
   }
 }
+
+const settingsForNetwork = (network) => {
+  try {
+    return require(configFilePath(`${network}key.json`))
+  } catch (e) {
+    return { }
+  }
+}
+
+// Lazily loaded provider
+const providerForNetwork = (network) => (
+  () => {
+    let { rpc, keys } = settingsForNetwork(network)
+
+    rpc = rpc || defaultRPC(network)
+
+    if (!keys || keys.lenght == 0) {
+      return new HDWalletProvider(mnemonic(), rpc)
+    }
+
+    return new HDWalletProviderPrivkey(keys, rpc)
+  }
+)
 
 const mochaGasSettings = {
   reporter: 'eth-gas-reporter',
@@ -38,29 +59,35 @@ module.exports = {
       network_id: 15,
       host: 'localhost',
       port: 8545,
-      gas: 6.9e6,
+      gas: 6.9e6
     },
-    devnet: {
+    development: {
       network_id: 15,
       host: 'localhost',
       port: 8535,
-      gas: 6.9e6,
+      gas: 6.9e6
+    },
+    mainnet: {
+      network_id: 1,
+      provider: providerForNetwork('mainnet'),
+      gas: 7.9e6,
+      gasPrice: 3000000001
     },
     ropsten: {
       network_id: 3,
-      provider: ropstenProvider,
-      gas: 4.712e6,
-    },
-    kovan: {
-      network_id: 42,
-      provider: kovanProvider,
-      gas: 6.9e6,
+      provider: providerForNetwork('ropsten'),
+      gas: 4.712e6
     },
     rinkeby: {
       network_id: 4,
-      provider: rinkebyProvider,
+      provider: providerForNetwork('rinkeby'),
       gas: 6.9e6,
       gasPrice: 15000000001
+    },
+    kovan: {
+      network_id: 42,
+      provider: providerForNetwork('kovan'),
+      gas: 6.9e6
     },
     coverage: {
       host: "localhost",

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -14,7 +14,7 @@ const configFilePath = (filename) =>
 
 const mnemonic = () => {
   try {
-  return require(configFilePath('mnemonic.json').mnemonic)
+    return require(configFilePath('mnemonic.json').mnemonic)
   } catch (e) {
     return DEFAULT_MNEMONIC
   }
@@ -22,7 +22,7 @@ const mnemonic = () => {
 
 const settingsForNetwork = (network) => {
   try {
-    return require(configFilePath(`${network}key.json`))
+    return require(configFilePath(`${network}_key.json`))
   } catch (e) {
     return { }
   }
@@ -35,7 +35,7 @@ const providerForNetwork = (network) => (
 
     rpc = rpc || defaultRPC(network)
 
-    if (!keys || keys.lenght == 0) {
+    if (!keys || keys.length == 0) {
       return new HDWalletProvider(mnemonic(), rpc)
     }
 


### PR DESCRIPTION
Consolidates the configuration for different networks. It will now look for a key file for the network under `~/.aragon/[network]key.json` and use the keys and RPC specified in the file. If no keys are found, then it will default to using the user defined mnemonic or the default mnemonic. As for the RPC, it will use the one in the key file, and if that is not present, it will use the infura endpoint for the network.

Because we are now lazy loading providers, we can remove the need for having the `LIVE_NETWORKS` environment variable set to true when interacting with live networks, as if one of the networks that aren't being used cannot be connected to it is not a problem.