### PR TITLE
Add revert reasons to proxies

### DIFF
--- a/contracts/apps/AppProxyBase.sol
+++ b/contracts/apps/AppProxyBase.sol
@@ -7,6 +7,9 @@ import "../kernel/IKernel.sol";
 
 
 contract AppProxyBase is AppStorage, DepositableDelegateProxy, KernelConstants {
+    string private constant INIT_DESTINATION_NOT_CONTRACT_ERROR = "APB1";
+    string private constant INIT_REVERTED = "APB2";
+
     /**
     * @dev Initialize AppProxy
     * @param _kernel Reference to organization kernel for the app
@@ -25,10 +28,10 @@ contract AppProxyBase is AppStorage, DepositableDelegateProxy, KernelConstants {
 
         // If initialize payload is provided, it will be executed
         if (_initializePayload.length > 0) {
-            require(isContract(appCode));
+            require(isContract(appCode), INIT_DESTINATION_NOT_CONTRACT_ERROR);
             // Cannot make delegatecall as a delegateproxy.delegatedFwd as it
             // returns ending execution context and halts contract deployment
-            require(appCode.delegatecall(_initializePayload));
+            require(appCode.delegatecall(_initializePayload), INIT_REVERTED);
         }
     }
 

--- a/contracts/apps/AppProxyPinned.sol
+++ b/contracts/apps/AppProxyPinned.sol
@@ -11,6 +11,7 @@ contract AppProxyPinned is IsContract, AppProxyBase {
     // keccak256("aragonOS.appStorage.pinnedCode")
     bytes32 internal constant PINNED_CODE_POSITION = 0xdee64df20d65e53d7f51cb6ab6d921a0a6a638a91e942e1d8d02df28e31c038e;
 
+    string private constant INIT_DESTINATION_NOT_CONTRACT_ERROR = "APP1";
     /**
     * @dev Initialize AppProxyPinned (makes it an un-upgradeable Aragon app)
     * @param _kernel Reference to organization kernel for the app
@@ -22,7 +23,7 @@ contract AppProxyPinned is IsContract, AppProxyBase {
         public // solium-disable-line visibility-first
     {
         setPinnedCode(getAppBase(_appId));
-        require(isContract(pinnedCode()));
+        require(isContract(pinnedCode()), INIT_DESTINATION_NOT_CONTRACT_ERROR);
     }
 
     /**

--- a/contracts/common/DelegateProxy.sol
+++ b/contracts/common/DelegateProxy.sol
@@ -7,13 +7,15 @@ import "../lib/misc/ERCProxy.sol";
 contract DelegateProxy is ERCProxy, IsContract {
     uint256 public constant FWD_GAS_LIMIT = 10000;
 
+    string private constant DESTINATION_NOT_CONTRACT_ERROR = "DP1";
+
     /**
     * @dev Performs a delegatecall and returns whatever the delegatecall returned (entire context execution will return!)
     * @param _dst Destination address to perform the delegatecall
     * @param _calldata Calldata for the delegatecall
     */
     function delegatedFwd(address _dst, bytes _calldata) internal {
-        require(isContract(_dst));
+        require(isContract(_dst), DESTINATION_NOT_CONTRACT_ERROR);
         uint256 fwdGasLimit = FWD_GAS_LIMIT;
 
         assembly {

--- a/contracts/common/DepositableDelegateProxy.sol
+++ b/contracts/common/DepositableDelegateProxy.sol
@@ -5,13 +5,16 @@ import "./DepositableStorage.sol";
 
 
 contract DepositableDelegateProxy is DepositableStorage, DelegateProxy {
+    string private constant INVALID_DEPOSIT_ERROR = "DDP1";
+    string private constant NOT_DEPOSITABLE_ERROR = "DDP2";
+
     event ProxyDeposit(address sender, uint256 value);
 
     function () external payable {
         // send / transfer
         if (gasleft() < FWD_GAS_LIMIT) {
-            require(msg.value > 0 && msg.data.length == 0);
-            require(isDepositable());
+            require(msg.value > 0 && msg.data.length == 0, INVALID_DEPOSIT_ERROR);
+            require(isDepositable(), NOT_DEPOSITABLE_ERROR);
             emit ProxyDeposit(msg.sender, msg.value);
         } else { // all calls except for send or transfer
             address target = implementation();

--- a/contracts/kernel/KernelProxy.sol
+++ b/contracts/kernel/KernelProxy.sol
@@ -7,13 +7,15 @@ import "../common/IsContract.sol";
 
 
 contract KernelProxy is KernelStorage, IsContract, DepositableDelegateProxy {
+    string private constant INIT_DESTINATION_NOT_CONTRACT_ERROR = "KP1";
+
     /**
     * @dev KernelProxy is a proxy contract to a kernel implementation. The implementation
     *      can update the reference, which effectively upgrades the contract
     * @param _kernelImpl Address of the contract used as implementation for kernel
     */
     constructor(IKernel _kernelImpl) public {
-        require(isContract(address(_kernelImpl)));
+        require(isContract(address(_kernelImpl)), INIT_DESTINATION_NOT_CONTRACT_ERROR);
         apps[CORE_NAMESPACE][KERNEL_APP_ID] = _kernelImpl;
     }
 


### PR DESCRIPTION
Partially solves #438 

The naming of errors optimizes for proxy size, given that having strings in contract bytecode is quite expensive.