### PR TITLE
fix: Use double quotes in contract imports

### DIFF
--- a/contracts/lib/ens/AbstractENS.sol
+++ b/contracts/lib/ens/AbstractENS.sol
@@ -1,3 +1,5 @@
+// See https://github.com/ensdomains/ens/blob/7e377df83f/contracts/AbstractENS.sol
+
 pragma solidity ^0.4.15;
 
 

--- a/contracts/lib/ens/ENS.sol
+++ b/contracts/lib/ens/ENS.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.4.0;
 
 
-import './AbstractENS.sol';
+import "./AbstractENS.sol";
 
 /**
  * The ENS registry contract.

--- a/contracts/lib/ens/ENS.sol
+++ b/contracts/lib/ens/ENS.sol
@@ -1,3 +1,5 @@
+// See https://github.com/ensdomains/ens/blob/7e377df83f/contracts/ENS.sol
+
 pragma solidity ^0.4.0;
 
 

--- a/contracts/lib/ens/PublicResolver.sol
+++ b/contracts/lib/ens/PublicResolver.sol
@@ -1,3 +1,5 @@
+// See https://github.com/ensdomains/ens/blob/7e377df83f/contracts/PublicResolver.sol
+
 pragma solidity ^0.4.0;
 
 import "./AbstractENS.sol";

--- a/contracts/lib/ens/PublicResolver.sol
+++ b/contracts/lib/ens/PublicResolver.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.4.0;
 
-import './AbstractENS.sol';
+import "./AbstractENS.sol";
 
 /**
  * A simple resolver anyone can use; only allows the owner of a node to set its


### PR DESCRIPTION
Not sure if single quotes was ever recommended, but the docs now only use double quotes for the import syntax.

Also adds links to where these ENS contracts are derived from.