### PR TITLE
KernelConstants: use nonstrict pragma

### DIFF
--- a/contracts/kernel/KernelConstants.sol
+++ b/contracts/kernel/KernelConstants.sol
@@ -1,3 +1,7 @@
+/*
+ * SPDX-License-Identitifer:    MIT
+ */
+
 pragma solidity ^0.4.24;
 
 

--- a/contracts/kernel/KernelConstants.sol
+++ b/contracts/kernel/KernelConstants.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.24;
+pragma solidity ^0.4.24;
 
 
 contract KernelConstants {


### PR DESCRIPTION
Use non-strict version to be able to import aragon contracts on Remix & Etheratom.

`KernelConstants` is eventually used by `AragonApp`.