### PR TITLE
VaultRecoverable: emit event on successful recovery

### DIFF
--- a/contracts/common/IVaultRecoverable.sol
+++ b/contracts/common/IVaultRecoverable.sol
@@ -6,7 +6,7 @@ pragma solidity ^0.4.24;
 
 
 interface IVaultRecoverable {
-    event RecoverToVault(address token, uint256 amount);
+    event RecoverToVault(address indexed token, uint256 amount);
 
     function transferToVault(address token) external;
 

--- a/contracts/common/IVaultRecoverable.sol
+++ b/contracts/common/IVaultRecoverable.sol
@@ -6,6 +6,8 @@ pragma solidity ^0.4.24;
 
 
 interface IVaultRecoverable {
+    event RecoverToVault(address token, uint256 amount);
+
     function transferToVault(address token) external;
 
     function allowRecoverability(address token) external view returns (bool);

--- a/contracts/common/IVaultRecoverable.sol
+++ b/contracts/common/IVaultRecoverable.sol
@@ -6,7 +6,7 @@ pragma solidity ^0.4.24;
 
 
 interface IVaultRecoverable {
-    event RecoverToVault(address indexed token, uint256 amount);
+    event RecoverToVault(address indexed vault, address indexed token, uint256 amount);
 
     function transferToVault(address token) external;
 

--- a/contracts/common/VaultRecoverable.sol
+++ b/contracts/common/VaultRecoverable.sol
@@ -38,7 +38,7 @@ contract VaultRecoverable is IVaultRecoverable, EtherTokenConstant, IsContract {
             require(token.safeTransfer(vault, balance), ERROR_TOKEN_TRANSFER_FAILED);
         }
 
-        emit RecoverToVault(_token, balance);
+        emit RecoverToVault(vault, _token, balance);
     }
 
     /**

--- a/contracts/common/VaultRecoverable.sol
+++ b/contracts/common/VaultRecoverable.sol
@@ -28,13 +28,17 @@ contract VaultRecoverable is IVaultRecoverable, EtherTokenConstant, IsContract {
         address vault = getRecoveryVault();
         require(isContract(vault), ERROR_VAULT_NOT_CONTRACT);
 
+        uint256 balance;
         if (_token == ETH) {
-            vault.transfer(address(this).balance);
+            balance = address(this).balance;
+            vault.transfer(balance);
         } else {
             ERC20 token = ERC20(_token);
-            uint256 amount = token.staticBalanceOf(this);
-            require(token.safeTransfer(vault, amount), ERROR_TOKEN_TRANSFER_FAILED);
+            balance = token.staticBalanceOf(this);
+            require(token.safeTransfer(vault, balance), ERROR_TOKEN_TRANSFER_FAILED);
         }
+
+        emit RecoverToVault(_token, balance);
     }
 
     /**

--- a/test/recovery_to_vault.js
+++ b/test/recovery_to_vault.js
@@ -50,6 +50,7 @@ contract('Recovery to vault', accounts => {
       assert.equal((await getBalance(target.address)).valueOf(), 0, 'Target balance should be 0')
       assert.equal((await getBalance(vault.address)).valueOf(), initialVaultBalance.plus(initialBalance).plus(amount), 'Vault balance should include recovered amount')
 
+      assert.equal(getEvent(recoverReceipt, 'RecoverToVault', 'vault'), vault.address, 'RecoverToVault event should have correct vault')
       assert.equal(getEvent(recoverReceipt, 'RecoverToVault', 'token'), ETH, 'RecoverToVault event should have correct token')
       assert.equal(getEvent(recoverReceipt, 'RecoverToVault', 'amount'), amount, 'RecoverToVault event should have correct amount')
       assertEvent(recoverReceipt, 'RecoverToVault', 1)
@@ -75,6 +76,7 @@ contract('Recovery to vault', accounts => {
       assert.equal((await token.balanceOf(target.address)).valueOf(), 0, 'Target balance should be 0')
       assert.equal((await token.balanceOf(vault.address)).valueOf(), initialVaultBalance.plus(initialBalance).plus(amount), 'Vault balance should include recovered amount')
 
+      assert.equal(getEvent(recoverReceipt, 'RecoverToVault', 'vault'), vault.address, 'RecoverToVault event should have correct vault')
       assert.equal(getEvent(recoverReceipt, 'RecoverToVault', 'token'), token.address, 'RecoverToVault event should have correct token')
       assert.equal(getEvent(recoverReceipt, 'RecoverToVault', 'amount'), amount, 'RecoverToVault event should have correct amount')
       assertEvent(recoverReceipt, 'RecoverToVault', 1)


### PR DESCRIPTION
Not sure if we made a conscious decision before to not emit an event, but it seems useful to know about for frontends and successful recoveries.