### PR TITLE
Change devnet (docker image) network id

### DIFF
--- a/truffle-config.js
+++ b/truffle-config.js
@@ -62,7 +62,7 @@ module.exports = {
       gas: 6.9e6
     },
     devnet: {
-      network_id: 15,
+      network_id: 16,
       host: 'localhost',
       port: 8535,
       gas: 6.9e6


### PR DESCRIPTION
Needed for dao-kits, to automatically choose network from scripts. Right now it's overlapping with `rpc`.