### PR TITLE
Optimize proxies and AragonApp by removing unnecessary constants from bytecode

### DIFF
--- a/contracts/apps/AppProxyBase.sol
+++ b/contracts/apps/AppProxyBase.sol
@@ -6,7 +6,7 @@ import "../kernel/KernelConstants.sol";
 import "../kernel/IKernel.sol";
 
 
-contract AppProxyBase is AppStorage, DepositableDelegateProxy, KernelConstants {
+contract AppProxyBase is AppStorage, DepositableDelegateProxy, KernelConstantsAppBases {
     /**
     * @dev Initialize AppProxy
     * @param _kernel Reference to organization kernel for the app

--- a/contracts/apps/AppStorage.sol
+++ b/contracts/apps/AppStorage.sol
@@ -15,8 +15,6 @@ contract AppStorage {
     bytes32 internal constant KERNEL_POSITION = 0x4172f0f7d2289153072b0a6ca36959e0cbe2efc3afe50fc81636caa96338137b;
     // keccak256("aragonOS.appStorage.appId")
     bytes32 internal constant APP_ID_POSITION = 0xd625496217aa6a3453eecb9c3489dc5a53e6c67b444329ea2b2cbc9ff547639b;
-    // keccak256("aragonOS.appStorage.pinnedCode"), used by Proxy Pinned
-    bytes32 internal constant PINNED_CODE_POSITION = 0xdee64df20d65e53d7f51cb6ab6d921a0a6a638a91e942e1d8d02df28e31c038e;
 
     function kernel() public view returns (IKernel) {
         return IKernel(KERNEL_POSITION.getStorageAddress());

--- a/contracts/evmscript/EVMScriptRunner.sol
+++ b/contracts/evmscript/EVMScriptRunner.sol
@@ -12,7 +12,7 @@ import "../kernel/KernelConstants.sol";
 import "../common/Initializable.sol";
 
 
-contract EVMScriptRunner is AppStorage, Initializable, EVMScriptRegistryConstants, KernelConstants {
+contract EVMScriptRunner is AppStorage, Initializable, EVMScriptRegistryConstants, KernelConstantsAppAddress {
     event ScriptResult(address indexed executor, bytes script, bytes input, bytes returnData);
 
     function getExecutor(bytes _script) public view returns (IEVMScriptExecutor) {

--- a/contracts/kernel/Kernel.sol
+++ b/contracts/kernel/Kernel.sol
@@ -9,9 +9,10 @@ import "../common/IsContract.sol";
 import "../common/Petrifiable.sol";
 import "../common/VaultRecoverable.sol";
 import "../factory/AppProxyFactory.sol";
+import "./KernelConstants.sol";
 
 
-contract Kernel is IKernel, KernelStorage, Petrifiable, IsContract, VaultRecoverable, AppProxyFactory, ACLSyntaxSugar {
+contract Kernel is IKernel, KernelStorage, KernelConstants, Petrifiable, IsContract, VaultRecoverable, AppProxyFactory, ACLSyntaxSugar {
     // Hardcode constant to save gas
     //bytes32 public constant APP_MANAGER_ROLE = keccak256("APP_MANAGER_ROLE");
     //bytes32 public constant DEFAULT_VAULT_APP_ID = apmNamehash("vault");

--- a/contracts/kernel/KernelConstants.sol
+++ b/contracts/kernel/KernelConstants.sol
@@ -3,12 +3,16 @@ pragma solidity 0.4.24;
 // Split in multiple contracts so they can be individually imported
 // Optimization for having lighter proxies and AragonApp base contract
 
+/* solium-disable no-empty-blocks */
+
+
 contract KernelConstantsAppBases {
     /*
     bytes32 public constant APP_BASES_NAMESPACE = keccak256("base");
     */
     bytes32 public constant APP_BASES_NAMESPACE = 0xf1f3eb40f5bc1ad1344716ced8b8a0431d840b5783aea1fd01786bc26f35ac0f;
 }
+
 
 contract KernelConstantsKernelCore {
     /*
@@ -18,6 +22,7 @@ contract KernelConstantsKernelCore {
     bytes32 public constant CORE_NAMESPACE = 0xc681a85306374a5ab27f0bbc385296a54bcd314a1948b6cf61c4ea1bc44bb9f8;
     bytes32 public constant KERNEL_APP_ID = 0x3b4bf6bf3ad5000ecf0f989d5befde585c6860fea3e574a4fab4c49d1c177d9c;
 }
+
 
 contract KernelConstantsAppAddress {
     /*

--- a/contracts/kernel/KernelConstants.sol
+++ b/contracts/kernel/KernelConstants.sol
@@ -1,10 +1,12 @@
 pragma solidity 0.4.24;
 
 // Split in multiple contracts so they can be individually imported
-// Optimization for having lighter proxies
+// Optimization for having lighter proxies and AragonApp base contract
 
 contract KernelConstantsAppBases {
-    // bytes32 public constant APP_BASES_NAMESPACE = keccak256("base");
+    /*
+    bytes32 public constant APP_BASES_NAMESPACE = keccak256("base");
+    */
     bytes32 public constant APP_BASES_NAMESPACE = 0xf1f3eb40f5bc1ad1344716ced8b8a0431d840b5783aea1fd01786bc26f35ac0f;
 }
 
@@ -17,15 +19,18 @@ contract KernelConstantsKernelCore {
     bytes32 public constant KERNEL_APP_ID = 0x3b4bf6bf3ad5000ecf0f989d5befde585c6860fea3e574a4fab4c49d1c177d9c;
 }
 
-contract KernelConstants is KernelConstantsAppBases, KernelConstantsKernelCore {
+contract KernelConstantsAppAddress {
     /*
-    bytes32 public constant CORE_NAMESPACE = keccak256("core");
     bytes32 public constant APP_ADDR_NAMESPACE = keccak256("app");
-
-    bytes32 public constant KERNEL_APP_ID = apmNamehash("kernel");
-    bytes32 public constant ACL_APP_ID = apmNamehash("acl");
     */
     bytes32 public constant APP_ADDR_NAMESPACE = 0xd6f028ca0e8edb4a8c9757ca4fdccab25fa1e0317da1188108f7d2dee14902fb;
+}
 
+contract KernelConstantsACL {
+    /*
+    bytes32 public constant ACL_APP_ID = apmNamehash("acl");
+    */
     bytes32 public constant ACL_APP_ID = 0xe3262375f45a6e2026b7e7b18c2b807434f2508fe1a2a3dfb493c7df8f4aad6a;
 }
+
+contract KernelConstants is KernelConstantsAppBases, KernelConstantsKernelCore, KernelConstantsAppAddress, KernelConstantsACL {}

--- a/contracts/kernel/KernelConstants.sol
+++ b/contracts/kernel/KernelConstants.sol
@@ -1,19 +1,31 @@
 pragma solidity 0.4.24;
 
+// Split in multiple contracts so they can be individually imported
+// Optimization for having lighter proxies
 
-contract KernelConstants {
+contract KernelConstantsAppBases {
+    // bytes32 public constant APP_BASES_NAMESPACE = keccak256("base");
+    bytes32 public constant APP_BASES_NAMESPACE = 0xf1f3eb40f5bc1ad1344716ced8b8a0431d840b5783aea1fd01786bc26f35ac0f;
+}
+
+contract KernelConstantsKernelCore {
     /*
     bytes32 public constant CORE_NAMESPACE = keccak256("core");
-    bytes32 public constant APP_BASES_NAMESPACE = keccak256("base");
+    bytes32 public constant KERNEL_APP_ID = apmNamehash("kernel");
+    */
+    bytes32 public constant CORE_NAMESPACE = 0xc681a85306374a5ab27f0bbc385296a54bcd314a1948b6cf61c4ea1bc44bb9f8;
+    bytes32 public constant KERNEL_APP_ID = 0x3b4bf6bf3ad5000ecf0f989d5befde585c6860fea3e574a4fab4c49d1c177d9c;
+}
+
+contract KernelConstants is KernelConstantsAppBases, KernelConstantsKernelCore {
+    /*
+    bytes32 public constant CORE_NAMESPACE = keccak256("core");
     bytes32 public constant APP_ADDR_NAMESPACE = keccak256("app");
 
     bytes32 public constant KERNEL_APP_ID = apmNamehash("kernel");
     bytes32 public constant ACL_APP_ID = apmNamehash("acl");
     */
-    bytes32 public constant CORE_NAMESPACE = 0xc681a85306374a5ab27f0bbc385296a54bcd314a1948b6cf61c4ea1bc44bb9f8;
-    bytes32 public constant APP_BASES_NAMESPACE = 0xf1f3eb40f5bc1ad1344716ced8b8a0431d840b5783aea1fd01786bc26f35ac0f;
     bytes32 public constant APP_ADDR_NAMESPACE = 0xd6f028ca0e8edb4a8c9757ca4fdccab25fa1e0317da1188108f7d2dee14902fb;
 
-    bytes32 public constant KERNEL_APP_ID = 0x3b4bf6bf3ad5000ecf0f989d5befde585c6860fea3e574a4fab4c49d1c177d9c;
     bytes32 public constant ACL_APP_ID = 0xe3262375f45a6e2026b7e7b18c2b807434f2508fe1a2a3dfb493c7df8f4aad6a;
 }

--- a/contracts/kernel/KernelProxy.sol
+++ b/contracts/kernel/KernelProxy.sol
@@ -4,9 +4,10 @@ import "./IKernel.sol";
 import "./KernelStorage.sol";
 import "../common/DepositableDelegateProxy.sol";
 import "../common/IsContract.sol";
+import "./KernelConstants.sol";
 
 
-contract KernelProxy is KernelStorage, IsContract, DepositableDelegateProxy {
+contract KernelProxy is KernelStorage, KernelConstantsKernelCore, IsContract, DepositableDelegateProxy {
     /**
     * @dev KernelProxy is a proxy contract to a kernel implementation. The implementation
     *      can update the reference, which effectively upgrades the contract

--- a/contracts/kernel/KernelStorage.sol
+++ b/contracts/kernel/KernelStorage.sol
@@ -1,9 +1,7 @@
 pragma solidity 0.4.24;
 
-import "./KernelConstants.sol";
 
-
-contract KernelStorage is KernelConstants {
+contract KernelStorage {
     mapping (bytes32 => mapping (bytes32 => address)) public apps;
     bytes32 public recoveryVaultAppId;
 }


### PR DESCRIPTION
Leaving constants in the bytecode that are not used is quite expensive, in an attempt to optimize bytecode size for proxies, removing constants has had good results. Using @sohkai's bytecode comparison tool: 

After applying 0bf39da and edd8120
```
                               CODE DEPOSIT COST    DEPLOYED BYTES     INITIALIZATION BYTES
APMRegistry.json               119600 less gas      -598               0
AppProxyFactory.json           119600 less gas      -598               0
AppProxyPinned.json            54400 less gas       -272               -54
AppProxyPinnedStorageMock.json 54400 less gas       -272               0
AppProxyUpgradeable.json       54400 less gas       -272               0
DAOFactory.json                40800 less gas       -204               0
EVMScriptRegistryFactory.json  119600 less gas      -598               0
Kernel.json                    119600 less gas      -598               0
KernelDepositableMock.json     119600 less gas      -598               0
KernelPinnedStorageMock.json   119600 less gas      -598               0
KernelProxy.json               40800 less gas       -204               0
KernelSetAppMock.json          119600 less gas      -598               0
KernelStorage.json             69800 less gas       -349               0
UpgradedKernel.json            119600 less gas      -598               0
```

Applying 9e763ca as well results in:
```
                               CODE DEPOSIT COST    DEPLOYED BYTES     INITIALIZATION BYTES
ACL.json                       54400 less gas       -272               0
APMRegistry.json               177200 less gas      -886               0
AppProxyFactory.json           119600 less gas      -598               0
AppProxyPinned.json            54400 less gas       -272               -54
AppProxyPinnedStorageMock.json 54400 less gas       -272               0
AppProxyUpgradeable.json       54400 less gas       -272               0
AragonApp.json                 54400 less gas       -272               0
DAOFactory.json                40800 less gas       -204               0
ENSSubdomainRegistrar.json     54400 less gas       -272               0
EVMScriptRegistry.json         54400 less gas       -272               0
EVMScriptRegistryFactory.json  119600 less gas      -598               -272
EVMScriptRunner.json           54400 less gas       -272               0
Kernel.json                    119600 less gas      -598               0
KernelPinnedStorageMock.json   119600 less gas      -598               0
KernelProxy.json               40800 less gas       -204               0
KernelStorage.json             69800 less gas       -349               0
Repo.json                      54400 less gas       -272               0
```