### PR TITLE
KernelProxy: emit SetApp event on construction

### DIFF
--- a/contracts/kernel/IKernel.sol
+++ b/contracts/kernel/IKernel.sol
@@ -8,10 +8,13 @@ import "../acl/IACL.sol";
 import "../common/IVaultRecoverable.sol";
 
 
-// This should be an interface, but interfaces can't inherit yet :(
-contract IKernel is IVaultRecoverable {
+interface IKernelEvents {
     event SetApp(bytes32 indexed namespace, bytes32 indexed appId, address app);
+}
 
+
+// This should be an interface, but interfaces can't inherit yet :(
+contract IKernel is IKernelEvents, IVaultRecoverable {
     function acl() public view returns (IACL);
     function hasPermission(address who, address where, bytes32 what, bytes how) public view returns (bool);
 

--- a/contracts/kernel/KernelProxy.sol
+++ b/contracts/kernel/KernelProxy.sol
@@ -7,7 +7,7 @@ import "../common/DepositableDelegateProxy.sol";
 import "../common/IsContract.sol";
 
 
-contract KernelProxy is KernelStorage, KernelAppIds, KernelNamespaceConstants, IsContract, DepositableDelegateProxy {
+contract KernelProxy is IKernelEvents, KernelStorage, KernelAppIds, KernelNamespaceConstants, IsContract, DepositableDelegateProxy {
     /**
     * @dev KernelProxy is a proxy contract to a kernel implementation. The implementation
     *      can update the reference, which effectively upgrades the contract
@@ -16,6 +16,12 @@ contract KernelProxy is KernelStorage, KernelAppIds, KernelNamespaceConstants, I
     constructor(IKernel _kernelImpl) public {
         require(isContract(address(_kernelImpl)));
         apps[KERNEL_CORE_NAMESPACE][KERNEL_CORE_APP_ID] = _kernelImpl;
+
+        // Note that emitting this event is important for verifying that a KernelProxy instance
+        // was never upgraded to a malicious Kernel logic contract over its lifespan.
+        // This starts the "chain of trust", that can be followed through later SetApp() events
+        // emitted during kernel upgrades.
+        emit SetApp(KERNEL_CORE_NAMESPACE, KERNEL_CORE_APP_ID, _kernelImpl);
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "truffle": "4.1.14",
     "truffle-bytecode-manager": "^1.1.1",
     "truffle-extract": "^1.2.1",
+    "web3-eth-abi": "1.0.0-beta.33",
     "web3-utils": "1.0.0-beta.33"
   },
   "dependencies": {

--- a/test/helpers/decodeEvent.js
+++ b/test/helpers/decodeEvent.js
@@ -1,0 +1,13 @@
+const abi = require('web3-eth-abi')
+
+module.exports = {
+    decodeEventsOfType: (receipt, eventAbi) => {
+        const eventSignature = abi.encodeEventSignature(eventAbi)
+        const eventLogs = receipt.logs.filter(l => l.topics[0] === eventSignature)
+        return eventLogs.map(log => {
+            log.event = abi.name
+            log.args = abi.decodeLog(eventAbi.inputs, log.data, log.topics.slice(1))
+            return log
+        })
+    }
+}

--- a/test/helpers/decodeEvent.js
+++ b/test/helpers/decodeEvent.js
@@ -1,7 +1,8 @@
 const abi = require('web3-eth-abi')
 
 module.exports = {
-    decodeEventsOfType: (receipt, eventAbi) => {
+    decodeEventsOfType: (receipt, contractAbi, eventName) => {
+        const eventAbi = contractAbi.filter(abi => abi.name === eventName && abi.type === 'event')[0]
         const eventSignature = abi.encodeEventSignature(eventAbi)
         const eventLogs = receipt.logs.filter(l => l.topics[0] === eventSignature)
         return eventLogs.map(log => {

--- a/test/kernel_upgrade.js
+++ b/test/kernel_upgrade.js
@@ -52,9 +52,7 @@ contract('Kernel upgrade', accounts => {
         const kernelProxy = await KernelProxy.new(kernelBase.address)
         const receipt = web3.eth.getTransactionReceipt(kernelProxy.transactionHash)
 
-        const setAppAbi = kernelProxy.abi.filter(abi => abi.name === 'SetApp' && abi.type === 'event')[0]
-        const setAppLogs = decodeEventsOfType(receipt, setAppAbi)
-
+        const setAppLogs = decodeEventsOfType(receipt, kernelProxy.abi, 'SetApp')
         assert.equal(setAppLogs.length, 1)
 
         const setAppArgs = setAppLogs[0].args

--- a/test/kernel_upgrade.js
+++ b/test/kernel_upgrade.js
@@ -1,4 +1,5 @@
 const { assertRevert } = require('./helpers/assertThrow')
+const { decodeEventsOfType } = require('./helpers/decodeEvent')
 
 const ACL = artifacts.require('ACL')
 const Kernel = artifacts.require('Kernel')
@@ -45,6 +46,21 @@ contract('Kernel upgrade', accounts => {
         assert.equal(implementation, kernelBase.address, "App address should match")
         const proxyType = (await kernelProxy.proxyType()).toString()
         assert.equal(proxyType, UPGRADEABLE, "Proxy type should be 2 (upgradeable)")
+    })
+
+    it('emits SetApp event', async () => {
+        const kernelProxy = await KernelProxy.new(kernelBase.address)
+        const receipt = web3.eth.getTransactionReceipt(kernelProxy.transactionHash)
+
+        const setAppAbi = kernelProxy.abi.filter(abi => abi.name === 'SetApp' && abi.type === 'event')[0]
+        const setAppLogs = decodeEventsOfType(receipt, setAppAbi)
+
+        assert.equal(setAppLogs.length, 1)
+
+        const setAppArgs = setAppLogs[0].args
+        assert.equal(setAppArgs.namespace, CORE_NAMESPACE, 'Kernel namespace should match')
+        assert.equal(setAppArgs.appId, KERNEL_APP_ID, 'Kernel app id should match')
+        assert.equal(setAppArgs.app.toLowerCase(), kernelBase.address.toLowerCase(), 'Kernel base address should match')
     })
 
     it('fails to create a KernelProxy if the base is 0', async () => {


### PR DESCRIPTION
Fixes #457 by allowing a frontend to follow all `SetApp()` events emitted from the start of a KernelProxy's lifespan.