### PR TITLE
chore: pin ganache-cli to 6.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eth-ens-namehash": "^2.0.8",
     "eth-gas-reporter": "^0.1.1",
     "ethereumjs-abi": "^0.6.5",
-    "ganache-cli": "^6.2.0",
+    "ganache-cli": "6.2.3",
     "mocha-lcov-reporter": "^1.3.0",
     "solidity-coverage": "0.5.8",
     "solium": "^1.1.8",


### PR DESCRIPTION
Check with the CI that `ganache-cli@6.2.3` and `ganache-core@2.3.1` are not breaking our tests.