### PR TITLE
Modular deployment scripts

### DIFF
--- a/scripts/deploy-beta-apm.js
+++ b/scripts/deploy-beta-apm.js
@@ -1,63 +1,104 @@
 const namehash = require('eth-ens-namehash').hash
 const keccak256 = require('js-sha3').keccak_256
 
-const APMRegistryFactory = artifacts.require('APMRegistryFactory')
-const DAOFactory = artifacts.require('DAOFactory')
-const ENS = artifacts.require('ENS')
+const deployENS = require('./deploy-beta-ens')
 
-const owner = process.env.OWNER || '0x4cb3fd420555a09ba98845f0b816e45cfb230983'
-const ens = process.env.ENS || '0xfbae32d1cde62858bc45f51efc8cc4fa1415447e'
+const globalArtifacts = this.artifacts // Not injected unless called directly via truffle
 
-const tld = namehash('eth')
-const label = '0x'+keccak256('aragonpm')
-
-const getContract = name => artifacts.require(name)
+const defaultOwner = process.env.OWNER || '0x4cb3fd420555a09ba98845f0b816e45cfb230983'
+const defaultENS = process.env.ENS
 
 const baseInitArguments = {
   Kernel: [ true ] // petrify
 }
 
-const deployBases = async baseNames => {
-  const baseContracts = await Promise.all(baseNames.map(c => getContract(c).new(...(baseInitArguments[c] || []))))
-  return baseContracts.map(c => c.address)
+const deployBases = async baseContracts => {
+  const deployedContracts = await Promise.all(baseContracts.map(c => c.new(...(baseInitArguments[c.contractName] || []))))
+  return deployedContracts.map(c => c.address)
 }
 
-module.exports = async callback => {
-  console.log('Deploying APM')
-  console.log('Owner:', owner)
-  console.log('ENS:', ens)
-  console.log('TLD:', tld)
-  console.log('Label:', label)
+module.exports = async (truffleExecCallback, { artifacts = globalArtifacts, ens = defaultENS, owner = defaultOwner, verbose = true } = {}) => {
+  const log = (...args) => {
+    if (verbose) { console.log(...args) }
+  }
 
-  console.log('=========')
-  console.log('deploying APM bases')
-  const apmBases = await deployBases(['APMRegistry', 'Repo', 'ENSSubdomainRegistrar'])
-  console.log('deployed APM bases', apmBases)
+  const ACL = artifacts.require('ACL')
+  const Kernel = artifacts.require('Kernel')
+  const APMRegistry = artifacts.require('APMRegistry')
+  const Repo = artifacts.require('Repo')
+  const ENSSubdomainRegistrar = artifacts.require('ENSSubdomainRegistrar')
 
-  console.log('deploying DAO bases')
-  const daoBases = await deployBases(['Kernel', 'ACL'])
-  console.log('deployed DAO bases', daoBases)
+  const APMRegistryFactory = artifacts.require('APMRegistryFactory')
+  const DAOFactory = artifacts.require('DAOFactory')
+  const ENS = artifacts.require('ENS')
 
-  console.log('deploying DAOFactory')
+  const tldName = 'eth'
+  const labelName = 'aragonpm'
+  const tldHash = namehash(tldName)
+  const labelHash = '0x'+keccak256(labelName)
+
+  log('Deploying APM...')
+  log('Owner:', owner)
+
+  if (!ens) {
+    log('=========')
+    log('Missing ENS! Deploying a custom ENS...')
+    ens = (await deployENS(null, { artifacts, owner, verbose: false })).ens
+  } else {
+    ens = ENS.at(ens)
+  }
+
+  log('ENS:', ens.address)
+  log(`TLD: ${tldName} (${tldHash})`)
+  log(`Label: ${labelName} (${labelHash})`)
+
+  log('=========')
+  log('Deploying APM bases...')
+  const apmBases = await deployBases([APMRegistry, Repo, ENSSubdomainRegistrar])
+  log('Deployed APM bases:', apmBases)
+
+  log('Deploying DAO bases...')
+  const daoBases = await deployBases([Kernel, ACL])
+  log('Deployed DAO bases', daoBases)
+
+  log('Deploying DAOFactory without EVMScripts...')
   const evmScriptRegistry = '0x00' // Basic APM needs no forwarding
   const daoFactory = await DAOFactory.new(...daoBases, evmScriptRegistry)
-  console.log('deployed DAOFactory', daoFactory.address)
+  log('Deployed DAOFactory:', daoFactory.address)
 
-  console.log('deploying APMRegistryFactory')
-  const apmFactory = await APMRegistryFactory.new(daoFactory.address, ...apmBases, ens, '0x00')
-  console.log('deployed APMRegistryFactory', apmFactory.address)
+  log('Deploying APMRegistryFactory...')
+  const apmFactory = await APMRegistryFactory.new(daoFactory.address, ...apmBases, ens.address, '0x00')
+  log('Deployed APMRegistryFactory:', apmFactory.address)
 
-  console.log('assigning ENS name to factory')
-  await ENS.at(ens).setSubnodeOwner(tld, label, apmFactory.address)
+  log(`Assigning ENS name (${labelName}.${tldName}) to factory...`)
+  try {
+    await ens.setSubnodeOwner(tldHash, labelHash, apmFactory.address)
+  } catch (err) {
+    console.error(
+      `Error: could not set the owner of '${labelName}.${tldName}' on the given ENS instance`,
+      `(${ens.address}). Make sure you have ownership rights over the subdomain.`
+    )
+    throw err
+  }
 
-  console.log('deploying APM')
-  const receipt = await apmFactory.newAPM(tld, label, owner)
+  log('Deploying APM...')
+  const receipt = await apmFactory.newAPM(tldHash, labelHash, owner)
 
-  console.log('=========')
+  log('=========')
   const apmAddr = receipt.logs.filter(l => l.event == 'DeployAPM')[0].args.apm
-  console.log('deployed APM:', apmAddr)
-  console.log(apmAddr)
-  callback()
+  log('Deployed APM:', apmAddr)
+  log(apmAddr)
+
+  if (typeof truffleExecCallback === 'function') {
+    // Called directly via `truffle exec`
+    truffleExecCallback()
+  } else {
+    return {
+      apmFactory,
+      ens,
+      apm: APM.at(apmAddr),
+    }
+  }
 }
 
 // Rinkeby APM: 0x700569b6c99b8b5fa17b7976a26ae2f0d5fd145c

--- a/scripts/deploy-beta-ens.js
+++ b/scripts/deploy-beta-ens.js
@@ -1,19 +1,35 @@
-const ENSFactory = artifacts.require('ENSFactory')
+const globalArtifacts = this.artifacts // Not injected unless called directly via truffle
 
-const owner = process.env.OWNER || '0x4cb3fd420555a09ba98845f0b816e45cfb230983'
+const defaultOwner = process.env.OWNER || '0x4cb3fd420555a09ba98845f0b816e45cfb230983'
 
-module.exports = async callback => {
-  console.log('deploying factory')
+module.exports = async (truffleExecCallback, { artifacts = globalArtifacts, owner = defaultOwner, verbose = true } = {}) => {
+  const log = (...args) => {
+    if (verbose) { console.log(...args) }
+  }
+
+  const ENS = artifacts.require('ENS')
+  const ENSFactory = artifacts.require('ENSFactory')
+
+  log('Deploying ENSFactory...')
   const factory = await ENSFactory.new()
-  console.log('factory deployed', factory.address)
+  log('ENSFactory deployed:', factory.address)
   const receipt = await factory.newENS(owner)
 
-  const ens = receipt.logs.filter(l => l.event == 'DeployENS')[0].args.ens
-  console.log('====================')
-  console.log('Deployed ENS:', ens)
+  const ensAddr = receipt.logs.filter(l => l.event == 'DeployENS')[0].args.ens
+  log('====================')
+  log('Deployed ENS:', ensAddr)
 
-  console.log(ens)
-  callback()
+  log(ensAddr)
+
+  if (typeof truffleExecCallback === 'function') {
+    // Called directly via `truffle exec`
+    truffleExecCallback()
+  } else {
+    return {
+      ens: ENS.at(ensAddr),
+      ensFactory: factory,
+    }
+  }
 }
 
 // Rinkeby ENS: 0xfbae32d1cde62858bc45f51efc8cc4fa1415447e

--- a/scripts/deploy-daofactory.js
+++ b/scripts/deploy-daofactory.js
@@ -1,0 +1,32 @@
+const globalArtifacts = this.artifacts // Not injected unless called directly via truffle
+
+module.exports = async (truffleExecCallback, { artifacts = globalArtifacts, verbose = true } = {}) => {
+  const log = (...args) => {
+    if (verbose) { console.log(...args) }
+  }
+
+  const ACL = artifacts.require('ACL')
+  const Kernel = artifacts.require('Kernel')
+
+  const DAOFactory = artifacts.require('DAOFactory')
+  const EVMScriptRegistryFactory = artifacts.require('EVMScriptRegistryFactory')
+
+  log('Deploying DAOFactory with bases...')
+  const kernelBase = await Kernel.new(true) // immediately petrify
+  const aclBase = await ACL.new()
+  const evmScriptRegistryFactory = await EVMScriptRegistryFactory.new()
+  const daoFactory = await DAOFactory.new(kernelBase.address, aclBase.address, evmScriptRegistryFactory.address)
+  log('DAOFactory deployed:', daoFactory.address)
+
+  if (typeof truffleExecCallback === 'function') {
+    // Called directly via `truffle exec`
+    truffleExecCallback()
+  } else {
+    return {
+      aclBase,
+      daoFactory,
+      evmScriptRegistryFactory,
+      kernelBase,
+    }
+  }
+}


### PR DESCRIPTION
Adds optional parameters to the deployment scripts to allow them to be used by other scripts being executed by `truffle exec`.

`deploy-beta-apm.js` automatically deploys a custom ENS if none is provided.

Also adds a script for deploying `DAOFactory`.