### PR TITLE
ACLSyntaxSugar: fix returning unallocated memory

### DIFF
--- a/contracts/acl/ACLSyntaxSugar.sol
+++ b/contracts/acl/ACLSyntaxSugar.sol
@@ -7,7 +7,7 @@ pragma solidity ^0.4.24;
 
 contract ACLSyntaxSugar {
     function arr() internal pure returns (uint256[]) {
-        // solium-disable-previous-line no-empty-blocks
+        return new uint256[](0);
     }
 
     function arr(bytes32 _a) internal pure returns (uint256[] r) {


### PR DESCRIPTION
This is actually [used by the Voting app](https://github.com/aragon/aragon-apps/blob/master/apps/voting/contracts/Voting.sol#L196) currently, although it never assigns to the array.