### PR TITLE
deploy-apm: Implement name transfer instead of always creating subnode

### DIFF
--- a/scripts/deploy-apm.js
+++ b/scripts/deploy-apm.js
@@ -1,10 +1,10 @@
 const namehash = require('eth-ens-namehash').hash
 const keccak256 = require('js-sha3').keccak_256
-const { promisify } = require('util')
 
 const deployENS = require('./deploy-test-ens')
 const deployDaoFactory = require('./deploy-daofactory')
 const logDeploy = require('./helpers/deploy-logger')
+const getAccounts = require('./helpers/get-accounts')
 
 const globalArtifacts = this.artifacts // Not injected unless called directly via truffle
 
@@ -45,8 +45,8 @@ module.exports = async (
 
   log('Deploying APM...')
 
+  const accounts = await getAccounts(web3)
   if (!owner) {
-    const accounts = await promisify(web3.eth.getAccounts)()
     owner = accounts[0]
     log('OWNER env variable not found, setting APM owner to the provider\'s first account')
   }

--- a/scripts/deploy-apm.js
+++ b/scripts/deploy-apm.js
@@ -40,6 +40,7 @@ module.exports = async (
   const labelName = 'aragonpm'
   const tldHash = namehash(tldName)
   const labelHash = '0x'+keccak256(labelName)
+  const apmNode = namehash(`${labelName}.${tldName}`)
 
   let ens
 
@@ -98,14 +99,21 @@ module.exports = async (
   await logDeploy(apmFactory, { verbose })
 
   log(`Assigning ENS name (${labelName}.${tldName}) to factory...`)
-  try {
-    await ens.setSubnodeOwner(tldHash, labelHash, apmFactory.address)
-  } catch (err) {
-    console.error(
-      `Error: could not set the owner of '${labelName}.${tldName}' on the given ENS instance`,
-      `(${ensAddress}). Make sure you have ownership rights over the subdomain.`
-    )
-    throw err
+
+  if (await ens.owner(apmNode) === accounts[0]) {
+    log('Transferring name ownership from deployer to APMRegistryFactory')
+    await ens.setOwner(apmNode, apmFactory.address)
+  } else {
+    log('Creating subdomain and assigning it to APMRegistryFactory')
+    try {
+      await ens.setSubnodeOwner(tldHash, labelHash, apmFactory.address)
+    } catch (err) {
+      console.error(
+        `Error: could not set the owner of '${labelName}.${tldName}' on the given ENS instance`,
+        `(${ensAddress}). Make sure you have ownership rights over the subdomain.`
+      )
+      throw err
+    }
   }
 
   log('Deploying APM...')

--- a/scripts/deploy-test-ens.js
+++ b/scripts/deploy-test-ens.js
@@ -1,5 +1,5 @@
 const logDeploy = require('./helpers/deploy-logger')
-const { promisify } = require('util')
+const getAccounts = require('./helpers/get-accounts')
 
 const globalArtifacts = this.artifacts // Not injected unless called directly via truffle
 
@@ -11,7 +11,7 @@ module.exports = async (truffleExecCallback, { artifacts = globalArtifacts, owne
   }
 
   if (!owner) {
-    const accounts = await promisify(web3.eth.getAccounts)()
+    const accounts = await getAccounts(web3)
     owner = accounts[0]
     log(`No OWNER environment variable passed, setting ENS owner to provider's account: ${owner}`)
   }

--- a/scripts/helpers/get-accounts.js
+++ b/scripts/helpers/get-accounts.js
@@ -1,0 +1,10 @@
+module.exports = web3 => (
+  new Promise((resolve, reject) => {
+    web3.eth.getAccounts((err, accounts) => {
+      if (err) {
+        return reject(err)
+      }
+      resolve(accounts)
+    })
+  })
+)


### PR DESCRIPTION
When using a real ENS (on mainnet) `setSubdomainOwner` would fail as the deployed won't be the owner of the `eth` TLD.

Also 8bb2d81 fixes the scripts failing as `util.promisify` is not available inside the `truffle exec` execution context.