### PR TITLE
Optimization: prune constants

### DIFF
--- a/contracts/acl/ACL.sol
+++ b/contracts/acl/ACL.sol
@@ -10,16 +10,10 @@ import "./IACLOracle.sol";
 /* solium-disable function-order */
 // Allow public initialize() to be first
 contract ACL is IACL, TimeHelpers, AragonApp, ACLHelpers {
-    // Hardcoded constant to save gas
-    //bytes32 public constant CREATE_PERMISSIONS_ROLE = keccak256("CREATE_PERMISSIONS_ROLE");
+    /* Hardcoded constants to save gas
+    bytes32 public constant CREATE_PERMISSIONS_ROLE = keccak256("CREATE_PERMISSIONS_ROLE");
+    */
     bytes32 public constant CREATE_PERMISSIONS_ROLE = 0x0b719b33c83b8e5d300c521cb8b54ae9bd933996a14bef8c2f4e0285d2d2400a;
-
-    // Whether someone has a permission
-    mapping (bytes32 => bytes32) internal permissions; // permissions hash => params hash
-    mapping (bytes32 => Param[]) internal permissionParams; // params hash => params
-
-    // Who is the manager of a permission
-    mapping (bytes32 => address) internal permissionManager;
 
     enum Op { NONE, EQ, NEQ, GT, LT, GTE, LTE, RET, NOT, AND, OR, XOR, IF_ELSE } // op types
 
@@ -39,8 +33,9 @@ contract ACL is IACL, TimeHelpers, AragonApp, ACLHelpers {
     uint8 internal constant PARAM_VALUE_PARAM_ID  = 205;
     // TODO: Add execution times param type?
 
-    // Hardcoded constant to save gas
-    //bytes32 public constant EMPTY_PARAM_HASH = keccak256(uint256(0));
+    /* Hardcoded constant to save gas
+    bytes32 public constant EMPTY_PARAM_HASH = keccak256(uint256(0));
+    */
     bytes32 public constant EMPTY_PARAM_HASH = 0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563;
     bytes32 public constant NO_PERMISSION = bytes32(0);
     address public constant ANY_ENTITY = address(-1);
@@ -52,6 +47,17 @@ contract ACL is IACL, TimeHelpers, AragonApp, ACLHelpers {
     string private constant ERROR_AUTH_NO_MANAGER = "ACL_AUTH_NO_MANAGER";
     string private constant ERROR_EXISTENT_MANAGER = "ACL_EXISTENT_MANAGER";
 
+    // Whether someone has a permission
+    mapping (bytes32 => bytes32) internal permissions; // permissions hash => params hash
+    mapping (bytes32 => Param[]) internal permissionParams; // params hash => params
+
+    // Who is the manager of a permission
+    mapping (bytes32 => address) internal permissionManager;
+
+    event SetPermission(address indexed entity, address indexed app, bytes32 indexed role, bool allowed);
+    event SetPermissionParams(address indexed entity, address indexed app, bytes32 indexed role, bytes32 paramsHash);
+    event ChangePermissionManager(address indexed app, bytes32 indexed role, address indexed manager);
+
     modifier onlyPermissionManager(address _app, bytes32 _role) {
         require(msg.sender == getPermissionManager(_app, _role), ERROR_AUTH_NO_MANAGER);
         _;
@@ -62,10 +68,6 @@ contract ACL is IACL, TimeHelpers, AragonApp, ACLHelpers {
         require(getPermissionManager(_app, _role) == address(0), ERROR_EXISTENT_MANAGER);
         _;
     }
-
-    event SetPermission(address indexed entity, address indexed app, bytes32 indexed role, bool allowed);
-    event SetPermissionParams(address indexed entity, address indexed app, bytes32 indexed role, bytes32 paramsHash);
-    event ChangePermissionManager(address indexed app, bytes32 indexed role, address indexed manager);
 
     /**
     * @dev Initialize can only be called once. It saves the block number in which it was initialized.

--- a/contracts/apm/APMNamehash.sol
+++ b/contracts/apm/APMNamehash.sol
@@ -4,11 +4,12 @@
 
 pragma solidity ^0.4.24;
 
-import "../ens/ENSConstants.sol";
 
-
-contract APMNamehash is ENSConstants {
-    bytes32 public constant APM_NODE = keccak256(abi.encodePacked(ETH_TLD_NODE, keccak256("aragonpm")));
+contract APMNamehash {
+    /* Hardcoded constants to save gas
+    bytes32 internal constant APM_NODE = keccak256(abi.encodePacked(ETH_TLD_NODE, keccak256(abi.encodePacked("aragonpm"))));
+    */
+    bytes32 internal constant APM_NODE = 0x9065c3e7f7b7ef1ef4e53d2d0b8e0cef02874ab020c1ece79d5f0d3d0111c0ba;
 
     function apmNamehash(string name) internal pure returns (bytes32) {
         return keccak256(abi.encodePacked(APM_NODE, keccak256(bytes(name))));

--- a/contracts/apm/APMRegistry.sol
+++ b/contracts/apm/APMRegistry.sol
@@ -8,16 +8,14 @@ import "../acl/ACL.sol";
 import "./Repo.sol";
 
 
-contract APMRegistryConstants {
-    // Cant have a regular APM appId because it is used to build APM
-    // TODO: recheck this
-    string public constant APM_APP_NAME = "apm-registry";
-    string public constant REPO_APP_NAME = "apm-repo";
-    string public constant ENS_SUB_APP_NAME = "apm-enssub";
+contract APMInternalAppNames {
+    string internal constant APM_APP_NAME = "apm-registry";
+    string internal constant REPO_APP_NAME = "apm-repo";
+    string internal constant ENS_SUB_APP_NAME = "apm-enssub";
 }
 
 
-contract APMRegistry is AragonApp, AppProxyFactory, APMRegistryConstants {
+contract APMRegistry is AragonApp, AppProxyFactory, APMInternalAppNames {
     /* Hardcoded constants to save gas
     bytes32 public constant CREATE_REPO_ROLE = keccak256("CREATE_REPO_ROLE");
     */

--- a/contracts/apm/APMRegistry.sol
+++ b/contracts/apm/APMRegistry.sol
@@ -18,14 +18,16 @@ contract APMRegistryConstants {
 
 
 contract APMRegistry is AragonApp, AppProxyFactory, APMRegistryConstants {
-    AbstractENS public ens;
-    ENSSubdomainRegistrar public registrar;
-
-    // bytes32 public constant CREATE_REPO_ROLE = keccak256("CREATE_REPO_ROLE");
+    /* Hardcoded constants to save gas
+    bytes32 public constant CREATE_REPO_ROLE = keccak256("CREATE_REPO_ROLE");
+    */
     bytes32 public constant CREATE_REPO_ROLE = 0x2a9494d64846c9fdbf0158785aa330d8bc9caf45af27fa0e8898eb4d55adcea6;
 
     string private constant ERROR_INIT_PERMISSIONS = "APMREG_INIT_PERMISSIONS";
     string private constant ERROR_EMPTY_NAME = "APMREG_EMPTY_NAME";
+
+    AbstractENS public ens;
+    ENSSubdomainRegistrar public registrar;
 
     event NewRepo(bytes32 id, string name, address repo);
 

--- a/contracts/apm/Repo.sol
+++ b/contracts/apm/Repo.sol
@@ -6,6 +6,15 @@ import "../apps/AragonApp.sol";
 /* solium-disable function-order */
 // Allow public initialize() to be first
 contract Repo is AragonApp {
+    /* Hardcoded constants to save gas
+    bytes32 public constant CREATE_VERSION_ROLE = keccak256("CREATE_VERSION_ROLE");
+    */
+    bytes32 public constant CREATE_VERSION_ROLE = 0x1f56cfecd3595a2e6cc1a7e6cb0b20df84cdbd92eff2fee554e70e4e45a9a7d8;
+
+    string private constant ERROR_INVALID_BUMP = "REPO_INVALID_BUMP";
+    string private constant ERROR_INVALID_VERSION = "REPO_INVALID_VERSION";
+    string private constant ERROR_INEXISTENT_VERSION = "REPO_INEXISTENT_VERSION";
+
     struct Version {
         uint16[3] semanticVersion;
         address contractAddress;
@@ -16,13 +25,6 @@ contract Repo is AragonApp {
     mapping (uint256 => Version) internal versions;
     mapping (bytes32 => uint256) internal versionIdForSemantic;
     mapping (address => uint256) internal latestVersionIdForContract;
-
-    // bytes32 public constant CREATE_VERSION_ROLE = keccak256("CREATE_VERSION_ROLE");
-    bytes32 public constant CREATE_VERSION_ROLE = 0x1f56cfecd3595a2e6cc1a7e6cb0b20df84cdbd92eff2fee554e70e4e45a9a7d8;
-
-    string private constant ERROR_INVALID_BUMP = "REPO_INVALID_BUMP";
-    string private constant ERROR_INVALID_VERSION = "REPO_INVALID_VERSION";
-    string private constant ERROR_INEXISTENT_VERSION = "REPO_INEXISTENT_VERSION";
 
     event NewVersion(uint256 versionId, uint16[3] semanticVersion);
 

--- a/contracts/apps/AppProxyBase.sol
+++ b/contracts/apps/AppProxyBase.sol
@@ -6,7 +6,7 @@ import "../kernel/KernelConstants.sol";
 import "../kernel/IKernel.sol";
 
 
-contract AppProxyBase is AppStorage, DepositableDelegateProxy, KernelConstants {
+contract AppProxyBase is AppStorage, DepositableDelegateProxy, KernelNamespaceConstants {
     /**
     * @dev Initialize AppProxy
     * @param _kernel Reference to organization kernel for the app
@@ -33,6 +33,6 @@ contract AppProxyBase is AppStorage, DepositableDelegateProxy, KernelConstants {
     }
 
     function getAppBase(bytes32 _appId) internal view returns (address) {
-        return kernel().getApp(APP_BASES_NAMESPACE, _appId);
+        return kernel().getApp(KERNEL_APP_BASES_NAMESPACE, _appId);
     }
 }

--- a/contracts/apps/AppStorage.sol
+++ b/contracts/apps/AppStorage.sol
@@ -11,12 +11,12 @@ import "../kernel/IKernel.sol";
 contract AppStorage {
     using UnstructuredStorage for bytes32;
 
-    // keccak256("aragonOS.appStorage.kernel")
+    /* Hardcoded constants to save gas
+    bytes32 internal constant KERNEL_POSITION = keccak256("aragonOS.appStorage.kernel");
+    bytes32 internal constant APP_ID_POSITION = keccak256("aragonOS.appStorage.appId");
+    */
     bytes32 internal constant KERNEL_POSITION = 0x4172f0f7d2289153072b0a6ca36959e0cbe2efc3afe50fc81636caa96338137b;
-    // keccak256("aragonOS.appStorage.appId")
     bytes32 internal constant APP_ID_POSITION = 0xd625496217aa6a3453eecb9c3489dc5a53e6c67b444329ea2b2cbc9ff547639b;
-    // keccak256("aragonOS.appStorage.pinnedCode"), used by Proxy Pinned
-    bytes32 internal constant PINNED_CODE_POSITION = 0xdee64df20d65e53d7f51cb6ab6d921a0a6a638a91e942e1d8d02df28e31c038e;
 
     function kernel() public view returns (IKernel) {
         return IKernel(KERNEL_POSITION.getStorageAddress());

--- a/contracts/common/DelegateProxy.sol
+++ b/contracts/common/DelegateProxy.sol
@@ -5,7 +5,7 @@ import "../lib/misc/ERCProxy.sol";
 
 
 contract DelegateProxy is ERCProxy, IsContract {
-    uint256 public constant FWD_GAS_LIMIT = 10000;
+    uint256 internal constant FWD_GAS_LIMIT = 10000;
 
     /**
     * @dev Performs a delegatecall and returns whatever the delegatecall returned (entire context execution will return!)

--- a/contracts/common/EtherTokenConstant.sol
+++ b/contracts/common/EtherTokenConstant.sol
@@ -8,5 +8,5 @@ pragma solidity ^0.4.24;
 // aragonOS and aragon-apps rely on address(0) to denote native ETH, in
 // contracts where both tokens and ETH are accepted
 contract EtherTokenConstant {
-    address public constant ETH = address(0);
+    address internal constant ETH = address(0);
 }

--- a/contracts/common/Uint256Helpers.sol
+++ b/contracts/common/Uint256Helpers.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.4.24;
 
 
 library Uint256Helpers {
-    uint256 public constant MAX_UINT64 = uint64(-1);
+    uint256 private constant MAX_UINT64 = uint64(-1);
 
     string private constant ERROR_NUMBER_TOO_BIG = "UINT64_NUMBER_TOO_BIG";
 

--- a/contracts/ens/ENSConstants.sol
+++ b/contracts/ens/ENSConstants.sol
@@ -6,9 +6,9 @@ pragma solidity ^0.4.24;
 
 
 contract ENSConstants {
-    bytes32 public constant ENS_ROOT = bytes32(0);
-    bytes32 public constant ETH_TLD_LABEL = keccak256("eth");
-    bytes32 public constant ETH_TLD_NODE = keccak256(abi.encodePacked(ENS_ROOT, ETH_TLD_LABEL));
-    bytes32 public constant PUBLIC_RESOLVER_LABEL = keccak256("resolver");
-    bytes32 public constant PUBLIC_RESOLVER_NODE = keccak256(abi.encodePacked(ETH_TLD_NODE, PUBLIC_RESOLVER_LABEL));
+    bytes32 internal constant ENS_ROOT = bytes32(0);
+    bytes32 internal constant ETH_TLD_LABEL = keccak256("eth");
+    bytes32 internal constant ETH_TLD_NODE = keccak256(abi.encodePacked(ENS_ROOT, ETH_TLD_LABEL));
+    bytes32 internal constant PUBLIC_RESOLVER_LABEL = keccak256("resolver");
+    bytes32 internal constant PUBLIC_RESOLVER_NODE = keccak256(abi.encodePacked(ETH_TLD_NODE, PUBLIC_RESOLVER_LABEL));
 }

--- a/contracts/ens/ENSSubdomainRegistrar.sol
+++ b/contracts/ens/ENSSubdomainRegistrar.sol
@@ -10,9 +10,11 @@ import "../apps/AragonApp.sol";
 /* solium-disable function-order */
 // Allow public initialize() to be first
 contract ENSSubdomainRegistrar is AragonApp, ENSConstants {
-    // bytes32 public constant CREATE_NAME_ROLE = keccak256("CREATE_NAME_ROLE");
-    // bytes32 public constant DELETE_NAME_ROLE = keccak256("DELETE_NAME_ROLE");
-    // bytes32 public constant POINT_ROOTNODE_ROLE = keccak256("POINT_ROOTNODE_ROLE");
+    /* Hardcoded constants to save gas
+    bytes32 public constant CREATE_NAME_ROLE = keccak256("CREATE_NAME_ROLE");
+    bytes32 public constant DELETE_NAME_ROLE = keccak256("DELETE_NAME_ROLE");
+    bytes32 public constant POINT_ROOTNODE_ROLE = keccak256("POINT_ROOTNODE_ROLE");
+    */
     bytes32 public constant CREATE_NAME_ROLE = 0xf86bc2abe0919ab91ef714b2bec7c148d94f61fdb069b91a6cfe9ecdee1799ba;
     bytes32 public constant DELETE_NAME_ROLE = 0x03d74c8724218ad4a99859bcb2d846d39999449fd18013dd8d69096627e68622;
     bytes32 public constant POINT_ROOTNODE_ROLE = 0x9ecd0e7bddb2e241c41b595a436c4ea4fd33c9fa0caa8056acf084fc3aa3bfbe;

--- a/contracts/evmscript/EVMScriptRegistry.sol
+++ b/contracts/evmscript/EVMScriptRegistry.sol
@@ -11,10 +11,12 @@ import "./IEVMScriptRegistry.sol";
 contract EVMScriptRegistry is IEVMScriptRegistry, EVMScriptRegistryConstants, AragonApp {
     using ScriptHelpers for bytes;
 
-    // bytes32 public constant REGISTRY_ADD_EXECUTOR_ROLE = keccak256("REGISTRY_ADD_EXECUTOR_ROLE");
+    /* Hardcoded constants to save gas
+    bytes32 public constant REGISTRY_ADD_EXECUTOR_ROLE = keccak256("REGISTRY_ADD_EXECUTOR_ROLE");
+    bytes32 public constant REGISTRY_MANAGER_ROLE = keccak256("REGISTRY_MANAGER_ROLE");
+    */
     bytes32 public constant REGISTRY_ADD_EXECUTOR_ROLE = 0xc4e90f38eea8c4212a009ca7b8947943ba4d4a58d19b683417f65291d1cd9ed2;
     // WARN: Manager can censor all votes and the like happening in an org
-    // bytes32 public constant REGISTRY_MANAGER_ROLE = keccak256("REGISTRY_MANAGER_ROLE");
     bytes32 public constant REGISTRY_MANAGER_ROLE = 0xf7a450ef335e1892cb42c8ca72e7242359d7711924b75db5717410da3f614aa3;
 
     string private constant ERROR_INEXISTENT_EXECUTOR = "EVMREG_INEXISTENT_EXECUTOR";

--- a/contracts/evmscript/EVMScriptRunner.sol
+++ b/contracts/evmscript/EVMScriptRunner.sol
@@ -12,7 +12,7 @@ import "../kernel/KernelConstants.sol";
 import "../common/Initializable.sol";
 
 
-contract EVMScriptRunner is AppStorage, Initializable, EVMScriptRegistryConstants, KernelConstants {
+contract EVMScriptRunner is AppStorage, Initializable, EVMScriptRegistryConstants, KernelNamespaceConstants {
     string private constant ERROR_EXECUTOR_UNAVAILABLE = "EVMRUN_EXECUTOR_UNAVAILABLE";
     string private constant ERROR_EXECUTION_REVERTED = "EVMRUN_EXECUTION_REVERTED";
     string private constant ERROR_PROTECTED_STATE_MODIFIED = "EVMRUN_PROTECTED_STATE_MODIFIED";
@@ -45,7 +45,7 @@ contract EVMScriptRunner is AppStorage, Initializable, EVMScriptRegistryConstant
     }
 
     function getExecutorRegistry() internal view returns (IEVMScriptRegistry) {
-        address registryAddr = kernel().getApp(APP_ADDR_NAMESPACE, EVMSCRIPT_REGISTRY_APP_ID);
+        address registryAddr = kernel().getApp(KERNEL_APP_ADDR_NAMESPACE, EVMSCRIPT_REGISTRY_APP_ID);
         return IEVMScriptRegistry(registryAddr);
     }
 

--- a/contracts/evmscript/IEVMScriptRegistry.sol
+++ b/contracts/evmscript/IEVMScriptRegistry.sol
@@ -9,9 +9,9 @@ import "./IEVMScriptExecutor.sol";
 
 contract EVMScriptRegistryConstants {
     /* Hardcoded constants to save gas
-    bytes32 public constant EVMSCRIPT_REGISTRY_APP_ID = apmNamehash("evmreg");
+    bytes32 internal constant EVMSCRIPT_REGISTRY_APP_ID = apmNamehash("evmreg");
     */
-    bytes32 public constant EVMSCRIPT_REGISTRY_APP_ID = 0xddbcfd564f642ab5627cf68b9b7d374fb4f8a36e941a75d89c87998cef03bd61;
+    bytes32 internal constant EVMSCRIPT_REGISTRY_APP_ID = 0xddbcfd564f642ab5627cf68b9b7d374fb4f8a36e941a75d89c87998cef03bd61;
 }
 
 

--- a/contracts/evmscript/executors/CallsScript.sol
+++ b/contracts/evmscript/executors/CallsScript.sol
@@ -9,7 +9,9 @@ import "./BaseEVMScriptExecutor.sol";
 contract CallsScript is BaseEVMScriptExecutor {
     using ScriptHelpers for bytes;
 
-    // bytes32 internal constant EXECUTOR_TYPE = keccak256("CALLS_SCRIPT");
+    /* Hardcoded constants to save gas
+    bytes32 internal constant EXECUTOR_TYPE = keccak256("CALLS_SCRIPT");
+    */
     bytes32 internal constant EXECUTOR_TYPE = 0x2dc858a00f3e417be1394b87c07158e989ec681ce8cc68a9093680ac1a870302;
 
     string private constant ERROR_BLACKLISTED_CALL = "EVMCALLS_BLACKLISTED_CALL";

--- a/contracts/factory/APMRegistryFactory.sol
+++ b/contracts/factory/APMRegistryFactory.sol
@@ -10,7 +10,7 @@ import "./ENSFactory.sol";
 import "./AppProxyFactory.sol";
 
 
-contract APMRegistryFactory is APMRegistryConstants {
+contract APMRegistryFactory is APMInternalAppNames {
     DAOFactory public daoFactory;
     APMRegistry public registryBase;
     Repo public repoBase;

--- a/contracts/kernel/Kernel.sol
+++ b/contracts/kernel/Kernel.sol
@@ -12,15 +12,25 @@ import "../factory/AppProxyFactory.sol";
 
 
 contract Kernel is IKernel, KernelStorage, Petrifiable, IsContract, VaultRecoverable, AppProxyFactory, ACLSyntaxSugar {
-    // Hardcode constant to save gas
-    //bytes32 public constant APP_MANAGER_ROLE = keccak256("APP_MANAGER_ROLE");
-    //bytes32 public constant DEFAULT_VAULT_APP_ID = apmNamehash("vault");
+    /* Hardcoded constants to save gas
+    bytes32 public constant APP_MANAGER_ROLE = keccak256("APP_MANAGER_ROLE");
+    bytes32 public constant DEFAULT_ACL_APP_ID = apmNamehash("acl");
+    bytes32 internal constant DEFAULT_VAULT_APP_ID = apmNamehash("vault");
+    */
     bytes32 public constant APP_MANAGER_ROLE = 0xb6d92708f3d4817afc106147d969e229ced5c46e65e0a5002a0d391287762bd0;
-    bytes32 public constant DEFAULT_VAULT_APP_ID = 0x7e852e0fcfce6551c13800f1e7476f982525c2b5277ba14b24339c68416336d1;
+    bytes32 public constant DEFAULT_ACL_APP_ID = 0xe3262375f45a6e2026b7e7b18c2b807434f2508fe1a2a3dfb493c7df8f4aad6a;
+    bytes32 internal constant DEFAULT_VAULT_APP_ID = 0x7e852e0fcfce6551c13800f1e7476f982525c2b5277ba14b24339c68416336d1;
 
     string private constant ERROR_APP_NOT_CONTRACT = "KERNEL_APP_NOT_CONTRACT";
     string private constant ERROR_INVALID_APP_CHANGE = "KERNEL_INVALID_APP_CHANGE";
     string private constant ERROR_AUTH_FAILED = "KERNEL_AUTH_FAILED";
+
+    // External access to namespace constants to mimic default getters for constants
+    /* solium-disable function-order, mixedcase */
+    function CORE_NAMESPACE() external pure returns (bytes32) { return KERNEL_CORE_NAMESPACE; }
+    function APP_BASES_NAMESPACE() external pure returns (bytes32) { return KERNEL_APP_BASES_NAMESPACE; }
+    function APP_ADDR_NAMESPACE() external pure returns (bytes32) { return KERNEL_APP_ADDR_NAMESPACE; }
+    /* solium-enable function-order, mixedcase */
 
     /**
     * @dev Constructor that allows the deployer to choose if the base instance should be petrified immediately.
@@ -42,12 +52,12 @@ contract Kernel is IKernel, KernelStorage, Petrifiable, IsContract, VaultRecover
         initialized();
 
         // Set ACL base
-        _setApp(APP_BASES_NAMESPACE, ACL_APP_ID, _baseAcl);
+        _setApp(KERNEL_APP_BASES_NAMESPACE, DEFAULT_ACL_APP_ID, _baseAcl);
 
         // Create ACL instance and attach it as the default ACL app
-        IACL acl = IACL(newAppProxy(this, ACL_APP_ID));
+        IACL acl = IACL(newAppProxy(this, DEFAULT_ACL_APP_ID));
         acl.initialize(_permissionsCreator);
-        _setApp(APP_ADDR_NAMESPACE, ACL_APP_ID, acl);
+        _setApp(KERNEL_APP_ADDR_NAMESPACE, DEFAULT_ACL_APP_ID, acl);
 
         recoveryVaultAppId = DEFAULT_VAULT_APP_ID;
     }
@@ -61,7 +71,7 @@ contract Kernel is IKernel, KernelStorage, Petrifiable, IsContract, VaultRecover
     */
     function newAppInstance(bytes32 _appId, address _appBase)
         public
-        auth(APP_MANAGER_ROLE, arr(APP_BASES_NAMESPACE, _appId))
+        auth(APP_MANAGER_ROLE, arr(KERNEL_APP_BASES_NAMESPACE, _appId))
         returns (ERCProxy appProxy)
     {
         return newAppInstance(_appId, _appBase, new bytes(0), false);
@@ -81,15 +91,15 @@ contract Kernel is IKernel, KernelStorage, Petrifiable, IsContract, VaultRecover
     */
     function newAppInstance(bytes32 _appId, address _appBase, bytes _initializePayload, bool _setDefault)
         public
-        auth(APP_MANAGER_ROLE, arr(APP_BASES_NAMESPACE, _appId))
+        auth(APP_MANAGER_ROLE, arr(KERNEL_APP_BASES_NAMESPACE, _appId))
         returns (ERCProxy appProxy)
     {
-        _setAppIfNew(APP_BASES_NAMESPACE, _appId, _appBase);
+        _setAppIfNew(KERNEL_APP_BASES_NAMESPACE, _appId, _appBase);
         appProxy = newAppProxy(this, _appId, _initializePayload);
         // By calling setApp directly and not the internal functions, we make sure the params are checked
         // and it will only succeed if sender has permissions to set something to the namespace.
         if (_setDefault) {
-            setApp(APP_ADDR_NAMESPACE, _appId, appProxy);
+            setApp(KERNEL_APP_ADDR_NAMESPACE, _appId, appProxy);
         }
     }
 
@@ -102,7 +112,7 @@ contract Kernel is IKernel, KernelStorage, Petrifiable, IsContract, VaultRecover
     */
     function newPinnedAppInstance(bytes32 _appId, address _appBase)
         public
-        auth(APP_MANAGER_ROLE, arr(APP_BASES_NAMESPACE, _appId))
+        auth(APP_MANAGER_ROLE, arr(KERNEL_APP_BASES_NAMESPACE, _appId))
         returns (ERCProxy appProxy)
     {
         return newPinnedAppInstance(_appId, _appBase, new bytes(0), false);
@@ -122,15 +132,15 @@ contract Kernel is IKernel, KernelStorage, Petrifiable, IsContract, VaultRecover
     */
     function newPinnedAppInstance(bytes32 _appId, address _appBase, bytes _initializePayload, bool _setDefault)
         public
-        auth(APP_MANAGER_ROLE, arr(APP_BASES_NAMESPACE, _appId))
+        auth(APP_MANAGER_ROLE, arr(KERNEL_APP_BASES_NAMESPACE, _appId))
         returns (ERCProxy appProxy)
     {
-        _setAppIfNew(APP_BASES_NAMESPACE, _appId, _appBase);
+        _setAppIfNew(KERNEL_APP_BASES_NAMESPACE, _appId, _appBase);
         appProxy = newAppProxyPinned(this, _appId, _initializePayload);
         // By calling setApp directly and not the internal functions, we make sure the params are checked
         // and it will only succeed if sender has permissions to set something to the namespace.
         if (_setDefault) {
-            setApp(APP_ADDR_NAMESPACE, _appId, appProxy);
+            setApp(KERNEL_APP_ADDR_NAMESPACE, _appId, appProxy);
         }
     }
 
@@ -155,7 +165,7 @@ contract Kernel is IKernel, KernelStorage, Petrifiable, IsContract, VaultRecover
     */
     function setRecoveryVaultAppId(bytes32 _recoveryVaultAppId)
         public
-        auth(APP_MANAGER_ROLE, arr(APP_ADDR_NAMESPACE, _recoveryVaultAppId))
+        auth(APP_MANAGER_ROLE, arr(KERNEL_APP_ADDR_NAMESPACE, _recoveryVaultAppId))
     {
         recoveryVaultAppId = _recoveryVaultAppId;
     }
@@ -175,7 +185,7 @@ contract Kernel is IKernel, KernelStorage, Petrifiable, IsContract, VaultRecover
     * @return Address of the Vault
     */
     function getRecoveryVault() public view returns (address) {
-        return apps[APP_ADDR_NAMESPACE][recoveryVaultAppId];
+        return apps[KERNEL_APP_ADDR_NAMESPACE][recoveryVaultAppId];
     }
 
     /**
@@ -183,7 +193,7 @@ contract Kernel is IKernel, KernelStorage, Petrifiable, IsContract, VaultRecover
     * @return ACL app
     */
     function acl() public view returns (IACL) {
-        return IACL(getApp(APP_ADDR_NAMESPACE, ACL_APP_ID));
+        return IACL(getApp(KERNEL_APP_ADDR_NAMESPACE, DEFAULT_ACL_APP_ID));
     }
 
     /**

--- a/contracts/kernel/KernelConstants.sol
+++ b/contracts/kernel/KernelConstants.sol
@@ -5,19 +5,21 @@
 pragma solidity ^0.4.24;
 
 
-contract KernelConstants {
-    /*
-    bytes32 public constant CORE_NAMESPACE = keccak256("core");
-    bytes32 public constant APP_BASES_NAMESPACE = keccak256("base");
-    bytes32 public constant APP_ADDR_NAMESPACE = keccak256("app");
-
-    bytes32 public constant KERNEL_APP_ID = apmNamehash("kernel");
-    bytes32 public constant ACL_APP_ID = apmNamehash("acl");
+contract KernelNamespaceConstants {
+    /* Hardcoded constants to save gas
+    bytes32 internal constant KERNEL_CORE_NAMESPACE = keccak256("core");
+    bytes32 internal constant KERNEL_APP_BASES_NAMESPACE = keccak256("base");
+    bytes32 internal constant KERNEL_APP_ADDR_NAMESPACE = keccak256("app");
     */
-    bytes32 public constant CORE_NAMESPACE = 0xc681a85306374a5ab27f0bbc385296a54bcd314a1948b6cf61c4ea1bc44bb9f8;
-    bytes32 public constant APP_BASES_NAMESPACE = 0xf1f3eb40f5bc1ad1344716ced8b8a0431d840b5783aea1fd01786bc26f35ac0f;
-    bytes32 public constant APP_ADDR_NAMESPACE = 0xd6f028ca0e8edb4a8c9757ca4fdccab25fa1e0317da1188108f7d2dee14902fb;
+    bytes32 internal constant KERNEL_CORE_NAMESPACE = 0xc681a85306374a5ab27f0bbc385296a54bcd314a1948b6cf61c4ea1bc44bb9f8;
+    bytes32 internal constant KERNEL_APP_BASES_NAMESPACE = 0xf1f3eb40f5bc1ad1344716ced8b8a0431d840b5783aea1fd01786bc26f35ac0f;
+    bytes32 internal constant KERNEL_APP_ADDR_NAMESPACE = 0xd6f028ca0e8edb4a8c9757ca4fdccab25fa1e0317da1188108f7d2dee14902fb;
+}
 
+
+contract KernelConstants {
+    /* Hardcoded constants to save gas
+    bytes32 public constant KERNEL_APP_ID = apmNamehash("kernel");
+    */
     bytes32 public constant KERNEL_APP_ID = 0x3b4bf6bf3ad5000ecf0f989d5befde585c6860fea3e574a4fab4c49d1c177d9c;
-    bytes32 public constant ACL_APP_ID = 0xe3262375f45a6e2026b7e7b18c2b807434f2508fe1a2a3dfb493c7df8f4aad6a;
 }

--- a/contracts/kernel/KernelProxy.sol
+++ b/contracts/kernel/KernelProxy.sol
@@ -14,7 +14,7 @@ contract KernelProxy is KernelStorage, IsContract, DepositableDelegateProxy {
     */
     constructor(IKernel _kernelImpl) public {
         require(isContract(address(_kernelImpl)));
-        apps[CORE_NAMESPACE][KERNEL_APP_ID] = _kernelImpl;
+        apps[KERNEL_CORE_NAMESPACE][KERNEL_APP_ID] = _kernelImpl;
     }
 
     /**
@@ -28,6 +28,6 @@ contract KernelProxy is KernelStorage, IsContract, DepositableDelegateProxy {
     * @dev ERC897, the address the proxy would delegate calls to
     */
     function implementation() public view returns (address) {
-        return apps[CORE_NAMESPACE][KERNEL_APP_ID];
+        return apps[KERNEL_CORE_NAMESPACE][KERNEL_APP_ID];
     }
 }

--- a/contracts/kernel/KernelStorage.sol
+++ b/contracts/kernel/KernelStorage.sol
@@ -3,7 +3,8 @@ pragma solidity 0.4.24;
 import "./KernelConstants.sol";
 
 
-contract KernelStorage is KernelConstants {
+contract KernelStorage is KernelConstants, KernelNamespaceConstants {
+    // namespace => app id => address
     mapping (bytes32 => mapping (bytes32 => address)) public apps;
     bytes32 public recoveryVaultAppId;
 }

--- a/contracts/lib/misc/ERCProxy.sol
+++ b/contracts/lib/misc/ERCProxy.sol
@@ -6,8 +6,8 @@ pragma solidity ^0.4.24;
 
 
 contract ERCProxy {
-    uint256 public constant FORWARDING = 1;
-    uint256 public constant UPGRADEABLE = 2;
+    uint256 internal constant FORWARDING = 1;
+    uint256 internal constant UPGRADEABLE = 2;
 
     function proxyType() public pure returns (uint256 proxyTypeId);
     function implementation() public view returns (address codeAddr);

--- a/contracts/test/mocks/APMNamehashMock.sol
+++ b/contracts/test/mocks/APMNamehashMock.sol
@@ -3,7 +3,9 @@ pragma solidity 0.4.24;
 import "../../apm/APMNamehash.sol";
 
 
-contract APMNamehashWrapper is APMNamehash {
+contract APMNamehashMock is APMNamehash {
+    function getAPMNode() external pure returns (bytes32) { return APM_NODE; }
+
     function getAPMNamehash(string name) external pure returns (bytes32) {
         return apmNamehash(name);
     }

--- a/contracts/test/mocks/AppProxyPinnedStorageMock.sol
+++ b/contracts/test/mocks/AppProxyPinnedStorageMock.sol
@@ -11,7 +11,7 @@ contract FakeAppConstants {
 
 contract KernelPinnedStorageMock is Kernel, FakeAppConstants {
     constructor(address _fakeApp) Kernel(false) public {
-        _setApp(APP_BASES_NAMESPACE, FAKE_APP_ID, _fakeApp);
+        _setApp(KERNEL_APP_BASES_NAMESPACE, FAKE_APP_ID, _fakeApp);
     }
 }
 

--- a/contracts/test/mocks/ENSConstantsMock.sol
+++ b/contracts/test/mocks/ENSConstantsMock.sol
@@ -1,0 +1,12 @@
+pragma solidity 0.4.24;
+
+import "../../ens/ENSConstants.sol";
+
+
+contract ENSConstantsMock is ENSConstants {
+    function getEnsRoot() external pure returns (bytes32) { return ENS_ROOT; }
+    function getEthTldLabel() external pure returns (bytes32) { return ETH_TLD_LABEL; }
+    function getEthTldNode() external pure returns (bytes32) { return ETH_TLD_NODE; }
+    function getPublicResolverLabel() external pure returns (bytes32) { return PUBLIC_RESOLVER_LABEL; }
+    function getPublicResolverNode() external pure returns (bytes32) { return PUBLIC_RESOLVER_NODE; }
+}

--- a/contracts/test/mocks/EVMScriptRegistryConstantsMock.sol
+++ b/contracts/test/mocks/EVMScriptRegistryConstantsMock.sol
@@ -1,0 +1,8 @@
+pragma solidity 0.4.24;
+
+import "../../evmscript/IEVMScriptRegistry.sol";
+
+
+contract EVMScriptRegistryConstantsMock is EVMScriptRegistryConstants {
+    function getEVMScriptRegistryAppId() external pure returns (bytes32) { return EVMSCRIPT_REGISTRY_APP_ID; }
+}

--- a/contracts/test/mocks/EtherTokenConstantMock.sol
+++ b/contracts/test/mocks/EtherTokenConstantMock.sol
@@ -1,0 +1,8 @@
+pragma solidity 0.4.24;
+
+import "../../common/EtherTokenConstant.sol";
+
+
+contract EtherTokenConstantMock is EtherTokenConstant {
+    function getETHConstant() external pure returns (address) { return ETH; }
+}

--- a/contracts/test/mocks/KeccakConstants.sol
+++ b/contracts/test/mocks/KeccakConstants.sol
@@ -1,29 +1,27 @@
 pragma solidity 0.4.24;
 
-import "../../apm/APMNamehash.sol";
 
-
-contract KeccakConstants is APMNamehash {
-    // Note: we can't use APMNamehash.apmNamehash() for constants, starting from pragma 0.5 :(
-
-    // Kernel
-    bytes32 public constant CORE_NAMESPACE = keccak256(abi.encodePacked("core"));
-    bytes32 public constant APP_BASES_NAMESPACE = keccak256(abi.encodePacked("base"));
-    bytes32 public constant APP_ADDR_NAMESPACE = keccak256(abi.encodePacked("app"));
-
-    bytes32 public constant KERNEL_APP_ID = keccak256(abi.encodePacked(APM_NODE, keccak256("kernel")));
-    bytes32 public constant ACL_APP_ID = keccak256(abi.encodePacked(APM_NODE, keccak256("acl")));
-
-    bytes32 public constant APP_MANAGER_ROLE = keccak256(abi.encodePacked("APP_MANAGER_ROLE"));
-
-    bytes32 public constant DEFAULT_VAULT_APP_ID = keccak256(abi.encodePacked(APM_NODE, keccak256("vault")));
-
+contract KeccakConstants {
     // ENS
     bytes32 public constant ENS_ROOT = bytes32(0);
     bytes32 public constant ETH_TLD_LABEL = keccak256(abi.encodePacked("eth"));
     bytes32 public constant ETH_TLD_NODE = keccak256(abi.encodePacked(ENS_ROOT, ETH_TLD_LABEL));
     bytes32 public constant PUBLIC_RESOLVER_LABEL = keccak256(abi.encodePacked("resolver"));
     bytes32 public constant PUBLIC_RESOLVER_NODE = keccak256(abi.encodePacked(ETH_TLD_NODE, PUBLIC_RESOLVER_LABEL));
+
+    // APM
+    bytes32 public constant APM_NODE = keccak256(abi.encodePacked(ETH_TLD_NODE, keccak256(abi.encodePacked("aragonpm"))));
+
+    // Kernel
+    bytes32 public constant KERNEL_CORE_NAMESPACE = keccak256(abi.encodePacked("core"));
+    bytes32 public constant KERNEL_APP_BASES_NAMESPACE = keccak256(abi.encodePacked("base"));
+    bytes32 public constant KERNEL_APP_ADDR_NAMESPACE = keccak256(abi.encodePacked("app"));
+
+    bytes32 public constant APP_MANAGER_ROLE = keccak256(abi.encodePacked("APP_MANAGER_ROLE"));
+
+    bytes32 public constant KERNEL_APP_ID = keccak256(abi.encodePacked(APM_NODE, keccak256("kernel")));
+    bytes32 public constant DEFAULT_ACL_APP_ID = keccak256(abi.encodePacked(APM_NODE, keccak256("acl")));
+    bytes32 public constant DEFAULT_VAULT_APP_ID = keccak256(abi.encodePacked(APM_NODE, keccak256("vault")));
 
     // ACL
     bytes32 public constant CREATE_PERMISSIONS_ROLE = keccak256(abi.encodePacked("CREATE_PERMISSIONS_ROLE"));

--- a/contracts/test/mocks/KernelConstantsMock.sol
+++ b/contracts/test/mocks/KernelConstantsMock.sol
@@ -1,0 +1,14 @@
+pragma solidity 0.4.24;
+
+import "../../kernel/Kernel.sol";
+
+
+contract KernelConstantsMock is Kernel {
+    constructor() public Kernel(false) { }
+
+    function getKernelCoreNamespace() external pure returns (bytes32) { return KERNEL_CORE_NAMESPACE; }
+    function getKernelAppBasesNamespace() external pure returns (bytes32) { return KERNEL_APP_BASES_NAMESPACE; }
+    function getKernelAppAddrNamespace() external pure returns (bytes32) { return KERNEL_APP_ADDR_NAMESPACE; }
+    function getKernelAppId() external pure returns (bytes32) { return KERNEL_APP_ID; }
+    function getDefaultVaultAppId() external pure returns (bytes32) { return DEFAULT_VAULT_APP_ID; }
+}

--- a/contracts/test/mocks/KernelOverloadMock.sol
+++ b/contracts/test/mocks/KernelOverloadMock.sol
@@ -7,25 +7,44 @@ import "../../lib/misc/ERCProxy.sol";
 /** Ugly hack to work around this issue:
  * https://github.com/trufflesuite/truffle/issues/569
  * https://github.com/trufflesuite/truffle/issues/737
+ *
+ * NOTE: awkwardly, by default we have access to the full version of `newAppInstance()` but only the
+ * minimized version for `newPinnedAppInstance()`
  */
 contract KernelOverloadMock {
-    Kernel kernel;
+    Kernel public kernel;
 
     event NewAppProxy(address proxy);
 
-    constructor(address _kernel) public {
-        kernel = Kernel(_kernel);
+    constructor(Kernel _kernel) public {
+        kernel = _kernel;
     }
 
-    //function newAppInstance(bytes32 _name, address _appBase, bytes _initializePayload, bool _setDefault) auth(APP_MANAGER_ROLE, arr(APP_BASES_NAMESPACE, _name)) public returns (ERCProxy appProxy) {
-    function newAppInstance(bytes32 _name, address _appBase, bytes _initializePayload, bool _setDefault) public returns (ERCProxy appProxy) {
-        appProxy = kernel.newAppInstance(_name, _appBase, _initializePayload, _setDefault);
+    /*
+    function newAppInstance(bytes32 _appId, address _appBase)
+        public
+        auth(APP_MANAGER_ROLE, arr(KERNEL_APP_BASES_NAMESPACE, _appId))
+        returns (ERCProxy appProxy)
+    */
+    function newAppInstance(bytes32 _appId, address _appBase)
+        public
+        returns (ERCProxy appProxy)
+    {
+        appProxy = kernel.newAppInstance(_appId, _appBase);
         emit NewAppProxy(appProxy);
     }
 
-    // function newPinnedAppInstance(bytes32 _name, address _appBase, bytes _initializePayload, bool _setDefault) auth(APP_MANAGER_ROLE, arr(APP_BASES_NAMESPACE, _name)) public returns (ERCProxy appProxy) {
-    function newPinnedAppInstance(bytes32 _name, address _appBase, bytes _initializePayload, bool _setDefault) public returns (ERCProxy appProxy) {
-        appProxy = kernel.newPinnedAppInstance(_name, _appBase, _initializePayload, _setDefault);
+    /*
+    function newPinnedAppInstance(bytes32 _appId, address _appBase, bytes _initializePayload, bool _setDefault)
+        public
+        auth(APP_MANAGER_ROLE, arr(KERNEL_APP_BASES_NAMESPACE, _appId))
+        returns (ERCProxy appProxy)
+    */
+    function newPinnedAppInstance(bytes32 _appId, address _appBase, bytes _initializePayload, bool _setDefault)
+        public
+        returns (ERCProxy appProxy)
+    {
+        appProxy = kernel.newPinnedAppInstance(_appId, _appBase, _initializePayload, _setDefault);
         emit NewAppProxy(appProxy);
     }
 }

--- a/test/apm_namehash.js
+++ b/test/apm_namehash.js
@@ -1,19 +1,19 @@
 const namehash = require('eth-ens-namehash').hash
-const APMNamehashWrapper = artifacts.require('APMNamehashWrapper')
+const APMNamehashMock = artifacts.require('APMNamehashMock')
 
 contract('APM Name Hash', accounts => {
-  let apmNamehashWrapper
+  let apmNamehashMock
 
   before(async() => {
     //console.log("eth: " + namehash('eth'))
     //console.log("aragonpm.eth: " + namehash('aragonpm.eth'))
-    apmNamehashWrapper = await APMNamehashWrapper.new()
+    apmNamehashMock = await APMNamehashMock.new()
   })
 
   const checkName = async (name) => {
     const node = namehash(name + '.aragonpm.eth')
-    //await apmNamehashWrapper.getAPMNamehash(name)
-    const apmNamehash = await apmNamehashWrapper.getAPMNamehash(name)
+    //await apmNamehashMock.getAPMNamehash(name)
+    const apmNamehash = await apmNamehashMock.getAPMNamehash(name)
     //console.log("node: " + node)
     return apmNamehash.toString() == node
   }

--- a/test/evm_script.js
+++ b/test/evm_script.js
@@ -166,7 +166,7 @@ contract('EVM Script', accounts => {
 
     context('> Uninitialized executor', () => {
         beforeEach(async () => {
-            const receipt = await dao.newAppInstance(executorAppId, executorAppBase.address, { from: boss })
+            const receipt = await dao.newAppInstance(executorAppId, executorAppBase.address, '0x', false, { from: boss })
             executorApp = MockScriptExecutorApp.at(receipt.logs.filter(l => l.event == 'NewAppProxy')[0].args.proxy)
             // Explicitly don't initialize the executorApp
             executionTarget = await ExecutionTarget.new()
@@ -182,7 +182,7 @@ contract('EVM Script', accounts => {
 
     context('> Executor', () => {
         beforeEach(async () => {
-            const receipt = await dao.newAppInstance(executorAppId, executorAppBase.address, { from: boss })
+            const receipt = await dao.newAppInstance(executorAppId, executorAppBase.address, '0x', false, { from: boss })
             executorApp = MockScriptExecutorApp.at(receipt.logs.filter(l => l.event == 'NewAppProxy')[0].args.proxy)
             await executorApp.initialize()
             executionTarget = await ExecutionTarget.new()

--- a/test/keccak_constants.js
+++ b/test/keccak_constants.js
@@ -11,28 +11,35 @@ contract('Constants', accounts => {
     keccakConstants = await getContract('KeccakConstants').new()
   })
 
+  it('checks ENS constants', async () => {
+    const ensConstants = await getContract('ENSConstantsMock').new()
+
+    assert.equal(await ensConstants.getEthTldLabel(), await keccakConstants.ETH_TLD_LABEL(), "ETH tld label doesn't match")
+    assert.equal(await ensConstants.getEthTldNode(), await keccakConstants.ETH_TLD_NODE(), "ETH tld node doesn't match")
+    assert.equal(await ensConstants.getPublicResolverLabel(), await keccakConstants.PUBLIC_RESOLVER_LABEL(), "public resolver label doesn't match")
+    assert.equal(await ensConstants.getPublicResolverNode(), await keccakConstants.PUBLIC_RESOLVER_NODE(), "public resolver node doesn't match")
+  })
+
+  it('checks APMNamehash constants', async () => {
+    const apmNamehash = await getContract('APMNamehashMock').new()
+
+    assert.equal(await apmNamehash.getAPMNode(), await keccakConstants.APM_NODE(), "APM node doesn't match")
+  })
+
   it('checks kernel constants', async () => {
-    const kernelConstants = await getContract('KernelConstants').new()
-
-    assert.equal(await kernelConstants.CORE_NAMESPACE(), await keccakConstants.CORE_NAMESPACE(), "core namespace doesn't match")
-    assert.equal(await kernelConstants.APP_BASES_NAMESPACE(), await keccakConstants.APP_BASES_NAMESPACE(), "base namespace doesn't match")
-    assert.equal(await kernelConstants.APP_ADDR_NAMESPACE(), await keccakConstants.APP_ADDR_NAMESPACE(), "app namespace doesn't match")
-
-    assert.equal(await kernelConstants.KERNEL_APP_ID(), await keccakConstants.KERNEL_APP_ID(), "kernel app id doesn't match")
-    assert.equal(await kernelConstants.ACL_APP_ID(), await keccakConstants.ACL_APP_ID(), "acl app id doesn't match")
+    const kernelConstants = await getContract('KernelConstantsMock').new()
+    assert.equal(await kernelConstants.getKernelAppId(), await keccakConstants.KERNEL_APP_ID(), "kernel app id doesn't match")
+    assert.equal(await kernelConstants.getDefaultVaultAppId(), await keccakConstants.DEFAULT_VAULT_APP_ID(), "default vault id doesn't match")
+    assert.equal(await kernelConstants.getKernelCoreNamespace(), await keccakConstants.KERNEL_CORE_NAMESPACE(), "core namespace doesn't match")
+    assert.equal(await kernelConstants.getKernelAppBasesNamespace(), await keccakConstants.KERNEL_APP_BASES_NAMESPACE(), "base namespace doesn't match")
+    assert.equal(await kernelConstants.getKernelAppAddrNamespace(), await keccakConstants.KERNEL_APP_ADDR_NAMESPACE(), "app namespace doesn't match")
 
     const kernel = await getContract('Kernel').new(false)
     assert.equal(await kernel.APP_MANAGER_ROLE(), await keccakConstants.APP_MANAGER_ROLE(), "app manager role doesn't match")
-    assert.equal(await kernel.DEFAULT_VAULT_APP_ID(), await keccakConstants.DEFAULT_VAULT_APP_ID(), "default vault id doesn't match")
-  })
-
-  it('checks ENS constants', async () => {
-    const ensConstants = await getContract('ENSConstants').new()
-
-    assert.equal(await ensConstants.ETH_TLD_LABEL(), await keccakConstants.ETH_TLD_LABEL(), "ETH tld label doesn't match")
-    assert.equal(await ensConstants.ETH_TLD_NODE(), await keccakConstants.ETH_TLD_NODE(), "ETH tld node doesn't match")
-    assert.equal(await ensConstants.PUBLIC_RESOLVER_LABEL(), await keccakConstants.PUBLIC_RESOLVER_LABEL(), "public resolver label doesn't match")
-    assert.equal(await ensConstants.PUBLIC_RESOLVER_NODE(), await keccakConstants.PUBLIC_RESOLVER_NODE(), "public resolver node doesn't match")
+    assert.equal(await kernel.DEFAULT_ACL_APP_ID(), await keccakConstants.DEFAULT_ACL_APP_ID(), "default acl id doesn't match")
+    assert.equal(await kernel.CORE_NAMESPACE(), await keccakConstants.KERNEL_CORE_NAMESPACE(), "core namespace doesn't match")
+    assert.equal(await kernel.APP_BASES_NAMESPACE(), await keccakConstants.KERNEL_APP_BASES_NAMESPACE(), "base namespace doesn't match")
+    assert.equal(await kernel.APP_ADDR_NAMESPACE(), await keccakConstants.KERNEL_APP_ADDR_NAMESPACE(), "app namespace doesn't match")
   })
 
   it('checks APMRegistry constants', async () => {
@@ -57,9 +64,9 @@ contract('Constants', accounts => {
   })
 
   it('checks EVM Script constants', async () => {
-    const evmScriptConstants = await getContract('EVMScriptRegistryConstants').new()
+    const evmScriptConstants = await getContract('EVMScriptRegistryConstantsMock').new()
 
-    assert.equal(await evmScriptConstants.EVMSCRIPT_REGISTRY_APP_ID(), await keccakConstants.EVMSCRIPT_REGISTRY_APP_ID(), "app id doesn't match")
+    assert.equal(await evmScriptConstants.getEVMScriptRegistryAppId(), await keccakConstants.EVMSCRIPT_REGISTRY_APP_ID(), "app id doesn't match")
   })
 
   it('checks EVM Script executor types', async () => {

--- a/test/kernel_acl.js
+++ b/test/kernel_acl.js
@@ -70,7 +70,7 @@ contract('Kernel ACL', accounts => {
             it('cannot initialize proxied ACL outside of Kernel', async () => {
                 // Set up ACL proxy
                 await acl.createPermission(permissionsRoot, kernelAddr, APP_MANAGER_ROLE, permissionsRoot)
-                const receipt = await kernel.newAppInstance(DEFAULT_ACL_APP_ID, aclBase.address)
+                const receipt = await kernel.newAppInstance(DEFAULT_ACL_APP_ID, aclBase.address, '0x', false)
                 const newAcl = ACL.at(receipt.logs.filter(l => l.event == 'NewAppProxy')[0].args.proxy)
 
                 return assertRevert(async () => {

--- a/test/kernel_acl.js
+++ b/test/kernel_acl.js
@@ -15,7 +15,7 @@ const APP_ID = hash('stub.aragonpm.test')
 
 contract('Kernel ACL', accounts => {
     let aclBase, appBase
-    let APP_MANAGER_ROLE, APP_BASES_NAMESPACE, ACL_APP_ID, ANY_ENTITY
+    let APP_MANAGER_ROLE, APP_BASES_NAMESPACE, DEFAULT_ACL_APP_ID, ANY_ENTITY
 
     const permissionsRoot = accounts[0]
     const granted = accounts[1]
@@ -31,7 +31,7 @@ contract('Kernel ACL', accounts => {
         const kernel = await Kernel.new(true)
         APP_BASES_NAMESPACE = await kernel.APP_BASES_NAMESPACE()
         APP_MANAGER_ROLE = await kernel.APP_MANAGER_ROLE()
-        ACL_APP_ID = await kernel.ACL_APP_ID()
+        DEFAULT_ACL_APP_ID = await kernel.DEFAULT_ACL_APP_ID()
         ANY_ENTITY = await aclBase.ANY_ENTITY()
     })
 
@@ -70,7 +70,7 @@ contract('Kernel ACL', accounts => {
             it('cannot initialize proxied ACL outside of Kernel', async () => {
                 // Set up ACL proxy
                 await acl.createPermission(permissionsRoot, kernelAddr, APP_MANAGER_ROLE, permissionsRoot)
-                const receipt = await kernel.newAppInstance(ACL_APP_ID, aclBase.address)
+                const receipt = await kernel.newAppInstance(DEFAULT_ACL_APP_ID, aclBase.address)
                 const newAcl = ACL.at(receipt.logs.filter(l => l.event == 'NewAppProxy')[0].args.proxy)
 
                 return assertRevert(async () => {

--- a/test/kernel_apps.js
+++ b/test/kernel_apps.js
@@ -145,7 +145,7 @@ contract('Kernel apps', accounts => {
                         const kernelMock = await KernelOverloadMock.new(kernel.address)
 
                         await withAppManagerPermission(kernelMock.address, async () => {
-                            const receipt = await kernelMock[newInstanceFn](APP_ID, appBase1.address, '0x', true)
+                            const receipt = await kernelMock[newInstanceFn](APP_ID, appBase1.address, true, '0x')
                             appProxyAddr = receipt.logs.filter(l => l.event == 'NewAppProxy')[0].args.proxy
                         })
 
@@ -166,7 +166,7 @@ contract('Kernel apps', accounts => {
                         const initData = appBase1.initialize.request().params[0].data
 
                         await withAppManagerPermission(kernelMock.address, async () => {
-                            const receipt = await kernelMock[newInstanceFn](APP_ID, appBase1.address, initData, false)
+                            const receipt = await kernelMock[newInstanceFn](APP_ID, appBase1.address, false, initData)
                             appProxyAddr = receipt.logs.filter(l => l.event == 'NewAppProxy')[0].args.proxy
                         })
 

--- a/test/kernel_lifecycle.js
+++ b/test/kernel_lifecycle.js
@@ -14,7 +14,7 @@ const VAULT_ID = hash('vault.aragonpm.test')
 
 contract('Kernel lifecycle', accounts => {
   let aclBase, appBase
-  let ACL_APP_ID, APP_BASES_NAMESPACE, APP_ADDR_NAMESPACE, APP_MANAGER_ROLE
+  let DEFAULT_ACL_APP_ID, APP_BASES_NAMESPACE, APP_ADDR_NAMESPACE, APP_MANAGER_ROLE
 
   const testUnaccessibleFunctionalityWhenUninitialized = async (kernel) => {
     // hasPermission should always return false when uninitialized
@@ -49,7 +49,7 @@ contract('Kernel lifecycle', accounts => {
 
     // Setup constants
     const kernel = await Kernel.new(true)
-    ACL_APP_ID = await kernel.ACL_APP_ID()
+    DEFAULT_ACL_APP_ID = await kernel.DEFAULT_ACL_APP_ID()
     APP_BASES_NAMESPACE = await kernel.APP_BASES_NAMESPACE()
     APP_ADDR_NAMESPACE = await kernel.APP_ADDR_NAMESPACE()
     APP_MANAGER_ROLE = await kernel.APP_MANAGER_ROLE()
@@ -146,10 +146,10 @@ contract('Kernel lifecycle', accounts => {
         const ACLAppLog = setAppLogs[1]
 
         assert.equal(ACLBaseLog.args.namespace, APP_BASES_NAMESPACE, 'should set base acl first')
-        assert.equal(ACLBaseLog.args.appId, ACL_APP_ID, 'should set base acl first')
+        assert.equal(ACLBaseLog.args.appId, DEFAULT_ACL_APP_ID, 'should set base acl first')
         assert.equal(ACLBaseLog.args.app, aclBase.address, 'should set base acl first')
         assert.equal(ACLAppLog.args.namespace, APP_ADDR_NAMESPACE, 'should set default acl second')
-        assert.equal(ACLAppLog.args.appId, ACL_APP_ID, 'should set default acl second')
+        assert.equal(ACLAppLog.args.appId, DEFAULT_ACL_APP_ID, 'should set default acl second')
         assert.equal(ACLAppLog.args.app, acl.address, 'should set default acl second')
       })
 

--- a/test/kernel_lifecycle.js
+++ b/test/kernel_lifecycle.js
@@ -21,7 +21,7 @@ contract('Kernel lifecycle', accounts => {
     assert.isFalse(await kernel.hasPermission(accounts[0], kernel.address, APP_MANAGER_ROLE, '0x'))
     assert.isFalse(await kernel.hasPermission(accounts[1], kernel.address, APP_MANAGER_ROLE, '0x'))
 
-    await assertRevert(() => kernel.newAppInstance(APP_ID, appBase.address))
+    await assertRevert(() => kernel.newAppInstance(APP_ID, appBase.address, '0x', false))
     await assertRevert(() => kernel.newPinnedAppInstance(APP_ID, appBase.address))
     await assertRevert(() => kernel.setApp(APP_BASES_NAMESPACE, APP_ID, appBase.address))
     await assertRevert(() => kernel.setRecoveryVaultAppId(VAULT_ID))
@@ -39,7 +39,7 @@ contract('Kernel lifecycle', accounts => {
     assert.isFalse(await kernel.hasPermission(accounts[1], kernel.address, APP_MANAGER_ROLE, '0x'))
 
     // And finally test functionality
-    await kernel.newAppInstance(APP_ID, appBase.address)
+    await kernel.newAppInstance(APP_ID, appBase.address, '0x', false)
   }
 
   // Initial setup

--- a/test/kernel_upgrade.js
+++ b/test/kernel_upgrade.js
@@ -5,12 +5,15 @@ const Kernel = artifacts.require('Kernel')
 const KernelProxy = artifacts.require('KernelProxy')
 const UpgradedKernel = artifacts.require('UpgradedKernel')
 
+// Mocks
+const ERCProxyMock = artifacts.require('ERCProxyMock')
+
 const ZERO_ADDR = '0x0000000000000000000000000000000000000000'
 
 // Only applicable to KernelProxy instances
 contract('Kernel upgrade', accounts => {
     let aclBase, kernelBase, upgradedBase, kernelAddr, kernel, acl
-    let APP_MANAGER_ROLE, CORE_NAMESPACE, KERNEL_APP_ID
+    let APP_MANAGER_ROLE, CORE_NAMESPACE, KERNEL_APP_ID, UPGRADEABLE
 
     const permissionsRoot = accounts[0]
 
@@ -24,6 +27,9 @@ contract('Kernel upgrade', accounts => {
         APP_MANAGER_ROLE = await kernelBase.APP_MANAGER_ROLE()
         CORE_NAMESPACE = await kernelBase.CORE_NAMESPACE()
         KERNEL_APP_ID = await kernelBase.KERNEL_APP_ID()
+
+        const ercProxyMock = await ERCProxyMock.new()
+        UPGRADEABLE = (await ercProxyMock.UPGRADEABLE()).toString()
     })
 
     beforeEach(async () => {
@@ -38,7 +44,7 @@ contract('Kernel upgrade', accounts => {
         const implementation = await kernelProxy.implementation()
         assert.equal(implementation, kernelBase.address, "App address should match")
         const proxyType = (await kernelProxy.proxyType()).toString()
-        assert.equal(proxyType, (await kernelProxy.UPGRADEABLE()).toString(), "Proxy type should be 2 (upgradeable)")
+        assert.equal(proxyType, UPGRADEABLE, "Proxy type should be 2 (upgradeable)")
     })
 
     it('fails to create a KernelProxy if the base is 0', async () => {

--- a/test/proxy_recover_funds.js
+++ b/test/proxy_recover_funds.js
@@ -125,7 +125,7 @@ contract('Proxy funds', accounts => {
               vault = vaultBase
             } else if (vaultType === 'VaultProxy') {
               // This doesn't automatically setup the recovery address
-              const receipt = await kernel.newAppInstance(vaultId, vaultBase.address)
+              const receipt = await kernel.newAppInstance(vaultId, vaultBase.address, '0x', false)
               const vaultProxyAddress = getEvent(receipt, 'NewAppProxy', 'proxy')
               vault = VaultMock.at(vaultProxyAddress)
             }
@@ -167,7 +167,7 @@ contract('Proxy funds', accounts => {
           context('> Proxied app with kernel', () => {
             beforeEach(async () => {
               // Setup app
-              const receipt = await kernel.newAppInstance(APP_ID, appBase.address)
+              const receipt = await kernel.newAppInstance(APP_ID, appBase.address, '0x', false)
               const appProxy = getEvent(receipt, 'NewAppProxy', 'proxy')
               const app = AppStubDepositable.at(appProxy)
               await app.enableDeposits()
@@ -203,7 +203,7 @@ contract('Proxy funds', accounts => {
           context('> Conditional fund recovery', () => {
             beforeEach(async () => {
               // Setup app with conditional recovery code
-              const receipt = await kernel.newAppInstance(APP_ID, appConditionalRecoveryBase.address)
+              const receipt = await kernel.newAppInstance(APP_ID, appConditionalRecoveryBase.address, '0x', false)
               const appProxy = getEvent(receipt, 'NewAppProxy', 'proxy')
               const app = AppStubConditionalRecovery.at(appProxy)
               await app.initialize()
@@ -246,7 +246,7 @@ contract('Proxy funds', accounts => {
       // Create a new vault and set that vault as the default vault in the kernel
       const vaultId = hash('vault.aragonpm.test')
       const vaultBase = await VaultMock.new()
-      const vaultReceipt = await kernel.newAppInstance(vaultId, vaultBase.address, '', true)
+      const vaultReceipt = await kernel.newAppInstance(vaultId, vaultBase.address, '0x', true)
       const vaultAddress = getEvent(vaultReceipt, 'NewAppProxy', 'proxy')
       vault = VaultMock.at(vaultAddress)
       await vault.initialize()

--- a/test/proxy_recover_funds.js
+++ b/test/proxy_recover_funds.js
@@ -12,6 +12,7 @@ const AppProxyUpgradeable = artifacts.require('AppProxyUpgradeable')
 // Mocks
 const AppStubDepositable = artifacts.require('AppStubDepositable')
 const AppStubConditionalRecovery = artifacts.require('AppStubConditionalRecovery')
+const EtherTokenConstantMock = artifacts.require('EtherTokenConstantMock')
 const TokenMock = artifacts.require('TokenMock')
 const VaultMock = artifacts.require('VaultMock')
 const KernelDepositableMock = artifacts.require('KernelDepositableMock')
@@ -23,7 +24,7 @@ const SEND_ETH_GAS = 31000 // 21k base tx cost + 10k limit on depositable proxie
 
 contract('Proxy funds', accounts => {
   let aclBase, appBase, appConditionalRecoveryBase
-  let APP_BASES_NAMESPACE, APP_ADDR_NAMESPACE, ETH
+  let APP_ADDR_NAMESPACE, ETH
 
   const permissionsRoot = accounts[0]
 
@@ -71,9 +72,10 @@ contract('Proxy funds', accounts => {
 
     // Setup constants
     const kernel = await Kernel.new(true)
-    APP_BASES_NAMESPACE = await kernel.APP_BASES_NAMESPACE()
     APP_ADDR_NAMESPACE = await kernel.APP_ADDR_NAMESPACE()
-    ETH = await kernel.ETH()
+
+    const etherTokenConstantMock = await EtherTokenConstantMock.new()
+    ETH = await etherTokenConstantMock.getETHConstant()
   })
 
   // Test both the Kernel itself and the KernelProxy to make sure their behaviours are the same


### PR DESCRIPTION
Prunes most public constants, leaving only important constants that are likely to be useful on-chain:

- Roles
- Default app IDs (useful across versions of `aragonOS` in case they change)
- Kernel namespaces (useful across versions of the `Kernel` in case they change)
- ACL scripting constants (potentially useful across versions / verifying information from getters)

Commits:

- e204fa2: cosmetic reordering / comments
- 0a0983e: renames `APMRegistryConstants` to `APMInternalAppNames` as these APM "internal" apps are registered in the same way as other APM packages and the contract only holds the string names
- **cd19f32**: actually removes constants
- f9fe190: fixes `kernel.newAppInstance()` in tests due to the default version changing :(

Against #432, the bytecode comparison:

```
                               CODE DEPOSIT COST    DEPLOYED BYTES     INITIALIZATION BYTES
ACL.json                       33600 less gas       -168               0
APMNamehash.json               270200 less gas      -1351              -3
APMRegistry.json               189200 less gas      -946               0
APMRegistryFactory.json        75600 less gas       -378               0
APMRegistryFactoryMock.json    75600 less gas       -378               0
AppProxyFactory.json           73600 less gas       -368               0
AppProxyPinned.json            36800 less gas       -184               0
AppProxyPinnedStorageMock.json 36000 less gas       -180               -53
AppProxyUpgradeable.json       36800 less gas       -184               0
AragonApp.json                 34600 less gas       -173               0
DAOFactory.json                36000 less gas       -180               0
ENSConstants.json              186600 less gas      -933               -3
ENSFactory.json                152800 less gas      -764               0
ENSSubdomainRegistrar.json     170800 less gas      -854               0
EVMScriptRegistry.json         34600 less gas       -173               0
EVMScriptRegistryConstants.js… 26000 less gas       -130               -1
EVMScriptRegistryFactory.json  91600 less gas       -458               -173
EVMScriptRunner.json           27200 less gas       -136               0
EtherTokenConstant.json        24400 less gas       -122               -2
KeccakConstants.json           183000 more gas      +915               0
Kernel.json                    97200 less gas       -486               0
KernelConstants.json           55400 less gas       -277               -2
KernelOverloadMock.json        14800 more gas       +74                0
KernelPinnedStorageMock.json   97200 less gas       -486               0
KernelProxy.json               36000 less gas       -180               0
KernelStorage.json             15400 more gas       +77                0
Repo.json                      34600 less gas       -173               0
Uint256Helpers.json            18800 less gas       -94                -3
```