### PR TITLE
Remove redundant kernel check in AragonApp.getRecoveryVault()

### DIFF
--- a/contracts/apps/AragonApp.sol
+++ b/contracts/apps/AragonApp.sol
@@ -62,7 +62,6 @@ contract AragonApp is AppStorage, Autopetrified, VaultRecoverable, EVMScriptRunn
     */
     function getRecoveryVault() public view returns (address) {
         // Funds recovery via a vault is only available when used with a kernel
-        require(address(kernel()) != address(0));
-        return kernel().getRecoveryVault();
+        return kernel().getRecoveryVault(); // if kernel is not set, it will revert
     }
 }

--- a/contracts/kernel/Kernel.sol
+++ b/contracts/kernel/Kernel.sol
@@ -193,8 +193,7 @@ contract Kernel is IKernel, KernelStorage, Petrifiable, IsContract, VaultRecover
     */
     function hasPermission(address _who, address _where, bytes32 _what, bytes _how) public view returns (bool) {
         IACL defaultAcl = acl();
-        return address(defaultAcl) != address(0) && // Poor man's initialization check (saves gas)
-            defaultAcl.hasPermission(_who, _where, _what, _how);
+        return defaultAcl.hasPermission(_who, _where, _what, _how); // if acl is not set, it will revert
     }
 
     function _setApp(bytes32 _namespace, bytes32 _appId, address _app) internal {

--- a/contracts/kernel/Kernel.sol
+++ b/contracts/kernel/Kernel.sol
@@ -193,7 +193,8 @@ contract Kernel is IKernel, KernelStorage, Petrifiable, IsContract, VaultRecover
     */
     function hasPermission(address _who, address _where, bytes32 _what, bytes _how) public view returns (bool) {
         IACL defaultAcl = acl();
-        return defaultAcl.hasPermission(_who, _where, _what, _how); // if acl is not set, it will revert
+        return address(defaultAcl) != address(0) && // Poor man's initialization check (saves gas)
+            defaultAcl.hasPermission(_who, _where, _what, _how);
     }
 
     function _setApp(bytes32 _namespace, bytes32 _appId, address _app) internal {


### PR DESCRIPTION
When using the native call syntax `target.method(...)` solc introduces
a check for the code size of the target (and reverts if it is 0), therefore
we don't need to manually ensure that the target address is not 0 before making
a call, as the size of the address 0 will be 0, and therefore already revert