### PR TITLE
feat: add executorType() as a required interface for EVMScriptExecutors

### DIFF
--- a/contracts/evmscript/executors/BaseEVMScriptExecutor.sol
+++ b/contracts/evmscript/executors/BaseEVMScriptExecutor.sol
@@ -10,4 +10,6 @@ import "../IEVMScriptExecutor.sol";
 
 contract BaseEVMScriptExecutor is IEVMScriptExecutor, Autopetrified {
     uint256 internal constant SCRIPT_START_LOCATION = 4;
+
+    function executorType() external pure returns (bytes32);
 }


### PR DESCRIPTION
Simply forces subclasses of `BaseEVMScriptExecutor` to include `executorType()` as an interface they expose.

This alleviates the need for https://github.com/aragon/aragonOS/issues/455 until we want to make that breaking change. If every executor implements the same `executorType()` interface, frontends can reduce the set of enabled executors and find out which executor spec ID a particular forwarding interaction may require.