### PR TITLE
test: update bytes and address constants

### DIFF
--- a/test/apm_repo.js
+++ b/test/apm_repo.js
@@ -1,7 +1,9 @@
 const { assertRevert } = require('./helpers/assertThrow')
 
-
 const Repo = artifacts.require('UnsafeRepo')
+
+const EMPTY_BYTES = '0x'
+const ZERO_ADDR = '0x0000000000000000000000000000000000000000'
 
 contract('Repo', accounts => {
     let repo
@@ -31,7 +33,7 @@ contract('Repo', accounts => {
     // valid version as being a correct bump from 0.0.0
     it('cannot create invalid first version', async () => {
         return assertRevert(async () => {
-            await repo.newVersion([1, 1, 0], '0x00', '0x00')
+            await repo.newVersion([1, 1, 0], ZERO_ADDR, EMPTY_BYTES)
         })
     })
 
@@ -71,7 +73,7 @@ contract('Repo', accounts => {
         })
 
         it('setting contract address to 0 reuses last version address', async () => {
-            await repo.newVersion([1, 1, 0], '0x00', initialContent)
+            await repo.newVersion([1, 1, 0], ZERO_ADDR, initialContent)
             assertVersion(await repo.getByVersionId(2), [1, 1, 0], initialCode, initialContent)
         })
 

--- a/test/ens_subdomains.js
+++ b/test/ens_subdomains.js
@@ -17,6 +17,7 @@ const APMRegistryFactory = artifacts.require('APMRegistryFactory')
 const DAOFactory = artifacts.require('DAOFactory')
 
 const EMPTY_BYTES = '0x'
+const ZERO_ADDR = '0x0000000000000000000000000000000000000000'
 
 // Using APMFactory in order to reuse it
 contract('ENSSubdomainRegistrar', accounts => {
@@ -32,8 +33,6 @@ contract('ENSSubdomainRegistrar', accounts => {
     const holanode = namehash('hola.aragonpm.eth')
     const holalabel = '0x'+keccak256('hola')
 
-    const zeroAddr = '0x0000000000000000000000000000000000000000'
-
     before(async () => {
         const bases = [APMRegistry, Repo, ENSSubdomainRegistrar]
         baseDeployed = await Promise.all(bases.map(base => base.new()))
@@ -42,14 +41,14 @@ contract('ENSSubdomainRegistrar', accounts => {
 
         const kernelBase = await Kernel.new(true) // petrify immediately
         const aclBase = await ACL.new()
-        daoFactory = await DAOFactory.new(kernelBase.address, aclBase.address, '0x00')
+        daoFactory = await DAOFactory.new(kernelBase.address, aclBase.address, ZERO_ADDR)
 
         APP_BASES_NAMESPACE = await kernelBase.APP_BASES_NAMESPACE()
     })
 
     beforeEach(async () => {
         const baseAddrs = baseDeployed.map(c => c.address)
-        apmFactory = await APMRegistryFactory.new(daoFactory.address, ...baseAddrs, '0x0', ensFactory.address)
+        apmFactory = await APMRegistryFactory.new(daoFactory.address, ...baseAddrs, ZERO_ADDR, ensFactory.address)
         ens = ENS.at(await apmFactory.ens())
 
         const receipt = await apmFactory.newAPM(namehash('eth'), '0x'+keccak256('aragonpm'), apmOwner)
@@ -95,14 +94,14 @@ contract('ENSSubdomainRegistrar', accounts => {
         await registrar.createName(holalabel, apmOwner, { from: apmOwner })
         await registrar.deleteName(holalabel, { from: apmOwner })
 
-        assert.equal(await ens.owner(holanode), zeroAddr, 'should have reset name')
+        assert.equal(await ens.owner(holanode), ZERO_ADDR, 'should have reset name')
     })
 
     it('can delete names registered to itself', async () => {
         await registrar.createName(holalabel, registrar.address, { from: apmOwner })
         await registrar.deleteName(holalabel, { from: apmOwner })
 
-        assert.equal(await ens.owner(holanode), zeroAddr, 'should have reset name')
+        assert.equal(await ens.owner(holanode), ZERO_ADDR, 'should have reset name')
     })
 
     it('fails if initializing without rootnode ownership', async () => {

--- a/test/evm_script.js
+++ b/test/evm_script.js
@@ -18,6 +18,7 @@ const ExecutionTarget = artifacts.require('ExecutionTarget')
 const EVMScriptExecutorMock = artifacts.require('EVMScriptExecutorMock')
 const MockScriptExecutorApp = artifacts.require('MockScriptExecutorApp')
 
+const EMPTY_BYTES = '0x'
 const ZERO_ADDR = '0x0000000000000000000000000000000000000000'
 
 contract('EVM Script', accounts => {
@@ -27,6 +28,8 @@ contract('EVM Script', accounts => {
     const boss = accounts[1]
 
     const executorAppId = '0x1234'
+
+    const createExecutorId = id => `0x${String(id).padStart(8, '0')}`
 
     before(async () => {
         const regFact = await EVMScriptRegistryFactory.new()
@@ -51,9 +54,9 @@ contract('EVM Script', accounts => {
     })
 
     it('factory registered just 1 script executor', async () => {
-        assert.equal(await reg.getScriptExecutor('0x00000000'), ZERO_ADDR)
-        assert.notEqual(await reg.getScriptExecutor('0x00000001'), ZERO_ADDR)
-        assert.equal(await reg.getScriptExecutor('0x00000002'), ZERO_ADDR)
+        assert.equal(await reg.getScriptExecutor(createExecutorId(0)), ZERO_ADDR)
+        assert.notEqual(await reg.getScriptExecutor(createExecutorId(1)), ZERO_ADDR)
+        assert.equal(await reg.getScriptExecutor(createExecutorId(2)), ZERO_ADDR)
     })
 
     it('fails if directly calling base executor', async () => {
@@ -61,7 +64,7 @@ contract('EVM Script', accounts => {
         const action = { to: executionTarget.address, calldata: executionTarget.contract.execute.getData() }
         const script = encodeCallScript([action])
 
-        await assertRevert(() => callsScriptBase.execScript(script, '0x', []))
+        await assertRevert(() => callsScriptBase.execScript(script, EMPTY_BYTES, []))
     })
 
     context('> Registry', () => {
@@ -109,7 +112,7 @@ contract('EVM Script', accounts => {
 
                 assertEvent(receipt, 'DisableExecutor')
                 assert.isFalse(executorEntry[1], "executor should now be disabled")
-                assert.equal(await reg.getScriptExecutor(`0x0000000${newExecutorId}`), ZERO_ADDR, 'getting disabled executor should return zero addr')
+                assert.equal(await reg.getScriptExecutor(createExecutorId(newExecutorId)), ZERO_ADDR, 'getting disabled executor should return zero addr')
             })
 
             it('can re-enable an executor', async () => {
@@ -118,14 +121,14 @@ contract('EVM Script', accounts => {
                 await reg.disableScriptExecutor(newExecutorId, { from: boss })
                 let executorEntry = await reg.executors(newExecutorId)
                 assert.isFalse(executorEntry[1], "executor should now be disabled")
-                assert.equal(await reg.getScriptExecutor(`0x0000000${newExecutorId}`), ZERO_ADDR, 'getting disabled executor should return zero addr')
+                assert.equal(await reg.getScriptExecutor(createExecutorId(newExecutorId)), ZERO_ADDR, 'getting disabled executor should return zero addr')
 
                 const receipt = await reg.enableScriptExecutor(newExecutorId, { from: boss })
                 executorEntry = await reg.executors(newExecutorId)
 
                 assertEvent(receipt, 'EnableExecutor')
                 assert.isTrue(executorEntry[1], "executor should now be re-enabled")
-                assert.notEqual(await reg.getScriptExecutor(`0x0000000${newExecutorId}`), ZERO_ADDR, 'getting disabled executor should return non-zero addr')
+                assert.notEqual(await reg.getScriptExecutor(createExecutorId(newExecutorId)), ZERO_ADDR, 'getting disabled executor should return non-zero addr')
             })
 
             it('fails to add a new executor without the correct permissions', async () => {
@@ -176,7 +179,7 @@ contract('EVM Script', accounts => {
 
     context('> Uninitialized executor', () => {
         beforeEach(async () => {
-            const receipt = await dao.newAppInstance(executorAppId, executorAppBase.address, '0x', false, { from: boss })
+            const receipt = await dao.newAppInstance(executorAppId, executorAppBase.address, EMPTY_BYTES, false, { from: boss })
             executorApp = MockScriptExecutorApp.at(receipt.logs.filter(l => l.event == 'NewAppProxy')[0].args.proxy)
             // Explicitly don't initialize the executorApp
             executionTarget = await ExecutionTarget.new()
@@ -192,7 +195,7 @@ contract('EVM Script', accounts => {
 
     context('> Executor', () => {
         beforeEach(async () => {
-            const receipt = await dao.newAppInstance(executorAppId, executorAppBase.address, '0x', false, { from: boss })
+            const receipt = await dao.newAppInstance(executorAppId, executorAppBase.address, EMPTY_BYTES, false, { from: boss })
             executorApp = MockScriptExecutorApp.at(receipt.logs.filter(l => l.event == 'NewAppProxy')[0].args.proxy)
             await executorApp.initialize()
             executionTarget = await ExecutionTarget.new()
@@ -205,29 +208,29 @@ contract('EVM Script', accounts => {
 
         it('fails to execute if spec ID is 0', async () => {
             return assertRevert(async () => {
-                await executorApp.execute('0x00000000')
+                await executorApp.execute(createExecutorId(0))
             })
         })
 
         it('fails to execute if spec ID is unknown', async () => {
             return assertRevert(async () => {
-                await executorApp.execute('0x00000004')
+                await executorApp.execute(createExecutorId(4))
             })
         })
 
         context('> Spec ID 1', () => {
             it('is the correct executor type', async () => {
                 const CALLS_SCRIPT_TYPE = soliditySha3('CALLS_SCRIPT')
-                const executor = IEVMScriptExecutor.at(await reg.getScriptExecutor('0x00000001'))
+                const executor = IEVMScriptExecutor.at(await reg.getScriptExecutor(createExecutorId(1)))
                 assert.equal(await executor.executorType(), CALLS_SCRIPT_TYPE)
             })
 
             it('gets the correct executor from the app', async () => {
                 const CALLS_SCRIPT_TYPE = soliditySha3('CALLS_SCRIPT')
-                const script = '0x00000001'
-                const executor = await reg.getScriptExecutor(script)
+                const scriptId = createExecutorId(1)
+                const executor = await reg.getScriptExecutor(scriptId)
 
-                const appExecutor = await executorApp.getEVMScriptExecutor(script)
+                const appExecutor = await executorApp.getEVMScriptExecutor(scriptId)
                 assert.equal(executor, appExecutor, 'app should return the same evm script executor')
             })
 
@@ -242,10 +245,10 @@ contract('EVM Script', accounts => {
                 // Check logs
                 // The Executor always uses 0x for the input and callscripts always have 0x returns
                 const scriptResult = receipt.logs.filter(l => l.event == 'ScriptResult')[0]
-                assert.equal(scriptResult.args.executor, await reg.getScriptExecutor('0x00000001'), 'should log the same executor')
+                assert.equal(scriptResult.args.executor, await reg.getScriptExecutor(createExecutorId(1)), 'should log the same executor')
                 assert.equal(scriptResult.args.script, script, 'should log the same script')
-                assert.equal(scriptResult.args.input, '0x', 'should log the same input')
-                assert.equal(scriptResult.args.returnData, '0x', 'should log the return data')
+                assert.equal(scriptResult.args.input, EMPTY_BYTES, 'should log the same input')
+                assert.equal(scriptResult.args.returnData, EMPTY_BYTES, 'should log the return data')
             })
 
             it('fails to execute if has blacklist addresses being called', async () => {
@@ -323,7 +326,7 @@ contract('EVM Script', accounts => {
 
                         // Remove 12 first 0s of padding for addr and 28 0s for uint32
                         return script + addr.slice(24) + length.slice(56) + calldata.slice(2)
-                    }, '0x00000001') // spec 1
+                    }, createExecutorId(1)) // spec 1
                 }
 
                 it('fails if data length is too big', async () => {

--- a/test/kernel_acl.js
+++ b/test/kernel_acl.js
@@ -13,6 +13,9 @@ const KernelProxy = artifacts.require('KernelProxy')
 const AppStub = artifacts.require('AppStub')
 const APP_ID = hash('stub.aragonpm.test')
 
+const EMPTY_BYTES = '0x'
+const ZERO_ADDR = '0x0000000000000000000000000000000000000000'
+
 contract('Kernel ACL', accounts => {
     let aclBase, appBase
     let APP_MANAGER_ROLE, APP_BASES_NAMESPACE, DEFAULT_ACL_APP_ID, ANY_ENTITY
@@ -70,7 +73,7 @@ contract('Kernel ACL', accounts => {
             it('cannot initialize proxied ACL outside of Kernel', async () => {
                 // Set up ACL proxy
                 await acl.createPermission(permissionsRoot, kernelAddr, APP_MANAGER_ROLE, permissionsRoot)
-                const receipt = await kernel.newAppInstance(DEFAULT_ACL_APP_ID, aclBase.address, '0x', false)
+                const receipt = await kernel.newAppInstance(DEFAULT_ACL_APP_ID, aclBase.address, EMPTY_BYTES, false)
                 const newAcl = ACL.at(receipt.logs.filter(l => l.event == 'NewAppProxy')[0].args.proxy)
 
                 return assertRevert(async () => {
@@ -153,14 +156,14 @@ contract('Kernel ACL', accounts => {
 
                     // Allows setting code for namespace other than 0
                     for (grantee of [child, secondChild]) {
-                        const receipt = await kernel.setApp('0x121212', '0x0', appBase.address, { from: grantee })
+                        const receipt = await kernel.setApp('0x121212', ZERO_ADDR, appBase.address, { from: grantee })
                         assertEvent(receipt, 'SetApp')
                     }
 
                     // Fail if setting code for namespace 0
                     for (grantee of [child, secondChild]) {
                         await assertRevert(async () => {
-                            await kernel.setApp('0x0', APP_ID, appBase.address, { from: grantee })
+                            await kernel.setApp('0x00', APP_ID, appBase.address, { from: grantee })
                         })
                     }
                 })
@@ -249,7 +252,7 @@ contract('Kernel ACL', accounts => {
 
                     it('removes manager', async () => {
                         const noManager = await acl.getPermissionManager(kernelAddr, APP_MANAGER_ROLE)
-                        assert.equal('0x0000000000000000000000000000000000000000', noManager, 'manager should have been removed')
+                        assert.equal(ZERO_ADDR, noManager, 'manager should have been removed')
                     })
 
                     it('old manager lost power', async () => {

--- a/test/kernel_acl.js
+++ b/test/kernel_acl.js
@@ -156,7 +156,7 @@ contract('Kernel ACL', accounts => {
 
                     // Allows setting code for namespace other than 0
                     for (grantee of [child, secondChild]) {
-                        const receipt = await kernel.setApp('0x121212', ZERO_ADDR, appBase.address, { from: grantee })
+                        const receipt = await kernel.setApp('0x121212', APP_ID, appBase.address, { from: grantee })
                         assertEvent(receipt, 'SetApp')
                     }
 
@@ -164,6 +164,13 @@ contract('Kernel ACL', accounts => {
                     for (grantee of [child, secondChild]) {
                         await assertRevert(async () => {
                             await kernel.setApp('0x00', APP_ID, appBase.address, { from: grantee })
+                        })
+                    }
+
+                    // Fail if setting code for empty namespace (which becomes 0)
+                    for (grantee of [child, secondChild]) {
+                        await assertRevert(async () => {
+                            await kernel.setApp(EMPTY_BYTES, APP_ID, appBase.address, { from: grantee })
                         })
                     }
                 })

--- a/test/kernel_apps.js
+++ b/test/kernel_apps.js
@@ -16,8 +16,8 @@ const ERCProxyMock = artifacts.require('ERCProxyMock')
 const KernelOverloadMock = artifacts.require('KernelOverloadMock')
 
 const APP_ID = hash('stub.aragonpm.test')
-const ZERO_ADDR = '0x0000000000000000000000000000000000000000'
 const EMPTY_BYTES = '0x'
+const ZERO_ADDR = '0x0000000000000000000000000000000000000000'
 
 contract('Kernel apps', accounts => {
     let aclBase, appBase1, appBase2
@@ -101,7 +101,7 @@ contract('Kernel apps', accounts => {
                 context(`> new ${appProxyType} instances`, () => {
                     onlyAppProxy(() =>
                         it('creates a new upgradeable app proxy instance', async () => {
-                            const receipt = await kernel.newAppInstance(APP_ID, appBase1.address, '0x', false)
+                            const receipt = await kernel.newAppInstance(APP_ID, appBase1.address, EMPTY_BYTES, false)
                             const appProxy = AppProxyUpgradeable.at(receipt.logs.filter(l => l.event == 'NewAppProxy')[0].args.proxy)
                             assert.equal(await appProxy.kernel(), kernel.address, "new appProxy instance's kernel should be set to the originating kernel")
 
@@ -137,18 +137,18 @@ contract('Kernel apps', accounts => {
                         it('sets the app base when not previously registered', async() => {
                             assert.equal(ZERO_ADDR, await kernel.getApp(APP_BASES_NAMESPACE, APP_ID))
 
-                            await kernelOverload[newInstanceFn](APP_ID, appBase1.address, '0x', false)
+                            await kernelOverload[newInstanceFn](APP_ID, appBase1.address, EMPTY_BYTES, false)
                             assert.equal(appBase1.address, await kernel.getApp(APP_BASES_NAMESPACE, APP_ID))
                         })
 
                         it("doesn't set the app base when already set", async() => {
                             await kernel.setApp(APP_BASES_NAMESPACE, APP_ID, appBase1.address)
-                            const receipt = await kernelOverload[newInstanceFn](APP_ID, appBase1.address, '0x', false)
+                            const receipt = await kernelOverload[newInstanceFn](APP_ID, appBase1.address, EMPTY_BYTES, false)
                             assert.isFalse(receipt.logs.includes(l => l.event == 'SetApp'))
                         })
 
                         it("also sets the default app", async () => {
-                            const receipt = await kernelOverload[newInstanceFn](APP_ID, appBase1.address, '0x', true)
+                            const receipt = await kernelOverload[newInstanceFn](APP_ID, appBase1.address, EMPTY_BYTES, true)
                             const appProxyAddr = receipt.logs.filter(l => l.event == 'NewAppProxy')[0].args.proxy
 
                             // Check that both the app base and default app are set
@@ -175,7 +175,7 @@ contract('Kernel apps', accounts => {
 
                         it("fails if the app base is not given", async() => {
                             return assertRevert(async () => {
-                                await kernelOverload[newInstanceFn](APP_ID, ZERO_ADDR, '0x', false)
+                                await kernelOverload[newInstanceFn](APP_ID, ZERO_ADDR, EMPTY_BYTES, false)
                             })
                         })
 
@@ -186,7 +186,7 @@ contract('Kernel apps', accounts => {
 
                             await kernel.setApp(APP_BASES_NAMESPACE, APP_ID, existingBase)
                             return assertRevert(async () => {
-                                await kernelOverload[newInstanceFn](APP_ID, differentBase, '0x', false)
+                                await kernelOverload[newInstanceFn](APP_ID, differentBase, EMPTY_BYTES, false)
                             })
                         })
                     })

--- a/test/kernel_lifecycle.js
+++ b/test/kernel_lifecycle.js
@@ -11,6 +11,7 @@ const KernelProxy = artifacts.require('KernelProxy')
 const AppStub = artifacts.require('AppStub')
 const APP_ID = hash('stub.aragonpm.test')
 const VAULT_ID = hash('vault.aragonpm.test')
+const EMPTY_BYTES = '0x'
 
 contract('Kernel lifecycle', accounts => {
   let aclBase, appBase
@@ -18,10 +19,10 @@ contract('Kernel lifecycle', accounts => {
 
   const testUnaccessibleFunctionalityWhenUninitialized = async (kernel) => {
     // hasPermission should always return false when uninitialized
-    assert.isFalse(await kernel.hasPermission(accounts[0], kernel.address, APP_MANAGER_ROLE, '0x'))
-    assert.isFalse(await kernel.hasPermission(accounts[1], kernel.address, APP_MANAGER_ROLE, '0x'))
+    assert.isFalse(await kernel.hasPermission(accounts[0], kernel.address, APP_MANAGER_ROLE, EMPTY_BYTES))
+    assert.isFalse(await kernel.hasPermission(accounts[1], kernel.address, APP_MANAGER_ROLE, EMPTY_BYTES))
 
-    await assertRevert(() => kernel.newAppInstance(APP_ID, appBase.address, '0x', false))
+    await assertRevert(() => kernel.newAppInstance(APP_ID, appBase.address, EMPTY_BYTES, false))
     await assertRevert(() => kernel.newPinnedAppInstance(APP_ID, appBase.address))
     await assertRevert(() => kernel.setApp(APP_BASES_NAMESPACE, APP_ID, appBase.address))
     await assertRevert(() => kernel.setRecoveryVaultAppId(VAULT_ID))
@@ -29,17 +30,17 @@ contract('Kernel lifecycle', accounts => {
 
   const testUsability = async (kernel) => {
     // Make sure we haven't already setup the required permission
-    assert.isFalse(await kernel.hasPermission(accounts[0], kernel.address, APP_MANAGER_ROLE, '0x'))
-    assert.isFalse(await kernel.hasPermission(accounts[1], kernel.address, APP_MANAGER_ROLE, '0x'))
+    assert.isFalse(await kernel.hasPermission(accounts[0], kernel.address, APP_MANAGER_ROLE, EMPTY_BYTES))
+    assert.isFalse(await kernel.hasPermission(accounts[1], kernel.address, APP_MANAGER_ROLE, EMPTY_BYTES))
 
     // Then set the required permission
     const acl = ACL.at(await kernel.acl())
     await acl.createPermission(accounts[0], kernel.address, APP_MANAGER_ROLE, accounts[0])
-    assert.isTrue(await kernel.hasPermission(accounts[0], kernel.address, APP_MANAGER_ROLE, '0x'))
-    assert.isFalse(await kernel.hasPermission(accounts[1], kernel.address, APP_MANAGER_ROLE, '0x'))
+    assert.isTrue(await kernel.hasPermission(accounts[0], kernel.address, APP_MANAGER_ROLE, EMPTY_BYTES))
+    assert.isFalse(await kernel.hasPermission(accounts[1], kernel.address, APP_MANAGER_ROLE, EMPTY_BYTES))
 
     // And finally test functionality
-    await kernel.newAppInstance(APP_ID, appBase.address, '0x', false)
+    await kernel.newAppInstance(APP_ID, appBase.address, EMPTY_BYTES, false)
   }
 
   // Initial setup

--- a/test/recovery_to_vault.js
+++ b/test/recovery_to_vault.js
@@ -23,6 +23,7 @@ const KernelDepositableMock = artifacts.require('KernelDepositableMock')
 const getEvent = (receipt, event, arg) => { return receipt.logs.filter(l => l.event == event)[0].args[arg] }
 
 const APP_ID = hash('stub.aragonpm.test')
+const EMPTY_BYTES = '0x'
 const SEND_ETH_GAS = 31000 // 21k base tx cost + 10k limit on depositable proxies
 
 contract('Recovery to vault', accounts => {
@@ -190,7 +191,7 @@ contract('Recovery to vault', accounts => {
               vault = vaultBase
             } else if (vaultType === 'VaultProxy') {
               // This doesn't automatically setup the recovery address
-              const receipt = await kernel.newAppInstance(vaultId, vaultBase.address, '0x', false)
+              const receipt = await kernel.newAppInstance(vaultId, vaultBase.address, EMPTY_BYTES, false)
               const vaultProxyAddress = getEvent(receipt, 'NewAppProxy', 'proxy')
               vault = VaultMock.at(vaultProxyAddress)
             }
@@ -249,7 +250,7 @@ contract('Recovery to vault', accounts => {
           context('> Proxied app with kernel', () => {
             beforeEach(async () => {
               // Setup app
-              const receipt = await kernel.newAppInstance(APP_ID, appBase.address, '0x', false)
+              const receipt = await kernel.newAppInstance(APP_ID, appBase.address, EMPTY_BYTES, false)
               const appProxy = getEvent(receipt, 'NewAppProxy', 'proxy')
               const app = AppStubDepositable.at(appProxy)
               await app.enableDeposits()
@@ -265,7 +266,7 @@ contract('Recovery to vault', accounts => {
 
             it('cannot send ETH with data to proxy', async () => {
               await assertRevert(async () => {
-                await target.sendTransaction({ value: 1, data: '0x1', gas: SEND_ETH_GAS })
+                await target.sendTransaction({ value: 1, data: '0x01', gas: SEND_ETH_GAS })
               })
             })
 
@@ -301,7 +302,7 @@ contract('Recovery to vault', accounts => {
           context('> Conditional fund recovery', () => {
             beforeEach(async () => {
               // Setup app with conditional recovery code
-              const receipt = await kernel.newAppInstance(APP_ID, appConditionalRecoveryBase.address, '0x', false)
+              const receipt = await kernel.newAppInstance(APP_ID, appConditionalRecoveryBase.address, EMPTY_BYTES, false)
               const appProxy = getEvent(receipt, 'NewAppProxy', 'proxy')
               const app = AppStubConditionalRecovery.at(appProxy)
               await app.initialize()
@@ -358,7 +359,7 @@ contract('Recovery to vault', accounts => {
       // Create a new vault and set that vault as the default vault in the kernel
       const vaultId = hash('vault.aragonpm.test')
       const vaultBase = await VaultMock.new()
-      const vaultReceipt = await kernel.newAppInstance(vaultId, vaultBase.address, '0x', true)
+      const vaultReceipt = await kernel.newAppInstance(vaultId, vaultBase.address, EMPTY_BYTES, true)
       const vaultAddress = getEvent(vaultReceipt, 'NewAppProxy', 'proxy')
       vault = VaultMock.at(vaultAddress)
       await vault.initialize()


### PR DESCRIPTION
Updates the tests to use `EMPTY_BYTES` and `ZERO_ADDR` constants (should move these out to a shared lib sometime).

Also fixes a few instances where we sent an invalid number of hex bytes (usually 1-length bytes like `0x1`; see https://github.com/trufflesuite/ganache-core/issues/283#issuecomment-470997764).