### PR TITLE
Check that the owner of the TLD is the APMRegistryFactory itself before setSubnodeOwner

### DIFF
--- a/contracts/factory/APMRegistryFactory.sol
+++ b/contracts/factory/APMRegistryFactory.sol
@@ -46,6 +46,7 @@ contract APMRegistryFactory is APMRegistryConstants {
         // Assume it is the test ENS
         if (ens.owner(node) != address(this)) {
             // If we weren't in test ens and factory doesn't have ownership, will fail
+            require(ens.owner(_tld) == address(this));
             ens.setSubnodeOwner(_tld, _label, this);
         }
 


### PR DESCRIPTION
Verify that the owner of the TLD is the APMRegistryFactory itself before setSubnodeOwner is invoked.

The [ENS.sol](https://github.com/aragon/aragonOS/blob/dev/contracts/lib/ens/ENS.sol) from lib has the modifier `only_owner` that throws in case `setSubnodeOwner` is invoked by someone who isn't the owner.

However it seems that this isn't the behavior of the ENS-Registry (0x314159265dD8dbb310642f98f50C066173C1259b) which doesn't make a throw/revert. It returns a "Bad jump destination" so it won't refund the remaining gas