### PR TITLE
Deployment: use DAOFactory deployment in APM deployment

### DIFF
--- a/scripts/deploy-beta-apm.js
+++ b/scripts/deploy-beta-apm.js
@@ -6,6 +6,8 @@ const deployDaoFactory = require('./deploy-daofactory')
 
 const globalArtifacts = this.artifacts // Not injected unless called directly via truffle
 
+const ZERO_ADDR = '0x0000000000000000000000000000000000000000'
+
 const defaultOwner = process.env.OWNER || '0x4cb3fd420555a09ba98845f0b816e45cfb230983'
 const defaultDaoFactoryAddress = process.env.DAO_FACTORY
 const defaultENSAddress = process.env.ENS
@@ -67,10 +69,12 @@ module.exports = async (
 
   let daoFactory
   if (daoFactoryAddress) {
-    log('Using provided DAOFactory:', daoFactoryAddress)
     daoFactory = DAOFactory.at(daoFactoryAddress)
+    const hasEVMScripts = await daoFactory.regFactory() !== ZERO_ADDR
+
+    log(`Using provided DAOFactory (with${hasEVMScripts ? '' : 'out' } EVMScripts):`, daoFactoryAddress)
   } else {
-    log('Deploying DAOFactory without EVMScripts...')
+    log('Deploying DAOFactory with EVMScripts...')
     daoFactory = (await deployDaoFactory(null, { artifacts, withEvmScriptRegistryFactory: true, verbose: false })).daoFactory
     log('Deployed DAOFactory:', daoFactory.address)
   }

--- a/scripts/deploy-beta-apm.js
+++ b/scripts/deploy-beta-apm.js
@@ -71,7 +71,7 @@ module.exports = async (
     daoFactory = DAOFactory.at(daoFactoryAddress)
   } else {
     log('Deploying DAOFactory without EVMScripts...')
-    daoFactory = (await deployDaoFactory(null, { artifacts, withEvmScriptRegistryFactory: false, verbose: false })).daoFactory
+    daoFactory = (await deployDaoFactory(null, { artifacts, withEvmScriptRegistryFactory: true, verbose: false })).daoFactory
     log('Deployed DAOFactory:', daoFactory.address)
   }
 

--- a/scripts/deploy-beta-apm.js
+++ b/scripts/deploy-beta-apm.js
@@ -2,18 +2,15 @@ const namehash = require('eth-ens-namehash').hash
 const keccak256 = require('js-sha3').keccak_256
 
 const deployENS = require('./deploy-beta-ens')
+const deployDaoFactory = require('./deploy-daofactory')
 
 const globalArtifacts = this.artifacts // Not injected unless called directly via truffle
 
 const defaultOwner = process.env.OWNER || '0x4cb3fd420555a09ba98845f0b816e45cfb230983'
 const defaultENSAddress = process.env.ENS
 
-const baseInitArguments = {
-  Kernel: [ true ] // petrify
-}
-
 const deployBases = async baseContracts => {
-  const deployedContracts = await Promise.all(baseContracts.map(c => c.new(...(baseInitArguments[c.contractName] || []))))
+  const deployedContracts = await Promise.all(baseContracts.map(c => c.new()))
   return deployedContracts.map(c => c.address)
 }
 
@@ -30,14 +27,11 @@ module.exports = async (
     if (verbose) { console.log(...args) }
   }
 
-  const ACL = artifacts.require('ACL')
-  const Kernel = artifacts.require('Kernel')
   const APMRegistry = artifacts.require('APMRegistry')
   const Repo = artifacts.require('Repo')
   const ENSSubdomainRegistrar = artifacts.require('ENSSubdomainRegistrar')
 
   const APMRegistryFactory = artifacts.require('APMRegistryFactory')
-  const DAOFactory = artifacts.require('DAOFactory')
   const ENS = artifacts.require('ENS')
 
   const tldName = 'eth'
@@ -66,13 +60,8 @@ module.exports = async (
   const apmBases = await deployBases([APMRegistry, Repo, ENSSubdomainRegistrar])
   log('Deployed APM bases:', apmBases)
 
-  log('Deploying DAO bases...')
-  const daoBases = await deployBases([Kernel, ACL])
-  log('Deployed DAO bases', daoBases)
-
   log('Deploying DAOFactory without EVMScripts...')
-  const evmScriptRegistry = '0x00' // Basic APM needs no forwarding
-  const daoFactory = await DAOFactory.new(...daoBases, evmScriptRegistry)
+  const daoFactory = (await deployDaoFactory(null, { artifacts, withEvmScripts: false, verbose: false })).daoFactory
   log('Deployed DAOFactory:', daoFactory.address)
 
   log('Deploying APMRegistryFactory...')

--- a/scripts/deploy-daofactory.js
+++ b/scripts/deploy-daofactory.js
@@ -1,6 +1,13 @@
 const globalArtifacts = this.artifacts // Not injected unless called directly via truffle
 
-module.exports = async (truffleExecCallback, { artifacts = globalArtifacts, verbose = true } = {}) => {
+module.exports = async (
+  truffleExecCallback,
+  {
+    artifacts = globalArtifacts,
+    withEvmScripts = true,
+    verbose = true
+  } = {}
+) => {
   const log = (...args) => {
     if (verbose) { console.log(...args) }
   }
@@ -9,13 +16,20 @@ module.exports = async (truffleExecCallback, { artifacts = globalArtifacts, verb
   const Kernel = artifacts.require('Kernel')
 
   const DAOFactory = artifacts.require('DAOFactory')
-  const EVMScriptRegistryFactory = artifacts.require('EVMScriptRegistryFactory')
 
   log('Deploying DAOFactory with bases...')
   const kernelBase = await Kernel.new(true) // immediately petrify
   const aclBase = await ACL.new()
-  const evmScriptRegistryFactory = await EVMScriptRegistryFactory.new()
-  const daoFactory = await DAOFactory.new(kernelBase.address, aclBase.address, evmScriptRegistryFactory.address)
+  let evmScriptRegistryFactory
+  if (withEvmScripts) {
+    const EVMScriptRegistryFactory = artifacts.require('EVMScriptRegistryFactory')
+    evmScriptRegistryFactory = await EVMScriptRegistryFactory.new()
+  }
+  const daoFactory = await DAOFactory.new(
+    kernelBase.address,
+    aclBase.address,
+    evmScriptRegistryFactory ? evmScriptRegistryFactory.address : '0x00'
+  )
   log('DAOFactory deployed:', daoFactory.address)
 
   if (typeof truffleExecCallback === 'function') {


### PR DESCRIPTION
Makes the DAOFactory deployment script accept a parameter to not deploy an `EVMScriptRegistryFactory`, and changes the APM deployment script to directly use the DAOFactory deployment script.