### PR TITLE
feat: Add SafeERC20

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -3,6 +3,7 @@ const skipFiles = [
   'test',
   'acl/ACLSyntaxSugar.sol',
   'common/DepositableStorage.sol', // Used in tests that send ETH
+  'common/SafeERC20.sol', // solidity-coverage fails on assembly if (https://github.com/sc-forks/solidity-coverage/issues/287)
   'common/UnstructuredStorage.sol' // Used in tests that send ETH
 ]
 

--- a/contracts/common/SafeERC20.sol
+++ b/contracts/common/SafeERC20.sol
@@ -92,6 +92,10 @@ library SafeERC20 {
         return checkSuccess();
     }
 
+    /**
+    * @dev Static call into ERC20.balanceOf().
+    * Reverts if the call fails for some reason (should never fail).
+    */
     function staticBalanceOf(ERC20 _token, address _owner) internal view returns (uint256) {
         bytes memory balanceOfCallData = abi.encodeWithSelector(
             ERC20(_token).balanceOf.selector,
@@ -104,6 +108,10 @@ library SafeERC20 {
         return tokenBalance;
     }
 
+    /**
+    * @dev Static call into ERC20.allowance().
+    * Reverts if the call fails for some reason (should never fail).
+    */
     function staticAllowance(ERC20 _token, address _owner, address _spender) internal view returns (uint256) {
         bytes memory allowanceCallData = abi.encodeWithSelector(
             ERC20(_token).allowance.selector,

--- a/contracts/common/SafeERC20.sol
+++ b/contracts/common/SafeERC20.sol
@@ -122,7 +122,7 @@ library SafeERC20 {
     */
     function staticBalanceOf(ERC20 _token, address _owner) internal view returns (uint256) {
         bytes memory balanceOfCallData = abi.encodeWithSelector(
-            ERC20(_token).balanceOf.selector,
+            _token.balanceOf.selector,
             _owner
         );
 
@@ -138,7 +138,7 @@ library SafeERC20 {
     */
     function staticAllowance(ERC20 _token, address _owner, address _spender) internal view returns (uint256) {
         bytes memory allowanceCallData = abi.encodeWithSelector(
-            ERC20(_token).allowance.selector,
+            _token.allowance.selector,
             _owner,
             _spender
         );

--- a/contracts/common/SafeERC20.sol
+++ b/contracts/common/SafeERC20.sol
@@ -1,0 +1,68 @@
+// Inspired by AdEx (https://github.com/AdExNetwork/adex-protocol-eth/blob/b9df617829661a7518ee10f4cb6c4108659dd6d5/contracts/libs/SafeERC20.sol)
+// and 0x (https://github.com/0xProject/0x-monorepo/blob/737d1dc54d72872e24abce5a1dbe1b66d35fa21a/contracts/protocol/contracts/protocol/AssetProxy/ERC20Proxy.sol#L143)
+
+pragma solidity ^0.4.24;
+
+import "../lib/token/ERC20.sol";
+
+// Same as ERC20 except the return values of these interfaces have been removed to allow us to
+// manually check them
+interface GeneralERC20 {
+    function transfer(address to, uint256 value) external;
+    function transferFrom(address from, address to, uint256 value) external;
+    function approve(address spender, uint256 value) external;
+}
+
+
+library SafeERC20 {
+    function checkSuccess() private pure returns (bool ret) {
+        assembly {
+            // Check number of bytes returned from last function call
+            switch returndatasize
+
+            // No bytes returned: assume success
+            case 0x0 {
+                ret := 1
+            }
+
+            // 32 bytes returned: check if non-zero
+            case 0x20 {
+                // Copy 32 bytes into scratch space
+                returndatacopy(0x0, 0x0, 0x20)
+
+                // Only return success if returned data was true
+                ret := eq(mload(0x0), 1)
+            }
+
+            // Not sure what was returned: don't mark as success
+            default { }
+        }
+    }
+
+    /**
+    * @dev Same as a standards-compliant ERC20.transfer().
+    *      Note that this makes an external call to the token.
+    */
+    function safeTransfer(ERC20 token, address to, uint256 amount) internal returns (bool) {
+        GeneralERC20(token).transfer(to, amount);
+        return checkSuccess();
+    }
+
+    /**
+    * @dev Same as a standards-compliant ERC20.transferFrom().
+    *      Note that this makes an external call to the token.
+    */
+    function safeTransferFrom(ERC20 token, address from, address to, uint256 amount) internal returns (bool) {
+        GeneralERC20(token).transferFrom(from, to, amount);
+        return checkSuccess();
+    }
+
+    /**
+    * @dev Same as a standards-compliant ERC20.approve().
+    *      Note that this makes an external call to the token.
+    */
+    function safeApprove(ERC20 token, address spender, uint256 amount) internal returns (bool) {
+        GeneralERC20(token).approve(spender, amount);
+        return checkSuccess();
+    }
+}

--- a/contracts/common/SafeERC20.sol
+++ b/contracts/common/SafeERC20.sol
@@ -16,8 +16,9 @@ library SafeERC20 {
 
     function invokeAndCheckSuccess(address _addr, bytes memory _calldata)
         private
-        returns (bool ret)
+        returns (bool)
     {
+        bool ret;
         assembly {
             let ptr := mload(0x40)    // free memory pointer
 
@@ -51,13 +52,16 @@ library SafeERC20 {
                 default { }
             }
         }
+        return ret;
     }
 
     function staticInvoke(address _addr, bytes memory _calldata)
         private
         view
-        returns (bool success, uint256 ret)
+        returns (bool, uint256)
     {
+        bool success;
+        uint256 ret;
         assembly {
             let ptr := mload(0x40)    // free memory pointer
 
@@ -74,6 +78,7 @@ library SafeERC20 {
                 ret := mload(ptr)
             }
         }
+        return (success, ret);
     }
 
     /**

--- a/contracts/common/SafeERC20.sol
+++ b/contracts/common/SafeERC20.sol
@@ -43,8 +43,8 @@ library SafeERC20 {
     * @dev Same as a standards-compliant ERC20.transfer().
     *      Note that this makes an external call to the token.
     */
-    function safeTransfer(ERC20 token, address to, uint256 amount) internal returns (bool) {
-        GeneralERC20(token).transfer(to, amount);
+    function safeTransfer(ERC20 _token, address _to, uint256 _amount) internal returns (bool) {
+        GeneralERC20(_token).transfer(_to, _amount);
         return checkSuccess();
     }
 
@@ -52,8 +52,8 @@ library SafeERC20 {
     * @dev Same as a standards-compliant ERC20.transferFrom().
     *      Note that this makes an external call to the token.
     */
-    function safeTransferFrom(ERC20 token, address from, address to, uint256 amount) internal returns (bool) {
-        GeneralERC20(token).transferFrom(from, to, amount);
+    function safeTransferFrom(ERC20 _token, address _from, address _to, uint256 _amount) internal returns (bool) {
+        GeneralERC20(_token).transferFrom(_from, _to, _amount);
         return checkSuccess();
     }
 
@@ -61,8 +61,8 @@ library SafeERC20 {
     * @dev Same as a standards-compliant ERC20.approve().
     *      Note that this makes an external call to the token.
     */
-    function safeApprove(ERC20 token, address spender, uint256 amount) internal returns (bool) {
-        GeneralERC20(token).approve(spender, amount);
+    function safeApprove(ERC20 _token, address _spender, uint256 _amount) internal returns (bool) {
+        GeneralERC20(_token).approve(_spender, _amount);
         return checkSuccess();
     }
 }

--- a/contracts/common/VaultRecoverable.sol
+++ b/contracts/common/VaultRecoverable.sol
@@ -32,7 +32,7 @@ contract VaultRecoverable is IVaultRecoverable, EtherTokenConstant, IsContract {
             vault.transfer(address(this).balance);
         } else {
             ERC20 token = ERC20(_token);
-            uint256 amount = token.balanceOf(this);
+            uint256 amount = token.staticBalanceOf(this);
             require(token.safeTransfer(vault, amount), ERROR_TOKEN_TRANSFER_FAILED);
         }
     }

--- a/contracts/common/VaultRecoverable.sol
+++ b/contracts/common/VaultRecoverable.sol
@@ -33,7 +33,7 @@ contract VaultRecoverable is IVaultRecoverable, EtherTokenConstant, IsContract {
         } else {
             ERC20 token = ERC20(_token);
             uint256 amount = token.balanceOf(this);
-            require(ERC20(_token).safeTransfer(vault, amount), ERROR_TOKEN_TRANSFER_FAILED);
+            require(token.safeTransfer(vault, amount), ERROR_TOKEN_TRANSFER_FAILED);
         }
     }
 

--- a/contracts/common/VaultRecoverable.sol
+++ b/contracts/common/VaultRecoverable.sol
@@ -8,11 +8,15 @@ import "../lib/token/ERC20.sol";
 import "./EtherTokenConstant.sol";
 import "./IsContract.sol";
 import "./IVaultRecoverable.sol";
+import "./SafeERC20.sol";
 
 
 contract VaultRecoverable is IVaultRecoverable, EtherTokenConstant, IsContract {
+    using SafeERC20 for ERC20;
+
     string private constant ERROR_DISALLOWED = "RECOVER_DISALLOWED";
     string private constant ERROR_VAULT_NOT_CONTRACT = "RECOVER_VAULT_NOT_CONTRACT";
+    string private constant ERROR_TOKEN_TRANSFER_FAILED = "RECOVER_TOKEN_TRANSFER_FAILED";
 
     /**
      * @notice Send funds to recovery Vault. This contract should never receive funds,
@@ -27,8 +31,9 @@ contract VaultRecoverable is IVaultRecoverable, EtherTokenConstant, IsContract {
         if (_token == ETH) {
             vault.transfer(address(this).balance);
         } else {
-            uint256 amount = ERC20(_token).balanceOf(this);
-            ERC20(_token).transfer(vault, amount);
+            ERC20 token = ERC20(_token);
+            uint256 amount = token.balanceOf(this);
+            require(ERC20(_token).safeTransfer(vault, amount), ERROR_TOKEN_TRANSFER_FAILED);
         }
     }
 

--- a/contracts/test/mocks/SafeERC20Mock.sol
+++ b/contracts/test/mocks/SafeERC20Mock.sol
@@ -25,4 +25,12 @@ contract SafeERC20Mock {
         emit Result(result);
         return result;
     }
+
+    function allowance(ERC20 token, address owner, address spender) external view returns (uint256) {
+        return token.staticAllowance(owner, spender);
+    }
+
+    function balanceOf(ERC20 token, address owner) external view returns (uint256) {
+        return token.staticBalanceOf(owner);
+    }
 }

--- a/contracts/test/mocks/SafeERC20Mock.sol
+++ b/contracts/test/mocks/SafeERC20Mock.sol
@@ -8,19 +8,19 @@ contract SafeERC20Mock {
     using SafeERC20 for ERC20;
     event Result(bool result);
 
-	function transfer(ERC20 token, address to, uint256 amount) external returns (bool) {
+    function transfer(ERC20 token, address to, uint256 amount) external returns (bool) {
         bool result = token.safeTransfer(to, amount);
         emit Result(result);
         return result;
-	}
+    }
 
-	function transferFrom(ERC20 token, address from, address to, uint256 amount) external returns (bool) {
+    function transferFrom(ERC20 token, address from, address to, uint256 amount) external returns (bool) {
         bool result = token.safeTransferFrom(from, to, amount);
         emit Result(result);
         return result;
-	}
+    }
 
-	function approve(ERC20 token, address spender, uint256 amount) external returns (bool) {
+    function approve(ERC20 token, address spender, uint256 amount) external returns (bool) {
         bool result = token.safeApprove(spender, amount);
         emit Result(result);
         return result;

--- a/contracts/test/mocks/SafeERC20Mock.sol
+++ b/contracts/test/mocks/SafeERC20Mock.sol
@@ -1,0 +1,28 @@
+pragma solidity 0.4.24;
+
+import "../../common/SafeERC20.sol";
+import "../../lib/token/ERC20.sol";
+
+
+contract SafeERC20Mock {
+    using SafeERC20 for ERC20;
+    event Result(bool result);
+
+	function transfer(ERC20 token, address to, uint256 amount) external returns (bool) {
+        bool result = token.safeTransfer(to, amount);
+        emit Result(result);
+        return result;
+	}
+
+	function transferFrom(ERC20 token, address from, address to, uint256 amount) external returns (bool) {
+        bool result = token.safeTransferFrom(from, to, amount);
+        emit Result(result);
+        return result;
+	}
+
+	function approve(ERC20 token, address spender, uint256 amount) external returns (bool) {
+        bool result = token.safeApprove(spender, amount);
+        emit Result(result);
+        return result;
+    }
+}

--- a/contracts/test/mocks/TokenMock.sol
+++ b/contracts/test/mocks/TokenMock.sol
@@ -1,4 +1,4 @@
-// Stripped from https://github.com/OpenZeppelin/openzeppelin-solidity/blob/a9f910d34f0ab33a1ae5e714f69f9596a02b4d91/contracts/token/ERC20/StandardToken.sol
+// Modified from https://github.com/OpenZeppelin/openzeppelin-solidity/blob/a9f910d34f0ab33a1ae5e714f69f9596a02b4d91/contracts/token/ERC20/StandardToken.sol
 
 pragma solidity 0.4.24;
 
@@ -10,6 +10,7 @@ contract TokenMock {
     mapping (address => uint256) private balances;
     mapping (address => mapping (address => uint256)) private allowed;
     uint256 private totalSupply_;
+    bool private allowTransfer_;
 
     event Approval(address indexed owner, address indexed spender, uint256 value);
     event Transfer(address indexed from, address indexed to, uint256 value);
@@ -18,6 +19,7 @@ contract TokenMock {
     constructor(address initialAccount, uint256 initialBalance) public {
         balances[initialAccount] = initialBalance;
         totalSupply_ = initialBalance;
+        allowTransfer_ = true;
     }
 
     function totalSupply() public view returns (uint256) { return totalSupply_; }
@@ -42,11 +44,20 @@ contract TokenMock {
     }
 
     /**
+    * @dev Set whether the token is transferable or not
+    * @param _allowTransfer Should token be transferable
+    */
+    function setAllowTransfer(bool _allowTransfer) public {
+        allowTransfer_ = _allowTransfer;
+    }
+
+    /**
     * @dev Transfer token for a specified address
     * @param _to The address to transfer to.
     * @param _value The amount to be transferred.
     */
     function transfer(address _to, uint256 _value) public returns (bool) {
+        require(allowTransfer_);
         require(_value <= balances[msg.sender]);
         require(_to != address(0));
 
@@ -81,6 +92,7 @@ contract TokenMock {
     * @param _value uint256 the amount of tokens to be transferred
     */
     function transferFrom(address _from, address _to, uint256 _value) public returns (bool) {
+        require(allowTransfer_);
         require(_value <= balances[_from]);
         require(_value <= allowed[_from][msg.sender]);
         require(_to != address(0));

--- a/contracts/test/mocks/TokenReturnFalseMock.sol
+++ b/contracts/test/mocks/TokenReturnFalseMock.sol
@@ -9,6 +9,7 @@ contract TokenReturnFalseMock {
     mapping (address => uint256) private balances;
     mapping (address => mapping (address => uint256)) private allowed;
     uint256 private totalSupply_;
+    bool private allowTransfer_;
 
     event Approval(address indexed owner, address indexed spender, uint256 value);
     event Transfer(address indexed from, address indexed to, uint256 value);
@@ -17,6 +18,7 @@ contract TokenReturnFalseMock {
     constructor(address initialAccount, uint256 initialBalance) public {
         balances[initialAccount] = initialBalance;
         totalSupply_ = initialBalance;
+        allowTransfer_ = true;
     }
 
     function totalSupply() public view returns (uint256) { return totalSupply_; }
@@ -41,12 +43,20 @@ contract TokenReturnFalseMock {
     }
 
     /**
+    * @dev Set whether the token is transferable or not
+    * @param _allowTransfer Should token be transferable
+    */
+    function setAllowTransfer(bool _allowTransfer) public {
+        allowTransfer_ = _allowTransfer;
+    }
+
+    /**
     * @dev Transfer token for a specified address
     * @param _to The address to transfer to.
     * @param _value The amount to be transferred.
     */
     function transfer(address _to, uint256 _value) public returns (bool) {
-        if (_to == address(0) || _value > balances[msg.sender]) {
+        if (!allowTransfer_ || _to == address(0) || _value > balances[msg.sender]) {
             return false;
         }
 
@@ -83,7 +93,11 @@ contract TokenReturnFalseMock {
     * @param _value uint256 the amount of tokens to be transferred
     */
     function transferFrom(address _from, address _to, uint256 _value) public returns (bool) {
-        if (_to == address(0) || _value > balances[_from] || _value > allowed[_from][msg.sender]) {
+        if (!allowTransfer_ ||
+            _to == address(0) ||
+            _value > balances[_from] ||
+            _value > allowed[_from][msg.sender]
+        ) {
             return false;
         }
 

--- a/contracts/test/mocks/TokenReturnMissingMock.sol
+++ b/contracts/test/mocks/TokenReturnMissingMock.sol
@@ -12,6 +12,7 @@ contract TokenReturnMissingMock {
     mapping (address => uint256) private balances;
     mapping (address => mapping (address => uint256)) private allowed;
     uint256 private totalSupply_;
+    bool private allowTransfer_;
 
     event Approval(address indexed owner, address indexed spender, uint256 value);
     event Transfer(address indexed from, address indexed to, uint256 value);
@@ -20,6 +21,7 @@ contract TokenReturnMissingMock {
     constructor(address initialAccount, uint256 initialBalance) public {
         balances[initialAccount] = initialBalance;
         totalSupply_ = initialBalance;
+        allowTransfer_ = true;
     }
 
     function totalSupply() public view returns (uint256) { return totalSupply_; }
@@ -31,6 +33,14 @@ contract TokenReturnMissingMock {
     */
     function balanceOf(address _owner) public view returns (uint256) {
         return balances[_owner];
+    }
+
+    /**
+    * @dev Set whether the token is transferable or not
+    * @param _allowTransfer Should token be transferable
+    */
+    function setAllowTransfer(bool _allowTransfer) public {
+        allowTransfer_ = _allowTransfer;
     }
 
     /**
@@ -49,6 +59,7 @@ contract TokenReturnMissingMock {
     * @param _value The amount to be transferred.
     */
     function transfer(address _to, uint256 _value) public {
+        require(allowTransfer_);
         require(_value <= balances[msg.sender]);
         require(_to != address(0));
 
@@ -81,6 +92,7 @@ contract TokenReturnMissingMock {
     * @param _value uint256 the amount of tokens to be transferred
     */
     function transferFrom(address _from, address _to, uint256 _value) public {
+        require(allowTransfer_);
         require(_value <= balances[_from]);
         require(_value <= allowed[_from][msg.sender]);
         require(_to != address(0));

--- a/contracts/test/mocks/TokenReturnMissingMock.sol
+++ b/contracts/test/mocks/TokenReturnMissingMock.sol
@@ -1,11 +1,13 @@
-// Stripped from https://github.com/OpenZeppelin/openzeppelin-solidity/blob/a9f910d34f0ab33a1ae5e714f69f9596a02b4d91/contracts/token/ERC20/StandardToken.sol
+// Non-standards compliant token that is missing return values for
+// `transfer()`, `transferFrom()`, and `approve().
+// Modified from https://github.com/OpenZeppelin/openzeppelin-solidity/blob/a9f910d34f0ab33a1ae5e714f69f9596a02b4d91/contracts/token/ERC20/StandardToken.sol
 
 pragma solidity 0.4.24;
 
 import "../../lib/math/SafeMath.sol";
 
 
-contract TokenMock {
+contract TokenReturnMissingMock {
     using SafeMath for uint256;
     mapping (address => uint256) private balances;
     mapping (address => mapping (address => uint256)) private allowed;
@@ -46,14 +48,13 @@ contract TokenMock {
     * @param _to The address to transfer to.
     * @param _value The amount to be transferred.
     */
-    function transfer(address _to, uint256 _value) public returns (bool) {
+    function transfer(address _to, uint256 _value) public {
         require(_value <= balances[msg.sender]);
         require(_to != address(0));
 
         balances[msg.sender] = balances[msg.sender].sub(_value);
         balances[_to] = balances[_to].add(_value);
         emit Transfer(msg.sender, _to, _value);
-        return true;
     }
 
     /**
@@ -65,13 +66,12 @@ contract TokenMock {
     * @param _spender The address which will spend the funds.
     * @param _value The amount of tokens to be spent.
     */
-    function approve(address _spender, uint256 _value) public returns (bool) {
+    function approve(address _spender, uint256 _value) public {
         // Assume we want to protect for the race condition
         require(allowed[msg.sender][_spender] == 0);
 
         allowed[msg.sender][_spender] = _value;
         emit Approval(msg.sender, _spender, _value);
-        return true;
     }
 
     /**
@@ -80,7 +80,7 @@ contract TokenMock {
     * @param _to address The address which you want to transfer to
     * @param _value uint256 the amount of tokens to be transferred
     */
-    function transferFrom(address _from, address _to, uint256 _value) public returns (bool) {
+    function transferFrom(address _from, address _to, uint256 _value) public {
         require(_value <= balances[_from]);
         require(_value <= allowed[_from][msg.sender]);
         require(_to != address(0));
@@ -89,6 +89,5 @@ contract TokenMock {
         balances[_to] = balances[_to].add(_value);
         allowed[_from][msg.sender] = allowed[_from][msg.sender].sub(_value);
         emit Transfer(_from, _to, _value);
-        return true;
     }
 }

--- a/test/recovery_to_vault.js
+++ b/test/recovery_to_vault.js
@@ -24,7 +24,7 @@ const getEvent = (receipt, event, arg) => { return receipt.logs.filter(l => l.ev
 const APP_ID = hash('stub.aragonpm.test')
 const SEND_ETH_GAS = 31000 // 21k base tx cost + 10k limit on depositable proxies
 
-contract('Fund recovery', accounts => {
+contract('Recovery to vault', accounts => {
   let aclBase, appBase, appConditionalRecoveryBase
   let APP_ADDR_NAMESPACE, ETH
 

--- a/test/recovery_to_vault.js
+++ b/test/recovery_to_vault.js
@@ -107,17 +107,14 @@ contract('Recovery to vault', accounts => {
     {
       title: 'standards compliant, reverting token',
       tokenContract: TokenMock,
-      revertsOnFailure: true,
     },
     {
       title: 'standards compliant, non-reverting token',
       tokenContract: TokenReturnFalseMock,
-      revertsOnFailure: false,
     },
     {
       title: 'non-standards compliant, missing return token',
       tokenContract: TokenReturnMissingMock,
-      revertsOnFailure: true,
     },
   ]
 
@@ -208,7 +205,7 @@ contract('Recovery to vault', accounts => {
             })
           }
 
-          for ({ title, revertsOnFailure, tokenContract} of tokenTestGroups) {
+          for ({ title, tokenContract} of tokenTestGroups) {
             it(`kernel reverts on failing recovery for ${title}`, async () => {
               await failingRecoverTokens({
                 tokenContract,
@@ -275,7 +272,7 @@ contract('Recovery to vault', accounts => {
               })
             }
 
-            for ({ title, revertsOnFailure, tokenContract} of tokenTestGroups) {
+            for ({ title, tokenContract} of tokenTestGroups) {
               it(`reverts on failing recovery for ${title}`, async () => {
                 await failingRecoverTokens({
                   tokenContract,
@@ -316,7 +313,7 @@ contract('Recovery to vault', accounts => {
               })
             }
 
-            for ({ title, revertsOnFailure, tokenContract} of tokenTestGroups) {
+            for ({ title, tokenContract} of tokenTestGroups) {
               it(`reverts on failing recovery for ${title}`, async () => {
                 await failingRecoverTokens({
                   tokenContract,

--- a/test/safe_erc20.js
+++ b/test/safe_erc20.js
@@ -122,6 +122,22 @@ contract('SafeERC20', accounts => {
         assert.equal((await tokenMock.balanceOf(receiver)).valueOf(), 0, 'Balance of receiver should stay the same')
         assert.equal((await tokenMock.balanceOf(safeERC20Mock.address)).valueOf(), 0, 'Balance of mock should stay the same')
       })
+
+      it('gives correct value with static allowance', async () => {
+        // Create approval
+        const approvedAmount = 5000
+        await tokenMock.approve(safeERC20Mock.address, approvedAmount)
+
+        const approval = (await safeERC20Mock.allowance(tokenMock.address, owner, safeERC20Mock.address)).valueOf()
+        assert.equal(approval, approvedAmount, 'Mock should return correct allowance')
+        assert.equal((await tokenMock.allowance(owner, safeERC20Mock.address)).valueOf(), approval, "Mock should match token contract's allowance")
+      })
+
+      it('gives correct value with static balanceOf', async () => {
+        const balance = (await safeERC20Mock.balanceOf(tokenMock.address, owner)).valueOf()
+        assert.equal(balance, initialBalance, 'Mock should return correct balance')
+        assert.equal((await tokenMock.balanceOf(owner)).valueOf(), balance, "Mock should match token contract's balance")
+      })
     })
   }
 })

--- a/test/safe_erc20.js
+++ b/test/safe_erc20.js
@@ -1,0 +1,127 @@
+const { assertRevert } = require('./helpers/assertThrow')
+
+// Mocks
+const SafeERC20Mock = artifacts.require('SafeERC20Mock')
+const TokenMock = artifacts.require('TokenMock')
+const TokenReturnFalseMock = artifacts.require('TokenReturnFalseMock')
+const TokenReturnMissingMock = artifacts.require('TokenReturnMissingMock')
+
+const assertMockResult = (receipt, result) => {
+  const events = receipt.logs.filter(x => x.event == 'Result')
+  const eventArg = events[0].args.result
+  assert.equal(eventArg, result, `Result not expected (got ${eventArg} instead of ${result})`)
+}
+
+contract('SafeERC20', accounts => {
+  const [owner, receiver] = accounts
+  const initialBalance = 10000
+  let safeERC20Mock
+
+  before(async () => {
+    safeERC20Mock = await SafeERC20Mock.new()
+  })
+
+  const testGroups = [
+    {
+      title: 'Standards compliant, reverting token',
+      tokenContract: TokenMock,
+      revertsOnFailure: true,
+    },
+    {
+      title: 'Standards compliant, non-reverting token',
+      tokenContract: TokenReturnFalseMock,
+      revertsOnFailure: false,
+    },
+    {
+      title: 'Non-standards compliant, missing return token',
+      tokenContract: TokenReturnMissingMock,
+      revertsOnFailure: true,
+    },
+  ]
+
+  for ({ title, revertsOnFailure, tokenContract} of testGroups) {
+    // Change behaviour based on whether failing action reverts or returns false
+    const assertFailingAction = async (action) => {
+      if (revertsOnFailure) {
+        await assertRevert(action)
+      } else {
+        const receipt = await action()
+        assertMockResult(receipt, false)
+      }
+    }
+
+    context(`> ${title}`, () => {
+      let tokenMock
+
+      beforeEach(async () => {
+        tokenMock = await tokenContract.new(owner, initialBalance)
+      })
+
+      it('can correctly transfer', async () => {
+        // Add balance to the mock
+        const transferAmount = 5000
+        await tokenMock.transfer(safeERC20Mock.address, transferAmount)
+
+        // Transfer it all back from the mock
+        const receipt = await safeERC20Mock.transfer(tokenMock.address, owner, transferAmount)
+        assertMockResult(receipt, true)
+        assert.equal((await tokenMock.balanceOf(owner)).valueOf(), initialBalance, 'Balance of owner should be correct')
+        assert.equal((await tokenMock.balanceOf(safeERC20Mock.address)).valueOf(), 0, 'Balance of mock should be correct')
+      })
+
+      it('detects failed transfer', async () => {
+        // Attempt transfer when mock has no balance
+        await assertFailingAction(
+          () => safeERC20Mock.transfer(tokenMock.address, owner, 1000)
+        )
+        assert.equal((await tokenMock.balanceOf(owner)).valueOf(), initialBalance, 'Balance of owner should stay the same')
+        assert.equal((await tokenMock.balanceOf(safeERC20Mock.address)).valueOf(), 0, 'Balance of mock should stay the same')
+      })
+
+      it('can correctly approve', async () => {
+        const approvedAmount = 5000
+
+        // Create approval from the mock
+        const receipt = await safeERC20Mock.approve(tokenMock.address, receiver, approvedAmount)
+        assertMockResult(receipt, true)
+        assert.equal((await tokenMock.allowance(safeERC20Mock.address, receiver)).valueOf(), approvedAmount, 'Allowance of receiver should be correct')
+      })
+
+      it('detects failed approve', async () => {
+        const preApprovedAmount = 5000
+
+        // Create pre-exisiting approval
+        await safeERC20Mock.approve(tokenMock.address, receiver, preApprovedAmount)
+
+        // Attempt to create another approval without reseting it back to 0
+        await assertFailingAction(
+          () => safeERC20Mock.approve(tokenMock.address, receiver, preApprovedAmount - 500)
+        )
+        assert.equal((await tokenMock.allowance(safeERC20Mock.address, receiver)).valueOf(), preApprovedAmount, 'Allowance of receiver should be the pre-existing value')
+      })
+
+      it('can correctly transferFrom', async () => {
+        // Create approval
+        const approvedAmount = 5000
+        await tokenMock.approve(safeERC20Mock.address, approvedAmount)
+
+        // Transfer to receiver through the mock
+        const receipt = await safeERC20Mock.transferFrom(tokenMock.address, owner, receiver, approvedAmount)
+        assertMockResult(receipt, true)
+        assert.equal((await tokenMock.balanceOf(owner)).valueOf(), initialBalance - approvedAmount, 'Balance of owner should be correct')
+        assert.equal((await tokenMock.balanceOf(receiver)).valueOf(), approvedAmount, 'Balance of receiver should be correct')
+        assert.equal((await tokenMock.balanceOf(safeERC20Mock.address)).valueOf(), 0, 'Balance of mock should stay the same')
+      })
+
+      it('detects failed transferFrom', async () => {
+        // Attempt transfer to receiver through the mock when mock wasn't approved
+        await assertFailingAction(
+          () => safeERC20Mock.transferFrom(tokenMock.address, owner, receiver, 5000)
+        )
+        assert.equal((await tokenMock.balanceOf(owner)).valueOf(), initialBalance, 'Balance of owner should stay the same')
+        assert.equal((await tokenMock.balanceOf(receiver)).valueOf(), 0, 'Balance of receiver should stay the same')
+        assert.equal((await tokenMock.balanceOf(safeERC20Mock.address)).valueOf(), 0, 'Balance of mock should stay the same')
+      })
+    })
+  }
+})

--- a/test/time_helpers.js
+++ b/test/time_helpers.js
@@ -1,4 +1,4 @@
-contract('TimeHelpers test', accounts => {
+contract('TimeHelpers', accounts => {
   let timeHelpersMock
 
   before(async () => {


### PR DESCRIPTION
Required for https://github.com/aragon/aragon-apps/issues/562.

Adds a `SafeERC20` library that should be used to enhance `ERC20` types. The `safeTransfer()`, `safeTransferFrom()`, and `safeApprove()` methods ensure standards-compliance (e.g. always returning a value) with different token interfaces in the wild.

Note that the change for `VaultRecoverable.sol` means every `AragonApp` is affected.

Bytecode comparison:

```
                               CODE DEPOSIT COST    DEPLOYED BYTES     INITIALIZATION BYTES
ACL.json                       49200 more gas       +246               0
APMRegistry.json               50600 more gas       +253               0
AppStub.json                   49000 more gas       +245               0
AppStub2.json                  49200 more gas       +246               0
AppStubConditionalRecovery.js… 49200 more gas       +246               0
AppStubDepositable.json        49200 more gas       +246               0
AragonApp.json                 49200 more gas       +246               0
ENSSubdomainRegistrar.json     47600 more gas       +238               0
EVMScriptRegistry.json         47600 more gas       +238               0
EVMScriptRegistryFactory.json  Same                 0                  +238
Kernel.json                    48600 more gas       +243               0
KernelConstantsMock.json       48600 more gas       +243               0
KernelDepositableMock.json     48600 more gas       +243               0
KernelPinnedStorageMock.json   48600 more gas       +243               0
KernelSetAppMock.json          48600 more gas       +243               0
MockScriptExecutorApp.json     47800 more gas       +239               0
Repo.json                      49000 more gas       +245               0
TestACLInterpreter.json        49200 more gas       +246               0
TokenMock.json                 202400 more gas      +1012              +13
UnsafeAppStub.json             49000 more gas       +245               0
UnsafeAppStubDepositable.json  49200 more gas       +246               0
UnsafeAragonApp.json           49200 more gas       +246               0
UnsafeAragonAppMock.json       49200 more gas       +246               0
UnsafeRepo.json                49000 more gas       +245               0
UpgradedKernel.json            48600 more gas       +243               0
VaultMock.json                 49200 more gas       +246               0

Warning: could not compare some contracts that might have been renamed or removed
  Missing from /Users/brett/Development/aragon/aragonOS/bytecode: GeneralERC20.json, SafeERC20.json, SafeERC20Mock.json, TokenReturnFalseMock.json, TokenReturnMissingMock.json
```