### PR TITLE
Enable optimization for 10k runs

### DIFF
--- a/truffle-config.js
+++ b/truffle-config.js
@@ -99,4 +99,10 @@ module.exports = {
   },
   build: {},
   mocha,
+  solc: {
+    optimizer: {
+      enabled: true,
+      runs: 10000
+    }
+  },
 }


### PR DESCRIPTION
Fixes #389.

As far as I can tell from the gas test reporter and bytecode comparisons, we never lose at 10k runs. However, the gas test reporter is unreliable due to it also includes the deployment cost in a lot of cases (which are always lower).