### PR TITLE
Fix visibility order for constants

### DIFF
--- a/contracts/acl/ACL.sol
+++ b/contracts/acl/ACL.sol
@@ -31,12 +31,12 @@ contract ACL is IACL, TimeHelpers, AragonApp, ACLHelpers {
         // op and id take less than 1 byte each so it can be kept in 1 sstore
     }
 
-    uint8 constant BLOCK_NUMBER_PARAM_ID = 200;
-    uint8 constant TIMESTAMP_PARAM_ID    = 201;
+    uint8 constant internal BLOCK_NUMBER_PARAM_ID = 200;
+    uint8 constant internal TIMESTAMP_PARAM_ID    = 201;
     // 202 is unused
-    uint8 constant ORACLE_PARAM_ID       = 203;
-    uint8 constant LOGIC_OP_PARAM_ID     = 204;
-    uint8 constant PARAM_VALUE_PARAM_ID  = 205;
+    uint8 constant internal ORACLE_PARAM_ID       = 203;
+    uint8 constant internal LOGIC_OP_PARAM_ID     = 204;
+    uint8 constant internal PARAM_VALUE_PARAM_ID  = 205;
     // TODO: Add execution times param type?
 
     // Hardcoded constant to save gas
@@ -44,7 +44,8 @@ contract ACL is IACL, TimeHelpers, AragonApp, ACLHelpers {
     bytes32 constant public EMPTY_PARAM_HASH = 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563;
     bytes32 constant public NO_PERMISSION = bytes32(0);
     address constant public ANY_ENTITY = address(-1);
-    uint256 constant ORACLE_CHECK_GAS = 30000;
+
+    uint256 constant internal ORACLE_CHECK_GAS = 30000;
 
     modifier onlyPermissionManager(address _app, bytes32 _role) {
         require(msg.sender == getPermissionManager(_app, _role));

--- a/contracts/acl/ACL.sol
+++ b/contracts/acl/ACL.sol
@@ -11,8 +11,8 @@ import "./IACLOracle.sol";
 // Allow public initialize() to be first
 contract ACL is IACL, TimeHelpers, AragonApp, ACLHelpers {
     // Hardcoded constant to save gas
-    //bytes32 constant public CREATE_PERMISSIONS_ROLE = keccak256("CREATE_PERMISSIONS_ROLE");
-    bytes32 constant public CREATE_PERMISSIONS_ROLE = 0x0b719b33c83b8e5d300c521cb8b54ae9bd933996a14bef8c2f4e0285d2d2400a;
+    //bytes32 public constant CREATE_PERMISSIONS_ROLE = keccak256("CREATE_PERMISSIONS_ROLE");
+    bytes32 public constant CREATE_PERMISSIONS_ROLE = 0x0b719b33c83b8e5d300c521cb8b54ae9bd933996a14bef8c2f4e0285d2d2400a;
 
     // Whether someone has a permission
     mapping (bytes32 => bytes32) internal permissions; // permissions hash => params hash
@@ -31,21 +31,21 @@ contract ACL is IACL, TimeHelpers, AragonApp, ACLHelpers {
         // op and id take less than 1 byte each so it can be kept in 1 sstore
     }
 
-    uint8 constant internal BLOCK_NUMBER_PARAM_ID = 200;
-    uint8 constant internal TIMESTAMP_PARAM_ID    = 201;
+    uint8 internal constant BLOCK_NUMBER_PARAM_ID = 200;
+    uint8 internal constant TIMESTAMP_PARAM_ID    = 201;
     // 202 is unused
-    uint8 constant internal ORACLE_PARAM_ID       = 203;
-    uint8 constant internal LOGIC_OP_PARAM_ID     = 204;
-    uint8 constant internal PARAM_VALUE_PARAM_ID  = 205;
+    uint8 internal constant ORACLE_PARAM_ID       = 203;
+    uint8 internal constant LOGIC_OP_PARAM_ID     = 204;
+    uint8 internal constant PARAM_VALUE_PARAM_ID  = 205;
     // TODO: Add execution times param type?
 
     // Hardcoded constant to save gas
-    //bytes32 constant public EMPTY_PARAM_HASH = keccak256(uint256(0));
-    bytes32 constant public EMPTY_PARAM_HASH = 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563;
-    bytes32 constant public NO_PERMISSION = bytes32(0);
-    address constant public ANY_ENTITY = address(-1);
+    //bytes32 public constant EMPTY_PARAM_HASH = keccak256(uint256(0));
+    bytes32 public constant EMPTY_PARAM_HASH = 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563;
+    bytes32 public constant NO_PERMISSION = bytes32(0);
+    address public constant ANY_ENTITY = address(-1);
 
-    uint256 constant internal ORACLE_CHECK_GAS = 30000;
+    uint256 internal constant ORACLE_CHECK_GAS = 30000;
 
     modifier onlyPermissionManager(address _app, bytes32 _role) {
         require(msg.sender == getPermissionManager(_app, _role));

--- a/contracts/apm/APMNamehash.sol
+++ b/contracts/apm/APMNamehash.sol
@@ -8,7 +8,7 @@ import "../ens/ENSConstants.sol";
 
 
 contract APMNamehash is ENSConstants {
-    bytes32 constant public APM_NODE = keccak256(abi.encodePacked(ETH_TLD_NODE, keccak256("aragonpm")));
+    bytes32 public constant APM_NODE = keccak256(abi.encodePacked(ETH_TLD_NODE, keccak256("aragonpm")));
 
     function apmNamehash(string name) internal pure returns (bytes32) {
         return keccak256(abi.encodePacked(APM_NODE, keccak256(bytes(name))));

--- a/contracts/apm/APMRegistry.sol
+++ b/contracts/apm/APMRegistry.sol
@@ -11,9 +11,9 @@ import "./Repo.sol";
 contract APMRegistryConstants {
     // Cant have a regular APM appId because it is used to build APM
     // TODO: recheck this
-    string constant public APM_APP_NAME = "apm-registry";
-    string constant public REPO_APP_NAME = "apm-repo";
-    string constant public ENS_SUB_APP_NAME = "apm-enssub";
+    string public constant APM_APP_NAME = "apm-registry";
+    string public constant REPO_APP_NAME = "apm-repo";
+    string public constant ENS_SUB_APP_NAME = "apm-enssub";
 }
 
 
@@ -21,8 +21,8 @@ contract APMRegistry is AragonApp, AppProxyFactory, APMRegistryConstants {
     AbstractENS public ens;
     ENSSubdomainRegistrar public registrar;
 
-    // bytes32 constant public CREATE_REPO_ROLE = keccak256("CREATE_REPO_ROLE");
-    bytes32 constant public CREATE_REPO_ROLE = 0x2a9494d64846c9fdbf0158785aa330d8bc9caf45af27fa0e8898eb4d55adcea6;
+    // bytes32 public constant CREATE_REPO_ROLE = keccak256("CREATE_REPO_ROLE");
+    bytes32 public constant CREATE_REPO_ROLE = 0x2a9494d64846c9fdbf0158785aa330d8bc9caf45af27fa0e8898eb4d55adcea6;
 
     event NewRepo(bytes32 id, string name, address repo);
 

--- a/contracts/apm/Repo.sol
+++ b/contracts/apm/Repo.sol
@@ -16,8 +16,8 @@ contract Repo is AragonApp {
     mapping (bytes32 => uint256) internal versionIdForSemantic;
     mapping (address => uint256) internal latestVersionIdForContract;
 
-    // bytes32 constant public CREATE_VERSION_ROLE = keccak256("CREATE_VERSION_ROLE");
-    bytes32 constant public CREATE_VERSION_ROLE = 0x1f56cfecd3595a2e6cc1a7e6cb0b20df84cdbd92eff2fee554e70e4e45a9a7d8;
+    // bytes32 public constant CREATE_VERSION_ROLE = keccak256("CREATE_VERSION_ROLE");
+    bytes32 public constant CREATE_VERSION_ROLE = 0x1f56cfecd3595a2e6cc1a7e6cb0b20df84cdbd92eff2fee554e70e4e45a9a7d8;
 
     event NewVersion(uint256 versionId, uint16[3] semanticVersion);
 

--- a/contracts/apps/AppProxyPinned.sol
+++ b/contracts/apps/AppProxyPinned.sol
@@ -8,7 +8,7 @@ import "./AppProxyBase.sol";
 contract AppProxyPinned is IsContract, AppProxyBase {
     using UnstructuredStorage for bytes32;
 
-    // keccak256("aragonOS.appStorage.pinnedCode"), used by Proxy Pinned
+    // keccak256("aragonOS.appStorage.pinnedCode")
     bytes32 internal constant PINNED_CODE_POSITION = 0xdee64df20d65e53d7f51cb6ab6d921a0a6a638a91e942e1d8d02df28e31c038e;
 
     /**

--- a/contracts/common/DelegateProxy.sol
+++ b/contracts/common/DelegateProxy.sol
@@ -5,7 +5,7 @@ import "../lib/misc/ERCProxy.sol";
 
 
 contract DelegateProxy is ERCProxy, IsContract {
-    uint256 constant public FWD_GAS_LIMIT = 10000;
+    uint256 public constant FWD_GAS_LIMIT = 10000;
 
     /**
     * @dev Performs a delegatecall and returns whatever the delegatecall returned (entire context execution will return!)

--- a/contracts/common/EtherTokenConstant.sol
+++ b/contracts/common/EtherTokenConstant.sol
@@ -8,5 +8,5 @@ pragma solidity ^0.4.24;
 // aragonOS and aragon-apps rely on address(0) to denote native ETH, in
 // contracts where both tokens and ETH are accepted
 contract EtherTokenConstant {
-    address constant public ETH = address(0);
+    address public constant ETH = address(0);
 }

--- a/contracts/common/Petrifiable.sol
+++ b/contracts/common/Petrifiable.sol
@@ -9,7 +9,7 @@ import "./Initializable.sol";
 
 contract Petrifiable is Initializable {
     // Use block UINT256_MAX (which should be never) as the initializable date
-    uint256 constant internal PETRIFIED_BLOCK = uint256(-1);
+    uint256 internal constant PETRIFIED_BLOCK = uint256(-1);
 
     function isPetrified() public view returns (bool) {
         return getInitializationBlock() == PETRIFIED_BLOCK;

--- a/contracts/ens/ENSConstants.sol
+++ b/contracts/ens/ENSConstants.sol
@@ -6,9 +6,9 @@ pragma solidity ^0.4.24;
 
 
 contract ENSConstants {
-    bytes32 constant public ENS_ROOT = bytes32(0);
-    bytes32 constant public ETH_TLD_LABEL = keccak256("eth");
-    bytes32 constant public ETH_TLD_NODE = keccak256(abi.encodePacked(ENS_ROOT, ETH_TLD_LABEL));
-    bytes32 constant public PUBLIC_RESOLVER_LABEL = keccak256("resolver");
-    bytes32 constant public PUBLIC_RESOLVER_NODE = keccak256(abi.encodePacked(ETH_TLD_NODE, PUBLIC_RESOLVER_LABEL));
+    bytes32 public constant ENS_ROOT = bytes32(0);
+    bytes32 public constant ETH_TLD_LABEL = keccak256("eth");
+    bytes32 public constant ETH_TLD_NODE = keccak256(abi.encodePacked(ENS_ROOT, ETH_TLD_LABEL));
+    bytes32 public constant PUBLIC_RESOLVER_LABEL = keccak256("resolver");
+    bytes32 public constant PUBLIC_RESOLVER_NODE = keccak256(abi.encodePacked(ETH_TLD_NODE, PUBLIC_RESOLVER_LABEL));
 }

--- a/contracts/ens/ENSSubdomainRegistrar.sol
+++ b/contracts/ens/ENSSubdomainRegistrar.sol
@@ -10,12 +10,12 @@ import "../apps/AragonApp.sol";
 /* solium-disable function-order */
 // Allow public initialize() to be first
 contract ENSSubdomainRegistrar is AragonApp, ENSConstants {
-    // bytes32 constant public CREATE_NAME_ROLE = keccak256("CREATE_NAME_ROLE");
-    // bytes32 constant public DELETE_NAME_ROLE = keccak256("DELETE_NAME_ROLE");
-    // bytes32 constant public POINT_ROOTNODE_ROLE = keccak256("POINT_ROOTNODE_ROLE");
-    bytes32 constant public CREATE_NAME_ROLE = 0xf86bc2abe0919ab91ef714b2bec7c148d94f61fdb069b91a6cfe9ecdee1799ba;
-    bytes32 constant public DELETE_NAME_ROLE = 0x03d74c8724218ad4a99859bcb2d846d39999449fd18013dd8d69096627e68622;
-    bytes32 constant public POINT_ROOTNODE_ROLE = 0x9ecd0e7bddb2e241c41b595a436c4ea4fd33c9fa0caa8056acf084fc3aa3bfbe;
+    // bytes32 public constant CREATE_NAME_ROLE = keccak256("CREATE_NAME_ROLE");
+    // bytes32 public constant DELETE_NAME_ROLE = keccak256("DELETE_NAME_ROLE");
+    // bytes32 public constant POINT_ROOTNODE_ROLE = keccak256("POINT_ROOTNODE_ROLE");
+    bytes32 public constant CREATE_NAME_ROLE = 0xf86bc2abe0919ab91ef714b2bec7c148d94f61fdb069b91a6cfe9ecdee1799ba;
+    bytes32 public constant DELETE_NAME_ROLE = 0x03d74c8724218ad4a99859bcb2d846d39999449fd18013dd8d69096627e68622;
+    bytes32 public constant POINT_ROOTNODE_ROLE = 0x9ecd0e7bddb2e241c41b595a436c4ea4fd33c9fa0caa8056acf084fc3aa3bfbe;
 
     AbstractENS public ens;
     bytes32 public rootNode;

--- a/contracts/evmscript/EVMScriptRegistry.sol
+++ b/contracts/evmscript/EVMScriptRegistry.sol
@@ -11,11 +11,11 @@ import "./IEVMScriptRegistry.sol";
 contract EVMScriptRegistry is IEVMScriptRegistry, EVMScriptRegistryConstants, AragonApp {
     using ScriptHelpers for bytes;
 
-    // bytes32 constant public REGISTRY_ADD_EXECUTOR_ROLE = keccak256("REGISTRY_ADD_EXECUTOR_ROLE");
-    bytes32 constant public REGISTRY_ADD_EXECUTOR_ROLE = 0xc4e90f38eea8c4212a009ca7b8947943ba4d4a58d19b683417f65291d1cd9ed2;
+    // bytes32 public constant REGISTRY_ADD_EXECUTOR_ROLE = keccak256("REGISTRY_ADD_EXECUTOR_ROLE");
+    bytes32 public constant REGISTRY_ADD_EXECUTOR_ROLE = 0xc4e90f38eea8c4212a009ca7b8947943ba4d4a58d19b683417f65291d1cd9ed2;
     // WARN: Manager can censor all votes and the like happening in an org
-    // bytes32 constant public REGISTRY_MANAGER_ROLE = keccak256("REGISTRY_MANAGER_ROLE");
-    bytes32 constant public REGISTRY_MANAGER_ROLE = 0xf7a450ef335e1892cb42c8ca72e7242359d7711924b75db5717410da3f614aa3;
+    // bytes32 public constant REGISTRY_MANAGER_ROLE = keccak256("REGISTRY_MANAGER_ROLE");
+    bytes32 public constant REGISTRY_MANAGER_ROLE = 0xf7a450ef335e1892cb42c8ca72e7242359d7711924b75db5717410da3f614aa3;
 
     struct ExecutorEntry {
         IEVMScriptExecutor executor;

--- a/contracts/evmscript/IEVMScriptRegistry.sol
+++ b/contracts/evmscript/IEVMScriptRegistry.sol
@@ -9,9 +9,9 @@ import "./IEVMScriptExecutor.sol";
 
 contract EVMScriptRegistryConstants {
     /* Hardcoded constants to save gas
-    bytes32 constant public EVMSCRIPT_REGISTRY_APP_ID = apmNamehash("evmreg");
+    bytes32 public constant EVMSCRIPT_REGISTRY_APP_ID = apmNamehash("evmreg");
     */
-    bytes32 constant public EVMSCRIPT_REGISTRY_APP_ID = 0xddbcfd564f642ab5627cf68b9b7d374fb4f8a36e941a75d89c87998cef03bd61;
+    bytes32 public constant EVMSCRIPT_REGISTRY_APP_ID = 0xddbcfd564f642ab5627cf68b9b7d374fb4f8a36e941a75d89c87998cef03bd61;
 }
 
 

--- a/contracts/evmscript/executors/BaseEVMScriptExecutor.sol
+++ b/contracts/evmscript/executors/BaseEVMScriptExecutor.sol
@@ -9,5 +9,5 @@ import "../IEVMScriptExecutor.sol";
 
 
 contract BaseEVMScriptExecutor is IEVMScriptExecutor, Autopetrified {
-    uint256 constant internal SCRIPT_START_LOCATION = 4;
+    uint256 internal constant SCRIPT_START_LOCATION = 4;
 }

--- a/contracts/evmscript/executors/CallsScript.sol
+++ b/contracts/evmscript/executors/CallsScript.sol
@@ -9,8 +9,8 @@ import "./BaseEVMScriptExecutor.sol";
 contract CallsScript is BaseEVMScriptExecutor {
     using ScriptHelpers for bytes;
 
-    // bytes32 constant internal EXECUTOR_TYPE = keccak256("CALLS_SCRIPT");
-    bytes32 constant internal EXECUTOR_TYPE = 0x2dc858a00f3e417be1394b87c07158e989ec681ce8cc68a9093680ac1a870302;
+    // bytes32 internal constant EXECUTOR_TYPE = keccak256("CALLS_SCRIPT");
+    bytes32 internal constant EXECUTOR_TYPE = 0x2dc858a00f3e417be1394b87c07158e989ec681ce8cc68a9093680ac1a870302;
 
     event LogScriptCall(address indexed sender, address indexed src, address indexed dst);
 

--- a/contracts/kernel/Kernel.sol
+++ b/contracts/kernel/Kernel.sol
@@ -13,10 +13,10 @@ import "../factory/AppProxyFactory.sol";
 
 contract Kernel is IKernel, KernelStorage, Petrifiable, IsContract, VaultRecoverable, AppProxyFactory, ACLSyntaxSugar {
     // Hardcode constant to save gas
-    //bytes32 constant public APP_MANAGER_ROLE = keccak256("APP_MANAGER_ROLE");
-    //bytes32 constant public DEFAULT_VAULT_APP_ID = apmNamehash("vault");
-    bytes32 constant public APP_MANAGER_ROLE = 0xb6d92708f3d4817afc106147d969e229ced5c46e65e0a5002a0d391287762bd0;
-    bytes32 constant public DEFAULT_VAULT_APP_ID = 0x7e852e0fcfce6551c13800f1e7476f982525c2b5277ba14b24339c68416336d1;
+    //bytes32 public constant APP_MANAGER_ROLE = keccak256("APP_MANAGER_ROLE");
+    //bytes32 public constant DEFAULT_VAULT_APP_ID = apmNamehash("vault");
+    bytes32 public constant APP_MANAGER_ROLE = 0xb6d92708f3d4817afc106147d969e229ced5c46e65e0a5002a0d391287762bd0;
+    bytes32 public constant DEFAULT_VAULT_APP_ID = 0x7e852e0fcfce6551c13800f1e7476f982525c2b5277ba14b24339c68416336d1;
 
     /**
     * @dev Constructor that allows the deployer to choose if the base instance should be petrified immediately.

--- a/contracts/kernel/KernelConstants.sol
+++ b/contracts/kernel/KernelConstants.sol
@@ -3,17 +3,17 @@ pragma solidity 0.4.24;
 
 contract KernelConstants {
     /*
-    bytes32 constant public CORE_NAMESPACE = keccak256("core");
-    bytes32 constant public APP_BASES_NAMESPACE = keccak256("base");
-    bytes32 constant public APP_ADDR_NAMESPACE = keccak256("app");
+    bytes32 public constant CORE_NAMESPACE = keccak256("core");
+    bytes32 public constant APP_BASES_NAMESPACE = keccak256("base");
+    bytes32 public constant APP_ADDR_NAMESPACE = keccak256("app");
 
-    bytes32 constant public KERNEL_APP_ID = apmNamehash("kernel");
-    bytes32 constant public ACL_APP_ID = apmNamehash("acl");
+    bytes32 public constant KERNEL_APP_ID = apmNamehash("kernel");
+    bytes32 public constant ACL_APP_ID = apmNamehash("acl");
     */
-    bytes32 constant public CORE_NAMESPACE = 0xc681a85306374a5ab27f0bbc385296a54bcd314a1948b6cf61c4ea1bc44bb9f8;
-    bytes32 constant public APP_BASES_NAMESPACE = 0xf1f3eb40f5bc1ad1344716ced8b8a0431d840b5783aea1fd01786bc26f35ac0f;
-    bytes32 constant public APP_ADDR_NAMESPACE = 0xd6f028ca0e8edb4a8c9757ca4fdccab25fa1e0317da1188108f7d2dee14902fb;
+    bytes32 public constant CORE_NAMESPACE = 0xc681a85306374a5ab27f0bbc385296a54bcd314a1948b6cf61c4ea1bc44bb9f8;
+    bytes32 public constant APP_BASES_NAMESPACE = 0xf1f3eb40f5bc1ad1344716ced8b8a0431d840b5783aea1fd01786bc26f35ac0f;
+    bytes32 public constant APP_ADDR_NAMESPACE = 0xd6f028ca0e8edb4a8c9757ca4fdccab25fa1e0317da1188108f7d2dee14902fb;
 
-    bytes32 constant public KERNEL_APP_ID = 0x3b4bf6bf3ad5000ecf0f989d5befde585c6860fea3e574a4fab4c49d1c177d9c;
-    bytes32 constant public ACL_APP_ID = 0xe3262375f45a6e2026b7e7b18c2b807434f2508fe1a2a3dfb493c7df8f4aad6a;
+    bytes32 public constant KERNEL_APP_ID = 0x3b4bf6bf3ad5000ecf0f989d5befde585c6860fea3e574a4fab4c49d1c177d9c;
+    bytes32 public constant ACL_APP_ID = 0xe3262375f45a6e2026b7e7b18c2b807434f2508fe1a2a3dfb493c7df8f4aad6a;
 }

--- a/contracts/lib/misc/ERCProxy.sol
+++ b/contracts/lib/misc/ERCProxy.sol
@@ -6,8 +6,8 @@ pragma solidity ^0.4.24;
 
 
 contract ERCProxy {
-    uint256 constant public FORWARDING = 1;
-    uint256 constant public UPGRADEABLE = 2;
+    uint256 public constant FORWARDING = 1;
+    uint256 public constant UPGRADEABLE = 2;
 
     function proxyType() public pure returns (uint256 proxyTypeId);
     function implementation() public view returns (address codeAddr);

--- a/contracts/test/mocks/AppProxyPinnedStorageMock.sol
+++ b/contracts/test/mocks/AppProxyPinnedStorageMock.sol
@@ -6,11 +6,10 @@ import "../../kernel/Kernel.sol";
 
 
 contract FakeAppConstants {
-    bytes32 constant FAKE_APP_ID = keccak256('FAKE_APP_ID');
+    bytes32 public constant FAKE_APP_ID = keccak256('FAKE_APP_ID');
 }
 
 contract KernelPinnedStorageMock is Kernel, FakeAppConstants {
-    bytes32 constant FAKE_APP_ID = keccak256('FAKE_APP_ID');
     constructor(address _fakeApp) Kernel(false) public {
         _setApp(APP_BASES_NAMESPACE, FAKE_APP_ID, _fakeApp);
     }

--- a/contracts/test/mocks/AppStub.sol
+++ b/contracts/test/mocks/AppStub.sol
@@ -11,7 +11,7 @@ contract AppStubStorage {
 }
 
 contract AppStub is AragonApp, AppStubStorage {
-    bytes32 constant public ROLE = keccak256("ROLE");
+    bytes32 public constant ROLE = keccak256("ROLE");
 
     function initialize() onlyInit public {
         initialized();

--- a/contracts/test/mocks/ERCProxyMock.sol
+++ b/contracts/test/mocks/ERCProxyMock.sol
@@ -4,8 +4,8 @@ import "../../lib/misc/ERCProxy.sol";
 
 
 contract ERCProxyMock is ERCProxy {
-    uint256 constant public FORWARDING = 1;
-    uint256 constant public UPGRADEABLE = 2;
+    uint256 public constant FORWARDING = 1;
+    uint256 public constant UPGRADEABLE = 2;
 
     function proxyType() public pure returns (uint256 proxyTypeId) {
         return 0;

--- a/contracts/test/mocks/EVMScriptExecutorMock.sol
+++ b/contracts/test/mocks/EVMScriptExecutorMock.sol
@@ -4,7 +4,7 @@ pragma solidity 0.4.24;
 import "../../evmscript/executors/BaseEVMScriptExecutor.sol";
 
 contract EVMScriptExecutorMock is BaseEVMScriptExecutor {
-    bytes32 constant internal EXECUTOR_TYPE = keccak256("MOCK_SCRIPT");
+    bytes32 internal constant EXECUTOR_TYPE = keccak256("MOCK_SCRIPT");
 
     function execScript(bytes, bytes, address[]) external isInitialized returns (bytes) {
     }

--- a/contracts/test/mocks/KeccakConstants.sol
+++ b/contracts/test/mocks/KeccakConstants.sol
@@ -7,46 +7,46 @@ contract KeccakConstants is APMNamehash {
     // Note: we can't use APMNamehash.apmNamehash() for constants, starting from pragma 0.5 :(
 
     // Kernel
-    bytes32 constant public CORE_NAMESPACE = keccak256(abi.encodePacked("core"));
-    bytes32 constant public APP_BASES_NAMESPACE = keccak256(abi.encodePacked("base"));
-    bytes32 constant public APP_ADDR_NAMESPACE = keccak256(abi.encodePacked("app"));
+    bytes32 public constant CORE_NAMESPACE = keccak256(abi.encodePacked("core"));
+    bytes32 public constant APP_BASES_NAMESPACE = keccak256(abi.encodePacked("base"));
+    bytes32 public constant APP_ADDR_NAMESPACE = keccak256(abi.encodePacked("app"));
 
-    bytes32 constant public KERNEL_APP_ID = keccak256(abi.encodePacked(APM_NODE, keccak256("kernel")));
-    bytes32 constant public ACL_APP_ID = keccak256(abi.encodePacked(APM_NODE, keccak256("acl")));
+    bytes32 public constant KERNEL_APP_ID = keccak256(abi.encodePacked(APM_NODE, keccak256("kernel")));
+    bytes32 public constant ACL_APP_ID = keccak256(abi.encodePacked(APM_NODE, keccak256("acl")));
 
-    bytes32 constant public APP_MANAGER_ROLE = keccak256(abi.encodePacked("APP_MANAGER_ROLE"));
+    bytes32 public constant APP_MANAGER_ROLE = keccak256(abi.encodePacked("APP_MANAGER_ROLE"));
 
-    bytes32 constant public DEFAULT_VAULT_APP_ID = keccak256(abi.encodePacked(APM_NODE, keccak256("vault")));
+    bytes32 public constant DEFAULT_VAULT_APP_ID = keccak256(abi.encodePacked(APM_NODE, keccak256("vault")));
 
     // ENS
-    bytes32 constant public ENS_ROOT = bytes32(0);
-    bytes32 constant public ETH_TLD_LABEL = keccak256(abi.encodePacked("eth"));
-    bytes32 constant public ETH_TLD_NODE = keccak256(abi.encodePacked(ENS_ROOT, ETH_TLD_LABEL));
-    bytes32 constant public PUBLIC_RESOLVER_LABEL = keccak256(abi.encodePacked("resolver"));
-    bytes32 constant public PUBLIC_RESOLVER_NODE = keccak256(abi.encodePacked(ETH_TLD_NODE, PUBLIC_RESOLVER_LABEL));
+    bytes32 public constant ENS_ROOT = bytes32(0);
+    bytes32 public constant ETH_TLD_LABEL = keccak256(abi.encodePacked("eth"));
+    bytes32 public constant ETH_TLD_NODE = keccak256(abi.encodePacked(ENS_ROOT, ETH_TLD_LABEL));
+    bytes32 public constant PUBLIC_RESOLVER_LABEL = keccak256(abi.encodePacked("resolver"));
+    bytes32 public constant PUBLIC_RESOLVER_NODE = keccak256(abi.encodePacked(ETH_TLD_NODE, PUBLIC_RESOLVER_LABEL));
 
     // ACL
-    bytes32 constant public CREATE_PERMISSIONS_ROLE = keccak256(abi.encodePacked("CREATE_PERMISSIONS_ROLE"));
-    bytes32 constant public EMPTY_PARAM_HASH = keccak256(abi.encodePacked(uint256(0)));
+    bytes32 public constant CREATE_PERMISSIONS_ROLE = keccak256(abi.encodePacked("CREATE_PERMISSIONS_ROLE"));
+    bytes32 public constant EMPTY_PARAM_HASH = keccak256(abi.encodePacked(uint256(0)));
 
     // APMRegistry
-    bytes32 constant public CREATE_REPO_ROLE = keccak256(abi.encodePacked("CREATE_REPO_ROLE"));
+    bytes32 public constant CREATE_REPO_ROLE = keccak256(abi.encodePacked("CREATE_REPO_ROLE"));
 
     // ENSSubdomainRegistrar
-    bytes32 constant public CREATE_NAME_ROLE = keccak256(abi.encodePacked("CREATE_NAME_ROLE"));
-    bytes32 constant public DELETE_NAME_ROLE = keccak256(abi.encodePacked("DELETE_NAME_ROLE"));
-    bytes32 constant public POINT_ROOTNODE_ROLE = keccak256(abi.encodePacked("POINT_ROOTNODE_ROLE"));
+    bytes32 public constant CREATE_NAME_ROLE = keccak256(abi.encodePacked("CREATE_NAME_ROLE"));
+    bytes32 public constant DELETE_NAME_ROLE = keccak256(abi.encodePacked("DELETE_NAME_ROLE"));
+    bytes32 public constant POINT_ROOTNODE_ROLE = keccak256(abi.encodePacked("POINT_ROOTNODE_ROLE"));
 
     // EVMScriptRegistry
-    bytes32 constant public EVMSCRIPT_REGISTRY_APP_ID = keccak256(abi.encodePacked(APM_NODE, keccak256("evmreg")));
-    bytes32 constant public REGISTRY_ADD_EXECUTOR_ROLE = keccak256("REGISTRY_ADD_EXECUTOR_ROLE");
-    bytes32 constant public REGISTRY_MANAGER_ROLE = keccak256(abi.encodePacked("REGISTRY_MANAGER_ROLE"));
+    bytes32 public constant EVMSCRIPT_REGISTRY_APP_ID = keccak256(abi.encodePacked(APM_NODE, keccak256("evmreg")));
+    bytes32 public constant REGISTRY_ADD_EXECUTOR_ROLE = keccak256("REGISTRY_ADD_EXECUTOR_ROLE");
+    bytes32 public constant REGISTRY_MANAGER_ROLE = keccak256(abi.encodePacked("REGISTRY_MANAGER_ROLE"));
 
     // EVMScriptExecutor types
-    bytes32 constant public EVMSCRIPT_EXECUTOR_CALLS_SCRIPT = keccak256(abi.encodePacked("CALLS_SCRIPT"));
+    bytes32 public constant EVMSCRIPT_EXECUTOR_CALLS_SCRIPT = keccak256(abi.encodePacked("CALLS_SCRIPT"));
 
     // Repo
-    bytes32 constant public CREATE_VERSION_ROLE = keccak256(abi.encodePacked("CREATE_VERSION_ROLE"));
+    bytes32 public constant CREATE_VERSION_ROLE = keccak256(abi.encodePacked("CREATE_VERSION_ROLE"));
 
     // Unstructured storage
     bytes32 public constant initializationBlockPosition = keccak256(abi.encodePacked("aragonOS.initializable.initializationBlock"));


### PR DESCRIPTION
Generally, visibility modifers are preferred before any other modifier (strong social consensus, e.g. OpenZeppelin).

Our linter doesn't have a rule to check this yet (see https://github.com/duaraghav8/Solium/issues/239).