### PR TITLE
Fix broken link in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # aragonOS <img align="right" src="https://raw.githubusercontent.com/aragon/design/master/readme-logo.png" height="80px" /> [![Travis branch](https://img.shields.io/travis/aragon/aragonOS/master.svg?style=for-the-badge)](https://travis-ci.org/aragon/aragonOS) [![Coveralls branch](https://img.shields.io/coveralls/aragon/aragonOS/master.svg?style=for-the-badge)](https://coveralls.io/github/aragon/aragonOS?branch=master) [![npm](https://img.shields.io/npm/v/@aragon/os.svg?style=for-the-badge)](https://www.npmjs.com/package/@aragon/os)
 
-This repo contains Aragon's reference implementation for [aragonOS](https://wiki.aragon.one/dev/aragonOS_index/).
+This repo contains Aragon's reference implementation for [aragonOS](https://hack.aragon.org/docs/aragonos-ref.html).
 
 #### 🚨 Everything in this repo is highly experimental software.
 It is not secure to use any of this code in production (mainnet) until proper security audits have been conducted. It can result in irreversible loss of funds.


### PR DESCRIPTION
Not quite sure this is the correct replacement link:
https://hack.aragon.org/docs/aragonos-ref.html

But the old one is surely 404'ed:
https://wiki.aragon.one/dev/aragonOS_index/