### PR TITLE
[Prototype] AragonApp: signed calls and multi call execution (aka meta-txs support)

### DIFF
--- a/contracts/apps/AppStorage.sol
+++ b/contracts/apps/AppStorage.sol
@@ -18,6 +18,9 @@ contract AppStorage {
     // keccak256("aragonOS.appStorage.pinnedCode"), used by Proxy Pinned
     bytes32 internal constant PINNED_CODE_POSITION = 0xdee64df20d65e53d7f51cb6ab6d921a0a6a638a91e942e1d8d02df28e31c038e;
 
+    bytes32 internal constant VOLATILE_SENDER_POSITION = keccak256("aragonOS.appStorage.volatile.sender");
+    bytes32 internal constant USED_NONCE_POSITION_BASE = keccak256("aragonOS.appStorage.usedNonce");
+
     function kernel() public view returns (IKernel) {
         return IKernel(KERNEL_POSITION.getStorageAddress());
     }
@@ -26,11 +29,31 @@ contract AppStorage {
         return APP_ID_POSITION.getStorageBytes32();
     }
 
+    function volatileStorageSender() public view returns (address) {
+        return VOLATILE_SENDER_POSITION.getStorageAddress();
+    }
+
+    function usedNonce(address _account, uint256 _nonce) public view returns (bool) {
+        return usedNoncePosition(_account, _nonce).getStorageBool();
+    }
+
     function setKernel(IKernel _kernel) internal {
         KERNEL_POSITION.setStorageAddress(address(_kernel));
     }
 
     function setAppId(bytes32 _appId) internal {
         APP_ID_POSITION.setStorageBytes32(_appId);
+    }
+
+    function setVolatileStorageSender(address _sender) internal {
+        VOLATILE_SENDER_POSITION.setStorageAddress(_sender);
+    }
+
+    function setUsedNonce(address _account, uint256 _nonce, bool _used) internal {
+        return usedNoncePosition(_account, _nonce).setStorageBool(_used);
+    }
+
+    function usedNoncePosition(address _account, uint256 _nonce) internal returns (bytes32) {
+        return keccak256(abi.encodePacked(USED_NONCE_POSITION_BASE, _account, _nonce));
     }
 }

--- a/contracts/apps/AragonApp.sol
+++ b/contracts/apps/AragonApp.sol
@@ -45,7 +45,7 @@ contract AragonApp is AppStorage, Autopetrified, VaultRecoverable, EVMScriptRunn
         setVolatileStorageSender(signer);
         setUsedNonce(signer, nonce, true);
         bool success = address(this).call(calldata);
-        if (!success){
+        if (!success) {
             // no need to clean up storage as the entire execution frame is reverted
             revertForwadingError();
         }

--- a/contracts/apps/AragonApp.sol
+++ b/contracts/apps/AragonApp.sol
@@ -3,6 +3,7 @@
  */
 
 pragma solidity ^0.4.24;
+// pragma experimental ABIEncoderV2;
 
 import "./AppStorage.sol";
 import "../common/Autopetrified.sol";
@@ -50,6 +51,19 @@ contract AragonApp is AppStorage, Autopetrified, VaultRecoverable, EVMScriptRunn
         }
         setVolatileStorageSender(ZERO_ADDRESS);
     }
+
+    /*
+    // TODO: Currently causing a solidity error: InternalCompilerError
+    function multiexec(address[] signers, bytes[] calldatas, uint256[] nonces, bytes[] signatures) external {
+        require(signers.length == calldatas.length);
+        require(signers.length == nonces.length);
+        require(signers.length == signatures.length);
+
+        for (uint256 i = 0; i < signers.length; i++) {
+            exec(signers[i], calldatas[i], nonces[i], signatures[i]);
+        }
+    }
+    */
 
     /**
     * @dev Check whether an action can be performed by a sender for a particular role on this app


### PR DESCRIPTION
Super early prototype of how we could add a way to execute signed calls in a contract inheriting `AragonApp`. Signed calls allow the entity performing an action doing so without ever having to own any ETH to pay for transaction fees, by having a relayer submit their signed calls on-chain. There seems to be some momentum around the [EIP1077](https://eips.ethereum.org/EIPS/eip-1077) standard, which could be interesting to support, as a standard interface could help create a ecosystem of relayer services.

By putting this in the `AragonApp` contract, any Aragon app would automatically benefit from this functionality. There is native support for ACL checks, but apps willing to use this for custom logic (e.g. Voting) should use `AragonApp.sender()` instead of `msg.sender`.

It uses volatile storage, `AragonApp` will write to a storage slot who the actual sender of the call is before calling itself with that calldata. After the sub-call ends executing, that storage slot is emptied. This would be quite expensive to do right now, but the new [net gas metering](https://eips.ethereum.org/EIPS/eip-1283) in Constantinople this is quite cheap to do.

Got down this rabbit-hole after having a discussing with @bingen about whether it would make sense to add [`multicall`](https://github.com/cartoucheco/registrar/blob/master/contracts/OwnedRegistrar.sol#L73-L77) to the Staking app, and his proposal to add it directly to `AragonApp`.

The current implementation doesn't allow to perform multiple calls from sender as in `multicall`, but it could be implemented by accepting empty signatures as calls executed by their sender.