### PR TITLE
Publish ABI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ allFiredEvents
 scTopics
 
 # truffle build artifacts
+abi/
 build/
 bytecode/
 bytecode_new/

--- a/package.json
+++ b/package.json
@@ -12,12 +12,14 @@
     "ganache-cli:test": "scripts/ganache-cli.sh",
     "deploy:devnet:ens": "truffle compile && truffle exec --network devnet scripts/deploy-beta-ens.js",
     "deploy:devnet:apm": "truffle compile && truffle exec --network devnet scripts/deploy-beta-apm.js",
+    "abi:extract": "truffle-extract --output abi/ --keys abi",
     "bytecode:extract": "truffle-bytecode extract -o bytecode",
     "bytecode:extract:new": "truffle-bytecode extract -o bytecode_new",
     "bytecode:compare": "npm run bytecode:extract:new && truffle-bytecode compare bytecode bytecode_new",
-    "prepublishOnly": "truffle compile --all"
+    "prepublishOnly": "truffle compile --all && npm run abi:extract -- --no-compile"
   },
   "files": [
+    "abi/",
     "build/",
     "contracts/",
     "scripts/",
@@ -41,6 +43,7 @@
     "solium": "^1.1.8",
     "truffle": "4.1.14",
     "truffle-bytecode-manager": "^1.1.1",
+    "truffle-extract": "^1.2.1",
     "web3-utils": "1.0.0-beta.33"
   },
   "dependencies": {


### PR DESCRIPTION
Fixes #369.

Extracts the abi on publish, so that frontends don't have to include the entire build artifact in their bundles.

Example extracted abi (for `Petrify.sol`):

```
{
  "abi": [
    {
      "constant": true,
      "inputs": [],
      "name": "hasInitialized",
      "outputs": [
        {
          "name": "",
          "type": "bool"
        }
      ],
      "payable": false,
      "stateMutability": "view",
      "type": "function"
    },
    {
      "constant": true,
      "inputs": [],
      "name": "getInitializationBlock",
      "outputs": [
        {
          "name": "",
          "type": "uint256"
        }
      ],
      "payable": false,
      "stateMutability": "view",
      "type": "function"
    },
    {
      "constant": true,
      "inputs": [],
      "name": "isPetrified",
      "outputs": [
        {
          "name": "",
          "type": "bool"
        }
      ],
      "payable": false,
      "stateMutability": "view",
      "type": "function"
    }
  ]
}
```