### PR TITLE
[BREAKING CHANGE] EVMScriptRunner: expose getEVMScriptRegistry

### DIFF
--- a/contracts/evmscript/EVMScriptRunner.sol
+++ b/contracts/evmscript/EVMScriptRunner.sol
@@ -19,8 +19,13 @@ contract EVMScriptRunner is AppStorage, Initializable, EVMScriptRegistryConstant
 
     event ScriptResult(address indexed executor, bytes script, bytes input, bytes returnData);
 
-    function getExecutor(bytes _script) public view returns (IEVMScriptExecutor) {
-        return IEVMScriptExecutor(getExecutorRegistry().getScriptExecutor(_script));
+    function getEVMScriptExecutor(bytes _script) public view returns (IEVMScriptExecutor) {
+        return IEVMScriptExecutor(getEVMScriptRegistry().getScriptExecutor(_script));
+    }
+
+    function getEVMScriptRegistry() public view returns (IEVMScriptRegistry) {
+        address registryAddr = kernel().getApp(KERNEL_APP_ADDR_NAMESPACE, EVMSCRIPT_REGISTRY_APP_ID);
+        return IEVMScriptRegistry(registryAddr);
     }
 
     function runScript(bytes _script, bytes _input, address[] _blacklist)
@@ -30,7 +35,7 @@ contract EVMScriptRunner is AppStorage, Initializable, EVMScriptRegistryConstant
         returns (bytes)
     {
         // TODO: Too much data flying around, maybe extracting spec id here is cheaper
-        IEVMScriptExecutor executor = getExecutor(_script);
+        IEVMScriptExecutor executor = getEVMScriptExecutor(_script);
         require(address(executor) != address(0), ERROR_EXECUTOR_UNAVAILABLE);
 
         bytes4 sig = executor.execScript.selector;
@@ -42,11 +47,6 @@ contract EVMScriptRunner is AppStorage, Initializable, EVMScriptRegistryConstant
         emit ScriptResult(address(executor), _script, _input, output);
 
         return output;
-    }
-
-    function getExecutorRegistry() internal view returns (IEVMScriptRegistry) {
-        address registryAddr = kernel().getApp(KERNEL_APP_ADDR_NAMESPACE, EVMSCRIPT_REGISTRY_APP_ID);
-        return IEVMScriptRegistry(registryAddr);
     }
 
     /**

--- a/test/evm_script.js
+++ b/test/evm_script.js
@@ -188,6 +188,11 @@ contract('EVM Script', accounts => {
             executionTarget = await ExecutionTarget.new()
         })
 
+        it('gets the correct executor registry from the app', async () => {
+            const appRegistry = await executorApp.getEVMScriptRegistry()
+            assert.equal(reg.address, appRegistry, 'app should return the same evm script registry')
+        })
+
         it('fails to execute if spec ID is 0', async () => {
             return assertRevert(async () => {
                 await executorApp.execute('0x00000000')
@@ -205,6 +210,15 @@ contract('EVM Script', accounts => {
                 const CALLS_SCRIPT_TYPE = soliditySha3('CALLS_SCRIPT')
                 const executor = IEVMScriptExecutor.at(await reg.getScriptExecutor('0x00000001'))
                 assert.equal(await executor.executorType(), CALLS_SCRIPT_TYPE)
+            })
+
+            it('gets the correct executor from the app', async () => {
+                const CALLS_SCRIPT_TYPE = soliditySha3('CALLS_SCRIPT')
+                const script = '0x00000001'
+                const executor = await reg.getScriptExecutor(script)
+
+                const appExecutor = await executorApp.getEVMScriptExecutor(script)
+                assert.equal(executor, appExecutor, 'app should return the same evm script executor')
             })
 
             it('executes single action script', async () => {


### PR DESCRIPTION
From https://github.com/aragon/aragonOS/pull/443#discussion_r227039851.

Since this will most commonly be exposed as part of an `AragonApp`, I've opted to make the two functions more explicit (note that this is a breaking public interface change).