### PR TITLE
AragonApp: fix possibly uninitialized bytes array when checking permissions

### DIFF
--- a/contracts/acl/ACL.sol
+++ b/contracts/acl/ACL.sol
@@ -244,7 +244,7 @@ contract ACL is IACL, TimeHelpers, AragonApp, ACLHelpers {
     function hasPermission(address _who, address _where, bytes32 _what, bytes memory _how) public view returns (bool) {
         // Force cast the bytes array into a uint256[], by overwriting its length
         // Note that the uint256[] doesn't need to be initialized as we immediately overwrite it
-        // with _how and a new length, and _howbecomes invalid from this point forward
+        // with _how and a new length, and _how becomes invalid from this point forward
         uint256[] memory how;
         uint256 intsLength = _how.length / 32;
         assembly {

--- a/contracts/acl/ACL.sol
+++ b/contracts/acl/ACL.sol
@@ -242,13 +242,16 @@ contract ACL is IACL, TimeHelpers, AragonApp, ACLHelpers {
     * @return boolean indicating whether the ACL allows the role or not
     */
     function hasPermission(address _who, address _where, bytes32 _what, bytes memory _how) public view returns (bool) {
+        // Force cast the bytes array into a uint256[], by overwriting its length
+        // Note that the uint256[] doesn't need to be initialized as we immediately overwrite it
+        // with _how and a new length, and _howbecomes invalid from this point forward
         uint256[] memory how;
         uint256 intsLength = _how.length / 32;
         assembly {
-            how := _how // forced casting
+            how := _how
             mstore(how, intsLength)
         }
-        // _how is invalid from this point fwd
+
         return hasPermission(_who, _where, _what, how);
     }
 

--- a/contracts/apps/AragonApp.sol
+++ b/contracts/apps/AragonApp.sol
@@ -47,10 +47,13 @@ contract AragonApp is AppStorage, Autopetrified, VaultRecoverable, EVMScriptRunn
             return false;
         }
 
-        bytes memory how; // no need to init memory as it is never used
+        // Force cast the uint256[] into a bytes array, by overwriting its length
+        // Note that the bytes array doesn't need to be initialized as we immediately overwrite it
+        // with _params and a new length, and _params becomes invalid from this point forward
+        bytes memory how;
         uint256 byteLength = _params.length * 32;
         assembly {
-            how := _params // forced casting
+            how := _params
             mstore(how, byteLength)
         }
         return linkedKernel.hasPermission(_sender, address(this), _role, how);

--- a/contracts/apps/AragonApp.sol
+++ b/contracts/apps/AragonApp.sol
@@ -48,12 +48,10 @@ contract AragonApp is AppStorage, Autopetrified, VaultRecoverable, EVMScriptRunn
         }
 
         bytes memory how; // no need to init memory as it is never used
-        if (_params.length > 0) {
-            uint256 byteLength = _params.length * 32;
-            assembly {
-                how := _params // forced casting
-                mstore(how, byteLength)
-            }
+        uint256 byteLength = _params.length * 32;
+        assembly {
+            how := _params // forced casting
+            mstore(how, byteLength)
         }
         return linkedKernel.hasPermission(_sender, address(this), _role, how);
     }

--- a/contracts/kernel/Kernel.sol
+++ b/contracts/kernel/Kernel.sol
@@ -228,13 +228,16 @@ contract Kernel is IKernel, KernelStorage, KernelAppIds, KernelNamespaceConstant
     }
 
     modifier auth(bytes32 _role, uint256[] memory params) {
+        // Force cast the uint256[] into a bytes array, by overwriting its length
+        // Note that the bytes array doesn't need to be initialized as we immediately overwrite it
+        // with params and a new length, and params becomes invalid from this point forward
         bytes memory how;
         uint256 byteLength = params.length * 32;
         assembly {
-            how := params // forced casting
+            how := params
             mstore(how, byteLength)
         }
-        // Params is invalid from this point fwd
+
         require(hasPermission(msg.sender, address(this), _role, how), ERROR_AUTH_FAILED);
         _;
     }


### PR DESCRIPTION
From https://github.com/ConsenSys/aragonOS-audit-repo/issues/46:

> The `how` object in the `AragonApp.canPerform` function depends on possibly undefined Solidity behavior. Due to the sensitive nature of the function, we recommend initializing the `how` variable when `_params.length == 0` to avoid the possibility of a vulnerability.

------------------

I tried removing all the logic related to casting to/from bytes and uint arrays to their own separate contract or libraries, but in both cases the bytecode diff was extreme (+50k to +120k in gas) so I've opted not to consolidate and just align all the comments.

Bytecode comparison:

```
                               CODE DEPOSIT COST    DEPLOYED BYTES     INITIALIZATION BYTES
ACL.json                       1600 less gas        -8                 0
APMRegistry.json               1800 less gas        -9                 0
AppStub.json                   1600 less gas        -8                 0
AppStub2.json                  1600 less gas        -8                 0
AppStubConditionalRecovery.js… 1600 less gas        -8                 0
AppStubDepositable.json        1600 less gas        -8                 0
AragonApp.json                 1600 less gas        -8                 0
ENSSubdomainRegistrar.json     1600 less gas        -8                 0
EVMScriptRegistry.json         1600 less gas        -8                 0
EVMScriptRegistryFactory.json  Same                 0                  -8
MockScriptExecutorApp.json     1600 less gas        -8                 0
Repo.json                      1600 less gas        -8                 0
TestACLInterpreter.json        1600 less gas        -8                 0
UnsafeAppStub.json             1600 less gas        -8                 0
UnsafeAppStubDepositable.json  1600 less gas        -8                 0
UnsafeAragonApp.json           1600 less gas        -8                 0
UnsafeAragonAppMock.json       1600 less gas        -8                 0
VaultMock.json                 1600 less gas        -8                 0
```