### PR TITLE
feat(SafeERC20): add static call utilities

### DIFF
--- a/contracts/common/SafeERC20.sol
+++ b/contracts/common/SafeERC20.sol
@@ -92,24 +92,28 @@ library SafeERC20 {
         return checkSuccess();
     }
 
-    function staticBalanceOf(ERC20 _token, address _owner) internal view returns (uint256 tokenBalance) {
+    function staticBalanceOf(ERC20 _token, address _owner) internal view returns (uint256) {
         bytes memory balanceOfCallData = abi.encodeWithSelector(
             ERC20(_token).balanceOf.selector,
             _owner
         );
-        bool success;
-        (success, tokenBalance) = staticInvoke(_token, balanceOfCallData);
+
+        (bool success, uint256 tokenBalance) = staticInvoke(_token, balanceOfCallData);
         require(success, ERROR_TOKEN_BALANCE_REVERTED);
+
+        return tokenBalance;
     }
 
-    function staticAllowance(ERC20 _token, address _owner, address _spender) internal view returns (uint256 allowance) {
+    function staticAllowance(ERC20 _token, address _owner, address _spender) internal view returns (uint256) {
         bytes memory allowanceCallData = abi.encodeWithSelector(
             ERC20(_token).allowance.selector,
             _owner,
             _spender
         );
-        bool success;
-        (success, allowance) = staticInvoke(_token, allowanceCallData);
+
+        (bool success, uint256 allowance) = staticInvoke(_token, allowanceCallData);
         require(success, ERROR_TOKEN_ALLOWANCE_REVERTED);
+
+        return allowance;
     }
 }

--- a/contracts/common/SafeERC20.sol
+++ b/contracts/common/SafeERC20.sol
@@ -54,7 +54,7 @@ library SafeERC20 {
                 add(_calldata, 0x20), // calldata start
                 mload(_calldata),     // calldata length
                 0,                    // write output over scratch
-                32                    // uint256 return
+                0x20                  // uint256 return
             )
 
             switch success

--- a/contracts/common/SafeERC20.sol
+++ b/contracts/common/SafeERC20.sol
@@ -15,6 +15,9 @@ interface GeneralERC20 {
 
 
 library SafeERC20 {
+    string private constant ERROR_TOKEN_BALANCE_REVERTED = "SAFE_ERC_20_BALANCE_REVERTED";
+    string private constant ERROR_TOKEN_ALLOWANCE_REVERTED = "SAFE_ERC_20_BALANCE_REVERTED";
+
     function checkSuccess() private pure returns (bool ret) {
         assembly {
             // Check number of bytes returned from last function call
@@ -36,6 +39,29 @@ library SafeERC20 {
 
             // Not sure what was returned: don't mark as success
             default { }
+        }
+    }
+
+    function staticInvoke(address _addr, bytes memory _calldata)
+        private
+        view
+        returns (bool success, uint256 ret)
+    {
+        assembly {
+            success := staticcall(
+                gas,                  // forward all gas
+                _addr,                // address
+                add(_calldata, 0x20), // calldata start
+                mload(_calldata),     // calldata length
+                0,                    // write output over scratch
+                32                    // uint256 return
+            )
+
+            switch success
+            case 1 {
+                ret := mload(0)
+            }
+            default {}
         }
     }
 
@@ -64,5 +90,26 @@ library SafeERC20 {
     function safeApprove(ERC20 _token, address _spender, uint256 _amount) internal returns (bool) {
         GeneralERC20(_token).approve(_spender, _amount);
         return checkSuccess();
+    }
+
+    function staticBalanceOf(ERC20 _token, address _owner) internal view returns (uint256 tokenBalance) {
+        bytes memory balanceOfCallData = abi.encodeWithSelector(
+            ERC20(_token).balanceOf.selector,
+            _owner
+        );
+        bool success;
+        (success, tokenBalance) = staticInvoke(_token, balanceOfCallData);
+        require(success, ERROR_TOKEN_BALANCE_REVERTED);
+    }
+
+    function staticAllowance(ERC20 _token, address _owner, address _spender) internal view returns (uint256 allowance) {
+        bytes memory allowanceCallData = abi.encodeWithSelector(
+            ERC20(_token).allowance.selector,
+            _owner,
+            _spender
+        );
+        bool success;
+        (success, allowance) = staticInvoke(_token, allowanceCallData);
+        require(success, ERROR_TOKEN_ALLOWANCE_REVERTED);
     }
 }

--- a/contracts/common/SafeERC20.sol
+++ b/contracts/common/SafeERC20.sol
@@ -16,7 +16,7 @@ interface GeneralERC20 {
 
 library SafeERC20 {
     string private constant ERROR_TOKEN_BALANCE_REVERTED = "SAFE_ERC_20_BALANCE_REVERTED";
-    string private constant ERROR_TOKEN_ALLOWANCE_REVERTED = "SAFE_ERC_20_BALANCE_REVERTED";
+    string private constant ERROR_TOKEN_ALLOWANCE_REVERTED = "SAFE_ERC_20_ALLOWANCE_REVERTED";
 
     function checkSuccess() private pure returns (bool ret) {
         assembly {

--- a/contracts/common/VaultRecoverable.sol
+++ b/contracts/common/VaultRecoverable.sol
@@ -32,7 +32,7 @@ contract VaultRecoverable is IVaultRecoverable, EtherTokenConstant, IsContract {
             vault.transfer(address(this).balance);
         } else {
             ERC20 token = ERC20(_token);
-            uint256 amount = token.balanceOf(this);
+            uint256 amount = token.staticBalanceOf(this);
             require(token.safeTransfer(vault, amount), ERROR_TOKEN_TRANSFER_FAILED);
         }
     }

--- a/contracts/test/mocks/SafeERC20Mock.sol
+++ b/contracts/test/mocks/SafeERC20Mock.sol
@@ -25,4 +25,12 @@ contract SafeERC20Mock {
         emit Result(result);
         return result;
     }
+
+    function allowance(ERC20 token, address owner, address spender) external view returns (uint256) {
+        return token.staticAllowance(owner, spender);
+    }
+
+    function balanceOf(ERC20 token, address owner) external view returns (uint256) {
+        return token.staticBalanceOf(owner);
+    }
 }

--- a/test/safe_erc20.js
+++ b/test/safe_erc20.js
@@ -122,6 +122,22 @@ contract('SafeERC20', accounts => {
         assert.equal((await tokenMock.balanceOf(receiver)).valueOf(), 0, 'Balance of receiver should stay the same')
         assert.equal((await tokenMock.balanceOf(safeERC20Mock.address)).valueOf(), 0, 'Balance of mock should stay the same')
       })
+
+      it('gives correct value with static allowance', async () => {
+        // Create approval
+        const approvedAmount = 5000
+        await tokenMock.approve(safeERC20Mock.address, approvedAmount)
+
+        const approval = (await safeERC20Mock.allowance(tokenMock.address, owner, safeERC20Mock.address)).valueOf()
+        assert.equal(approval, approvedAmount, 'Mock should return correct allowance')
+        assert.equal((await tokenMock.allowance(owner, safeERC20Mock.address)).valueOf(), approval, "Mock should match token contract's allowance")
+      })
+
+      it('gives correct value with static balanceOf', async () => {
+        const balance = (await safeERC20Mock.balanceOf(tokenMock.address, owner)).valueOf()
+        assert.equal(balance, initialBalance, 'Mock should return correct balance')
+        assert.equal((await tokenMock.balanceOf(owner)).valueOf(), balance, "Mock should match token contract's balance")
+      })
     })
   }
 })


### PR DESCRIPTION
Builds on #469.

Adds some `staticcall` utilities to the `ERC20` interface, as before solidity 0.5 these `balanceOf()` and `allowance()` functions were not called with a `staticcall`.

Useful for cases like [here](https://github.com/aragon/aragonOS/pull/470/files#diff-32170f8bb97d146f323f07e8ee82f9acR35), [here](https://github.com/aragon/aragon-apps/blob/master/apps/finance/contracts/Finance.sol#L362), or [here](https://github.com/aragon/aragon-apps/blob/master/apps/vault/contracts/Vault.sol#L77) where users may be unsuspecting of a function actually calling out to another contract (that may be malicious).

Bytecode diff:

```
                               CODE DEPOSIT COST    DEPLOYED BYTES     INITIALIZATION BYTES
ACL.json                       48600 more gas       +243               0
APMRegistry.json               49800 more gas       +249               0
AppStub.json                   48600 more gas       +243               0
AppStub2.json                  48600 more gas       +243               0
AppStubConditionalRecovery.js… 48600 more gas       +243               0
AppStubDepositable.json        48600 more gas       +243               0
AragonApp.json                 48600 more gas       +243               0
ENSSubdomainRegistrar.json     48600 more gas       +243               0
EVMScriptRegistry.json         48600 more gas       +243               0
EVMScriptRegistryFactory.json  Same                 0                  +243
Kernel.json                    49800 more gas       +249               0
KernelConstantsMock.json       49800 more gas       +249               0
KernelDepositableMock.json     49800 more gas       +249               0
KernelPinnedStorageMock.json   49800 more gas       +249               0
KernelSetAppMock.json          49800 more gas       +249               0
MockScriptExecutorApp.json     48600 more gas       +243               0
Repo.json                      48600 more gas       +243               0
SafeERC20Mock.json             195800 more gas      +979               0
TestACLInterpreter.json        48600 more gas       +243               0
UnsafeAppStub.json             48600 more gas       +243               0
UnsafeAppStubDepositable.json  48600 more gas       +243               0
UnsafeAragonApp.json           48600 more gas       +243               0
UnsafeAragonAppMock.json       48600 more gas       +243               0
UnsafeRepo.json                48600 more gas       +243               0
UpgradedKernel.json            49800 more gas       +249               0
VaultMock.json                 48600 more gas       +243               0
```