### PR TITLE
Kernel: allow initializing app proxies on overloaded newAppInstance

### DIFF
--- a/contracts/factory/APMRegistryFactory.sol
+++ b/contracts/factory/APMRegistryFactory.sol
@@ -55,18 +55,21 @@ contract APMRegistryFactory is APMRegistryConstants {
         acl.createPermission(this, dao, dao.APP_MANAGER_ROLE(), this);
 
         // Deploy app proxies
+        bytes memory noInit = new bytes(0);
         ENSSubdomainRegistrar ensSub = ENSSubdomainRegistrar(
             dao.newAppInstance(
                 keccak256(abi.encodePacked(node, keccak256(abi.encodePacked(ENS_SUB_APP_NAME)))),
                 ensSubdomainRegistrarBase,
-                false
+                false,
+                noInit
             )
         );
         APMRegistry apm = APMRegistry(
             dao.newAppInstance(
                 keccak256(abi.encodePacked(node, keccak256(abi.encodePacked(APM_APP_NAME)))),
                 registryBase,
-                false
+                false,
+                noInit
             )
         );
 

--- a/contracts/factory/APMRegistryFactory.sol
+++ b/contracts/factory/APMRegistryFactory.sol
@@ -60,16 +60,16 @@ contract APMRegistryFactory is APMRegistryConstants {
             dao.newAppInstance(
                 keccak256(abi.encodePacked(node, keccak256(abi.encodePacked(ENS_SUB_APP_NAME)))),
                 ensSubdomainRegistrarBase,
-                false,
-                noInit
+                noInit,
+                false
             )
         );
         APMRegistry apm = APMRegistry(
             dao.newAppInstance(
                 keccak256(abi.encodePacked(node, keccak256(abi.encodePacked(APM_APP_NAME)))),
                 registryBase,
-                false,
-                noInit
+                noInit,
+                false
             )
         );
 

--- a/contracts/factory/EVMScriptRegistryFactory.sol
+++ b/contracts/factory/EVMScriptRegistryFactory.sol
@@ -20,8 +20,8 @@ contract EVMScriptRegistryFactory is AppProxyFactory, EVMScriptRegistryConstants
     }
 
     function newEVMScriptRegistry(Kernel _dao) public returns (EVMScriptRegistry reg) {
-        reg = EVMScriptRegistry(_dao.newPinnedAppInstance(EVMSCRIPT_REGISTRY_APP_ID, baseReg, true));
-        reg.initialize();
+        bytes memory initPayload = abi.encodeWithSelector(reg.initialize.selector);
+        reg = EVMScriptRegistry(_dao.newPinnedAppInstance(EVMSCRIPT_REGISTRY_APP_ID, baseReg, true, initPayload));
 
         ACL acl = ACL(_dao.acl());
 

--- a/contracts/factory/EVMScriptRegistryFactory.sol
+++ b/contracts/factory/EVMScriptRegistryFactory.sol
@@ -21,7 +21,7 @@ contract EVMScriptRegistryFactory is AppProxyFactory, EVMScriptRegistryConstants
 
     function newEVMScriptRegistry(Kernel _dao) public returns (EVMScriptRegistry reg) {
         bytes memory initPayload = abi.encodeWithSelector(reg.initialize.selector);
-        reg = EVMScriptRegistry(_dao.newPinnedAppInstance(EVMSCRIPT_REGISTRY_APP_ID, baseReg, true, initPayload));
+        reg = EVMScriptRegistry(_dao.newPinnedAppInstance(EVMSCRIPT_REGISTRY_APP_ID, baseReg, initPayload, true));
 
         ACL acl = ACL(_dao.acl());
 

--- a/contracts/kernel/Kernel.sol
+++ b/contracts/kernel/Kernel.sol
@@ -59,7 +59,7 @@ contract Kernel is IKernel, KernelStorage, Petrifiable, IsContract, VaultRecover
         auth(APP_MANAGER_ROLE, arr(APP_BASES_NAMESPACE, _appId))
         returns (ERCProxy appProxy)
     {
-        return newAppInstance(_appId, _appBase, false, new bytes(0));
+        return newAppInstance(_appId, _appBase, new bytes(0), false);
     }
 
     /**
@@ -67,13 +67,13 @@ contract Kernel is IKernel, KernelStorage, Petrifiable, IsContract, VaultRecover
     *      implementation if it was not already set
     * @param _appId Identifier for app
     * @param _appBase Address of the app's base implementation
+    * @param _initializePayload Payload for call made by the proxy during its construction to initialize
     * @param _setDefault Whether the app proxy app is the default one.
     *        Useful when the Kernel needs to know of an instance of a particular app,
     *        like Vault for escape hatch mechanism.
-    * @param _initializePayload Payload for call made by the proxy on its constructor to initialize
     * @return AppProxy instance
     */
-    function newAppInstance(bytes32 _appId, address _appBase, bool _setDefault, bytes _initializePayload)
+    function newAppInstance(bytes32 _appId, address _appBase, bytes _initializePayload, bool _setDefault)
         public
         auth(APP_MANAGER_ROLE, arr(APP_BASES_NAMESPACE, _appId))
         returns (ERCProxy appProxy)
@@ -98,7 +98,7 @@ contract Kernel is IKernel, KernelStorage, Petrifiable, IsContract, VaultRecover
         auth(APP_MANAGER_ROLE, arr(APP_BASES_NAMESPACE, _appId))
         returns (ERCProxy appProxy)
     {
-        return newPinnedAppInstance(_appId, _appBase, false, new bytes(0));
+        return newPinnedAppInstance(_appId, _appBase, new bytes(0), false);
     }
 
     /**
@@ -106,13 +106,13 @@ contract Kernel is IKernel, KernelStorage, Petrifiable, IsContract, VaultRecover
     *      its base implementation if it was not already set
     * @param _appId Identifier for app
     * @param _appBase Address of the app's base implementation
+    * @param _initializePayload Payload for call made by the proxy during its construction to initialize
     * @param _setDefault Whether the app proxy app is the default one.
     *        Useful when the Kernel needs to know of an instance of a particular app,
     *        like Vault for escape hatch mechanism.
-    * @param _initializePayload Payload for call made by the proxy on its constructor to initialize
     * @return AppProxy instance
     */
-    function newPinnedAppInstance(bytes32 _appId, address _appBase, bool _setDefault, bytes _initializePayload)
+    function newPinnedAppInstance(bytes32 _appId, address _appBase, bytes _initializePayload, bool _setDefault)
         public
         auth(APP_MANAGER_ROLE, arr(APP_BASES_NAMESPACE, _appId))
         returns (ERCProxy appProxy)

--- a/contracts/kernel/Kernel.sol
+++ b/contracts/kernel/Kernel.sol
@@ -59,7 +59,7 @@ contract Kernel is IKernel, KernelStorage, Petrifiable, IsContract, VaultRecover
         auth(APP_MANAGER_ROLE, arr(APP_BASES_NAMESPACE, _appId))
         returns (ERCProxy appProxy)
     {
-        return newAppInstance(_appId, _appBase, false);
+        return newAppInstance(_appId, _appBase, false, new bytes(0));
     }
 
     /**
@@ -70,15 +70,16 @@ contract Kernel is IKernel, KernelStorage, Petrifiable, IsContract, VaultRecover
     * @param _setDefault Whether the app proxy app is the default one.
     *        Useful when the Kernel needs to know of an instance of a particular app,
     *        like Vault for escape hatch mechanism.
+    * @param _initializePayload Payload for call made by the proxy on its constructor to initialize
     * @return AppProxy instance
     */
-    function newAppInstance(bytes32 _appId, address _appBase, bool _setDefault)
+    function newAppInstance(bytes32 _appId, address _appBase, bool _setDefault, bytes _initializePayload)
         public
         auth(APP_MANAGER_ROLE, arr(APP_BASES_NAMESPACE, _appId))
         returns (ERCProxy appProxy)
     {
         _setAppIfNew(APP_BASES_NAMESPACE, _appId, _appBase);
-        appProxy = newAppProxy(this, _appId);
+        appProxy = newAppProxy(this, _appId, _initializePayload);
         // By calling setApp directly and not the internal functions, we make sure the params are checked
         // and it will only succeed if sender has permissions to set something to the namespace.
         if (_setDefault) {
@@ -97,7 +98,7 @@ contract Kernel is IKernel, KernelStorage, Petrifiable, IsContract, VaultRecover
         auth(APP_MANAGER_ROLE, arr(APP_BASES_NAMESPACE, _appId))
         returns (ERCProxy appProxy)
     {
-        return newPinnedAppInstance(_appId, _appBase, false);
+        return newPinnedAppInstance(_appId, _appBase, false, new bytes(0));
     }
 
     /**
@@ -108,15 +109,16 @@ contract Kernel is IKernel, KernelStorage, Petrifiable, IsContract, VaultRecover
     * @param _setDefault Whether the app proxy app is the default one.
     *        Useful when the Kernel needs to know of an instance of a particular app,
     *        like Vault for escape hatch mechanism.
+    * @param _initializePayload Payload for call made by the proxy on its constructor to initialize
     * @return AppProxy instance
     */
-    function newPinnedAppInstance(bytes32 _appId, address _appBase, bool _setDefault)
+    function newPinnedAppInstance(bytes32 _appId, address _appBase, bool _setDefault, bytes _initializePayload)
         public
         auth(APP_MANAGER_ROLE, arr(APP_BASES_NAMESPACE, _appId))
         returns (ERCProxy appProxy)
     {
         _setAppIfNew(APP_BASES_NAMESPACE, _appId, _appBase);
-        appProxy = newAppProxyPinned(this, _appId);
+        appProxy = newAppProxyPinned(this, _appId, _initializePayload);
         // By calling setApp directly and not the internal functions, we make sure the params are checked
         // and it will only succeed if sender has permissions to set something to the namespace.
         if (_setDefault) {

--- a/contracts/test/mocks/APMRegistryFactoryMock.sol
+++ b/contracts/test/mocks/APMRegistryFactoryMock.sol
@@ -38,16 +38,16 @@ contract APMRegistryFactoryMock is APMRegistryFactory {
             dao.newAppInstance(
                 keccak256(abi.encodePacked(node, keccak256(abi.encodePacked(ENS_SUB_APP_NAME)))),
                 ensSubdomainRegistrarBase,
-                false,
-                noInit
+                noInit,
+                false
             )
         );
         APMRegistry apm = APMRegistry(
             dao.newAppInstance(
                 keccak256(abi.encodePacked(node, keccak256(abi.encodePacked(APM_APP_NAME)))),
                 registryBase,
-                false,
-                noInit
+                noInit,
+                false
             )
         );
 

--- a/contracts/test/mocks/APMRegistryFactoryMock.sol
+++ b/contracts/test/mocks/APMRegistryFactoryMock.sol
@@ -33,19 +33,21 @@ contract APMRegistryFactoryMock is APMRegistryFactory {
         acl.createPermission(this, dao, dao.APP_MANAGER_ROLE(), this);
 
         // Deploy app proxies
-        // Deploy app proxies
+        bytes memory noInit = new bytes(0);
         ENSSubdomainRegistrar ensSub = ENSSubdomainRegistrar(
             dao.newAppInstance(
                 keccak256(abi.encodePacked(node, keccak256(abi.encodePacked(ENS_SUB_APP_NAME)))),
                 ensSubdomainRegistrarBase,
-                false
+                false,
+                noInit
             )
         );
         APMRegistry apm = APMRegistry(
             dao.newAppInstance(
                 keccak256(abi.encodePacked(node, keccak256(abi.encodePacked(APM_APP_NAME)))),
                 registryBase,
-                false
+                false,
+                noInit
             )
         );
 

--- a/contracts/test/mocks/KernelOverloadMock.sol
+++ b/contracts/test/mocks/KernelOverloadMock.sol
@@ -17,15 +17,15 @@ contract KernelOverloadMock {
         kernel = Kernel(_kernel);
     }
 
-    //function newAppInstance(bytes32 _name, address _appBase, bool _setDefault) auth(APP_MANAGER_ROLE, arr(APP_BASES_NAMESPACE, _name)) public returns (ERCProxy appProxy) {
-    function newAppInstance(bytes32 _name, address _appBase, bool _setDefault) public returns (ERCProxy appProxy) {
-        appProxy = kernel.newAppInstance(_name, _appBase, _setDefault);
+    //function newAppInstance(bytes32 _name, address _appBase, bool _setDefault, bytes _initializePayload) auth(APP_MANAGER_ROLE, arr(APP_BASES_NAMESPACE, _name)) public returns (ERCProxy appProxy) {
+    function newAppInstance(bytes32 _name, address _appBase, bool _setDefault, bytes _initializePayload) public returns (ERCProxy appProxy) {
+        appProxy = kernel.newAppInstance(_name, _appBase, _setDefault, _initializePayload);
         emit NewAppProxy(appProxy);
     }
 
-    // function newPinnedAppInstance(bytes32 _name, address _appBase) auth(APP_MANAGER_ROLE, arr(APP_BASES_NAMESPACE, _name)) public returns (ERCProxy appProxy) {
-    function newPinnedAppInstance(bytes32 _name, address _appBase, bool _setDefault) public returns (ERCProxy appProxy) {
-        appProxy = kernel.newPinnedAppInstance(_name, _appBase, _setDefault);
+    // function newPinnedAppInstance(bytes32 _name, address _appBase, bool _setDefault, bytes _initializePayload) auth(APP_MANAGER_ROLE, arr(APP_BASES_NAMESPACE, _name)) public returns (ERCProxy appProxy) {
+    function newPinnedAppInstance(bytes32 _name, address _appBase, bool _setDefault, bytes _initializePayload) public returns (ERCProxy appProxy) {
+        appProxy = kernel.newPinnedAppInstance(_name, _appBase, _setDefault, _initializePayload);
         emit NewAppProxy(appProxy);
     }
 }

--- a/contracts/test/mocks/KernelOverloadMock.sol
+++ b/contracts/test/mocks/KernelOverloadMock.sol
@@ -17,15 +17,15 @@ contract KernelOverloadMock {
         kernel = Kernel(_kernel);
     }
 
-    //function newAppInstance(bytes32 _name, address _appBase, bool _setDefault, bytes _initializePayload) auth(APP_MANAGER_ROLE, arr(APP_BASES_NAMESPACE, _name)) public returns (ERCProxy appProxy) {
-    function newAppInstance(bytes32 _name, address _appBase, bool _setDefault, bytes _initializePayload) public returns (ERCProxy appProxy) {
-        appProxy = kernel.newAppInstance(_name, _appBase, _setDefault, _initializePayload);
+    //function newAppInstance(bytes32 _name, address _appBase, bytes _initializePayload, bool _setDefault) auth(APP_MANAGER_ROLE, arr(APP_BASES_NAMESPACE, _name)) public returns (ERCProxy appProxy) {
+    function newAppInstance(bytes32 _name, address _appBase, bytes _initializePayload, bool _setDefault) public returns (ERCProxy appProxy) {
+        appProxy = kernel.newAppInstance(_name, _appBase, _initializePayload, _setDefault);
         emit NewAppProxy(appProxy);
     }
 
-    // function newPinnedAppInstance(bytes32 _name, address _appBase, bool _setDefault, bytes _initializePayload) auth(APP_MANAGER_ROLE, arr(APP_BASES_NAMESPACE, _name)) public returns (ERCProxy appProxy) {
-    function newPinnedAppInstance(bytes32 _name, address _appBase, bool _setDefault, bytes _initializePayload) public returns (ERCProxy appProxy) {
-        appProxy = kernel.newPinnedAppInstance(_name, _appBase, _setDefault, _initializePayload);
+    // function newPinnedAppInstance(bytes32 _name, address _appBase, bytes _initializePayload, bool _setDefault) auth(APP_MANAGER_ROLE, arr(APP_BASES_NAMESPACE, _name)) public returns (ERCProxy appProxy) {
+    function newPinnedAppInstance(bytes32 _name, address _appBase, bytes _initializePayload, bool _setDefault) public returns (ERCProxy appProxy) {
+        appProxy = kernel.newPinnedAppInstance(_name, _appBase, _initializePayload, _setDefault);
         emit NewAppProxy(appProxy);
     }
 }

--- a/test/kernel_apps.js
+++ b/test/kernel_apps.js
@@ -145,7 +145,7 @@ contract('Kernel apps', accounts => {
                         const kernelMock = await KernelOverloadMock.new(kernel.address)
 
                         await withAppManagerPermission(kernelMock.address, async () => {
-                            const receipt = await kernelMock[newInstanceFn](APP_ID, appBase1.address, true, '0x')
+                            const receipt = await kernelMock[newInstanceFn](APP_ID, appBase1.address, '0x', true)
                             appProxyAddr = receipt.logs.filter(l => l.event == 'NewAppProxy')[0].args.proxy
                         })
 
@@ -166,7 +166,7 @@ contract('Kernel apps', accounts => {
                         const initData = appBase1.initialize.request().params[0].data
 
                         await withAppManagerPermission(kernelMock.address, async () => {
-                            const receipt = await kernelMock[newInstanceFn](APP_ID, appBase1.address, false, initData)
+                            const receipt = await kernelMock[newInstanceFn](APP_ID, appBase1.address, initData, false)
                             appProxyAddr = receipt.logs.filter(l => l.event == 'NewAppProxy')[0].args.proxy
                         })
 


### PR DESCRIPTION
`AppProxyFactory` exposes the ability to pass an initialization payload that app proxies execute on their constructor. This PR exposes this ability at the Kernel level, so apps can be atomically initialized when they are created.