### PR TITLE
feat: add ConversionHelpers lib for converting memory types

### DIFF
--- a/contracts/acl/ACL.sol
+++ b/contracts/acl/ACL.sol
@@ -1,6 +1,7 @@
 pragma solidity 0.4.24;
 
 import "../apps/AragonApp.sol";
+import "../common/ConversionHelpers.sol";
 import "../common/TimeHelpers.sol";
 import "./ACLSyntaxSugar.sol";
 import "./IACL.sol";
@@ -242,17 +243,7 @@ contract ACL is IACL, TimeHelpers, AragonApp, ACLHelpers {
     * @return boolean indicating whether the ACL allows the role or not
     */
     function hasPermission(address _who, address _where, bytes32 _what, bytes memory _how) public view returns (bool) {
-        // Force cast the bytes array into a uint256[], by overwriting its length
-        // Note that the uint256[] doesn't need to be initialized as we immediately overwrite it
-        // with _how and a new length, and _how becomes invalid from this point forward
-        uint256[] memory how;
-        uint256 intsLength = _how.length / 32;
-        assembly {
-            how := _how
-            mstore(how, intsLength)
-        }
-
-        return hasPermission(_who, _where, _what, how);
+        return hasPermission(_who, _where, _what, ConversionHelpers.castBytesToUintArray(_how));
     }
 
     function hasPermission(address _who, address _where, bytes32 _what, uint256[] memory _how) public view returns (bool) {

--- a/contracts/acl/ACL.sol
+++ b/contracts/acl/ACL.sol
@@ -243,7 +243,7 @@ contract ACL is IACL, TimeHelpers, AragonApp, ACLHelpers {
     * @return boolean indicating whether the ACL allows the role or not
     */
     function hasPermission(address _who, address _where, bytes32 _what, bytes memory _how) public view returns (bool) {
-        return hasPermission(_who, _where, _what, ConversionHelpers.castBytesToUintArray(_how));
+        return hasPermission(_who, _where, _what, ConversionHelpers.dangerouslyCastBytesToUintArray(_how));
     }
 
     function hasPermission(address _who, address _where, bytes32 _what, uint256[] memory _how) public view returns (bool) {

--- a/contracts/apps/AragonApp.sol
+++ b/contracts/apps/AragonApp.sol
@@ -48,7 +48,12 @@ contract AragonApp is AppStorage, Autopetrified, VaultRecoverable, EVMScriptRunn
             return false;
         }
 
-        return linkedKernel.hasPermission(_sender, address(this), _role, ConversionHelpers.castUintArrayToBytes(_params));
+        return linkedKernel.hasPermission(
+            _sender,
+            address(this),
+            _role,
+            ConversionHelpers.dangerouslyCastUintArrayToBytes(_params)
+        );
     }
 
     /**

--- a/contracts/apps/AragonApp.sol
+++ b/contracts/apps/AragonApp.sol
@@ -5,10 +5,11 @@
 pragma solidity ^0.4.24;
 
 import "./AppStorage.sol";
+import "../acl/ACLSyntaxSugar.sol";
 import "../common/Autopetrified.sol";
+import "../common/ConversionHelpers.sol";
 import "../common/VaultRecoverable.sol";
 import "../evmscript/EVMScriptRunner.sol";
-import "../acl/ACLSyntaxSugar.sol";
 
 
 // Contracts inheriting from AragonApp are, by default, immediately petrified upon deployment so
@@ -47,16 +48,7 @@ contract AragonApp is AppStorage, Autopetrified, VaultRecoverable, EVMScriptRunn
             return false;
         }
 
-        // Force cast the uint256[] into a bytes array, by overwriting its length
-        // Note that the bytes array doesn't need to be initialized as we immediately overwrite it
-        // with _params and a new length, and _params becomes invalid from this point forward
-        bytes memory how;
-        uint256 byteLength = _params.length * 32;
-        assembly {
-            how := _params
-            mstore(how, byteLength)
-        }
-        return linkedKernel.hasPermission(_sender, address(this), _role, how);
+        return linkedKernel.hasPermission(_sender, address(this), _role, ConversionHelpers.castUintArrayToBytes(_params));
     }
 
     /**

--- a/contracts/common/ConversionHelpers.sol
+++ b/contracts/common/ConversionHelpers.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.4.24;
 
 
 library ConversionHelpers {
-    function castUintArrayToBytes(uint256[] memory _input) internal pure returns (bytes memory output) {
+    function dangerouslyCastUintArrayToBytes(uint256[] memory _input) internal pure returns (bytes memory output) {
         // Force cast the uint256[] into a bytes array, by overwriting its length
         // Note that the bytes array doesn't need to be initialized as we immediately overwrite it
         // with the input and a new length. The input becomes invalid from this point forward.
@@ -13,7 +13,7 @@ library ConversionHelpers {
         }
     }
 
-    function castBytesToUintArray(bytes memory _input) internal pure returns (uint256[] memory output) {
+    function dangerouslyCastBytesToUintArray(bytes memory _input) internal pure returns (uint256[] memory output) {
         // Force cast the bytes array into a uint256[], by overwriting its length
         // Note that the uint256[] doesn't need to be initialized as we immediately overwrite it
         // with the input and a new length. The input becomes invalid from this point forward.

--- a/contracts/common/ConversionHelpers.sol
+++ b/contracts/common/ConversionHelpers.sol
@@ -1,0 +1,26 @@
+pragma solidity ^0.4.24;
+
+
+library ConversionHelpers {
+    function castUintArrayToBytes(uint256[] memory _input) internal pure returns (bytes memory output) {
+        // Force cast the uint256[] into a bytes array, by overwriting its length
+        // Note that the bytes array doesn't need to be initialized as we immediately overwrite it
+        // with the input and a new length. The input becomes invalid from this point forward.
+        uint256 byteLength = _input.length * 32;
+        assembly {
+            output := _input
+            mstore(output, byteLength)
+        }
+    }
+
+    function castBytesToUintArray(bytes memory _input) internal pure returns (uint256[] memory output) {
+        // Force cast the bytes array into a uint256[], by overwriting its length
+        // Note that the uint256[] doesn't need to be initialized as we immediately overwrite it
+        // with the input and a new length. The input becomes invalid from this point forward.
+        uint256 intsLength = _input.length / 32;
+        assembly {
+            output := _input
+            mstore(output, intsLength)
+        }
+    }
+}

--- a/contracts/kernel/Kernel.sol
+++ b/contracts/kernel/Kernel.sol
@@ -5,11 +5,12 @@ import "./KernelConstants.sol";
 import "./KernelStorage.sol";
 import "../acl/IACL.sol";
 import "../acl/ACLSyntaxSugar.sol";
-import "../lib/misc/ERCProxy.sol";
+import "../common/ConversionHelpers.sol";
 import "../common/IsContract.sol";
 import "../common/Petrifiable.sol";
 import "../common/VaultRecoverable.sol";
 import "../factory/AppProxyFactory.sol";
+import "../lib/misc/ERCProxy.sol";
 
 
 // solium-disable-next-line max-len
@@ -227,18 +228,11 @@ contract Kernel is IKernel, KernelStorage, KernelAppIds, KernelNamespaceConstant
         }
     }
 
-    modifier auth(bytes32 _role, uint256[] memory params) {
-        // Force cast the uint256[] into a bytes array, by overwriting its length
-        // Note that the bytes array doesn't need to be initialized as we immediately overwrite it
-        // with params and a new length, and params becomes invalid from this point forward
-        bytes memory how;
-        uint256 byteLength = params.length * 32;
-        assembly {
-            how := params
-            mstore(how, byteLength)
-        }
-
-        require(hasPermission(msg.sender, address(this), _role, how), ERROR_AUTH_FAILED);
+    modifier auth(bytes32 _role, uint256[] memory _params) {
+        require(
+            hasPermission(msg.sender, address(this), _role, ConversionHelpers.castUintArrayToBytes(_params)),
+            ERROR_AUTH_FAILED
+        );
         _;
     }
 }

--- a/contracts/kernel/Kernel.sol
+++ b/contracts/kernel/Kernel.sol
@@ -230,7 +230,7 @@ contract Kernel is IKernel, KernelStorage, KernelAppIds, KernelNamespaceConstant
 
     modifier auth(bytes32 _role, uint256[] memory _params) {
         require(
-            hasPermission(msg.sender, address(this), _role, ConversionHelpers.castUintArrayToBytes(_params)),
+            hasPermission(msg.sender, address(this), _role, ConversionHelpers.dangerouslyCastUintArrayToBytes(_params)),
             ERROR_AUTH_FAILED
         );
         _;

--- a/contracts/test/TestConversionHelpers.sol
+++ b/contracts/test/TestConversionHelpers.sol
@@ -22,6 +22,9 @@ contract TestConversionHelpers {
         // Check length
         Assert.equal(arrBytes.length, arrLength * 32, "should have correct length as bytes array");
 
+        // Check values
+        assertValues(arrBytes);
+
         // Check memory position (conversion should be in place)
         uint256 arrMemLoc;
         uint256 arrBytesMemLoc;
@@ -46,6 +49,9 @@ contract TestConversionHelpers {
         // Check length
         Assert.equal(arrLength, arrReconverted.length, "should have correct length after reconverting");
 
+        // Check values
+        assertValues(arrReconverted);
+
         // Check memory position (conversion should be in place)
         uint256 arrMemLoc;
         uint256 arrReconvertedMemLoc;
@@ -54,11 +60,6 @@ contract TestConversionHelpers {
             arrReconvertedMemLoc := arrReconverted
         }
         Assert.equal(arrMemLoc, arrReconvertedMemLoc, "should have same memory location after reconverting");
-
-        // Check values
-        Assert.equal(arrReconverted[0], FIRST, "should have correct index value at 0");
-        Assert.equal(arrReconverted[1], SECOND, "should have correct index value at 1");
-        Assert.equal(arrReconverted[2], THIRD, "should have correct index value at 2");
     }
 
     function testBytesConvertedToUintArray() public {
@@ -81,6 +82,9 @@ contract TestConversionHelpers {
         // Check length
         Assert.equal(arrUint.length, arrLength / 32, "should have correct length as uint256 array");
 
+        // Check values
+        assertValues(arrUint);
+
         // Check memory position (conversion should be in place)
         uint256 arrMemLoc;
         uint256 arrUintMemLoc;
@@ -89,11 +93,6 @@ contract TestConversionHelpers {
             arrUintMemLoc := arrUint
         }
         Assert.equal(arrMemLoc, arrUintMemLoc, "should have same memory location after conversion");
-
-        // Check values
-        Assert.equal(arrUint[0], FIRST, "should have correct index value at 0");
-        Assert.equal(arrUint[1], SECOND, "should have correct index value at 1");
-        Assert.equal(arrUint[2], THIRD, "should have correct index value at 2");
     }
 
     function testBytesIntactIfConvertedBack() public {
@@ -117,6 +116,9 @@ contract TestConversionHelpers {
         // Check length
         Assert.equal(arrLength, arrReconverted.length, "should have correct length after reconverting");
 
+        // Check values
+        assertValues(arrReconverted);
+
         // Check memory position (conversion should be in place)
         uint256 arrMemLoc;
         uint256 arrReconvertedMemLoc;
@@ -125,12 +127,22 @@ contract TestConversionHelpers {
             arrReconvertedMemLoc := arrReconverted
         }
         Assert.equal(arrMemLoc, arrReconvertedMemLoc, "should have same memory location after reconverting");
+    }
 
-        // Check values
+    function assertValues(uint256[] memory _data) {
+        Assert.equal(_data[0], FIRST, "should have correct index value at 0");
+        Assert.equal(_data[1], SECOND, "should have correct index value at 1");
+        Assert.equal(_data[2], THIRD, "should have correct index value at 2");
+    }
+
+    function assertValues(bytes memory _data) {
+        uint256 first;
+        uint256 second;
+        uint256 third;
         assembly {
-            first := mload(add(arrReconvertedMemLoc, 0x20))
-            second := mload(add(arrReconvertedMemLoc, 0x40))
-            third := mload(add(arrReconvertedMemLoc, 0x60))
+            first := mload(add(_data, 0x20))
+            second := mload(add(_data, 0x40))
+            third := mload(add(_data, 0x60))
         }
         Assert.equal(first, FIRST, "should have correct first value");
         Assert.equal(second, SECOND, "should have correct second value");

--- a/contracts/test/TestConversionHelpers.sol
+++ b/contracts/test/TestConversionHelpers.sol
@@ -1,0 +1,139 @@
+pragma solidity 0.4.24;
+
+import "./helpers/Assert.sol";
+import "../common/ConversionHelpers.sol";
+
+
+contract TestConversionHelpers {
+    uint256 constant internal FIRST = uint256(keccak256("0"));
+    uint256 constant internal SECOND = uint256(keccak256("1"));
+    uint256 constant internal THIRD = uint256(keccak256("2"));
+
+    function testUintArrayConvertedToBytes() public {
+        uint256[] memory arr = new uint256[](3);
+        arr[0] = FIRST;
+        arr[1] = SECOND;
+        arr[2] = THIRD;
+        uint256 arrLength = arr.length;
+
+        // Do conversion
+        bytes memory arrBytes = ConversionHelpers.dangerouslyCastUintArrayToBytes(arr);
+
+        // Check length
+        Assert.equal(arrBytes.length, arrLength * 32, "should have correct length as bytes array");
+
+        // Check memory position (conversion should be in place)
+        uint256 arrMemLoc;
+        uint256 arrBytesMemLoc;
+        assembly {
+            arrMemLoc := arr
+            arrBytesMemLoc := arrBytes
+        }
+        Assert.equal(arrMemLoc, arrBytesMemLoc, "should have same memory location after conversion");
+    }
+
+    function testUintArrayIntactIfConvertedBack() public {
+        uint256[] memory arr = new uint256[](3);
+        arr[0] = FIRST;
+        arr[1] = SECOND;
+        arr[2] = THIRD;
+        uint256 arrLength = arr.length;
+
+        // Convert to and back
+        bytes memory arrBytes = ConversionHelpers.dangerouslyCastUintArrayToBytes(arr);
+        uint256[] memory arrReconverted = ConversionHelpers.dangerouslyCastBytesToUintArray(arrBytes);
+
+        // Check length
+        Assert.equal(arrLength, arrReconverted.length, "should have correct length after reconverting");
+
+        // Check memory position (conversion should be in place)
+        uint256 arrMemLoc;
+        uint256 arrReconvertedMemLoc;
+        assembly {
+            arrMemLoc := arr
+            arrReconvertedMemLoc := arrReconverted
+        }
+        Assert.equal(arrMemLoc, arrReconvertedMemLoc, "should have same memory location after reconverting");
+
+        // Check values
+        Assert.equal(arrReconverted[0], FIRST, "should have correct index value at 0");
+        Assert.equal(arrReconverted[1], SECOND, "should have correct index value at 1");
+        Assert.equal(arrReconverted[2], THIRD, "should have correct index value at 2");
+    }
+
+    function testBytesConvertedToUintArray() public {
+        bytes memory arr = new bytes(96);
+
+        // Fill in bytes arr
+        uint256 first = FIRST;
+        uint256 second = SECOND;
+        uint256 third = THIRD;
+        assembly {
+            mstore(add(arr, 0x20), first)
+            mstore(add(arr, 0x40), second)
+            mstore(add(arr, 0x60), third)
+        }
+        uint256 arrLength = arr.length;
+
+        // Do conversion
+        uint256[] memory arrUint = ConversionHelpers.dangerouslyCastBytesToUintArray(arr);
+
+        // Check length
+        Assert.equal(arrUint.length, arrLength / 32, "should have correct length as uint256 array");
+
+        // Check memory position (conversion should be in place)
+        uint256 arrMemLoc;
+        uint256 arrUintMemLoc;
+        assembly {
+            arrMemLoc := arr
+            arrUintMemLoc := arrUint
+        }
+        Assert.equal(arrMemLoc, arrUintMemLoc, "should have same memory location after conversion");
+
+        // Check values
+        Assert.equal(arrUint[0], FIRST, "should have correct index value at 0");
+        Assert.equal(arrUint[1], SECOND, "should have correct index value at 1");
+        Assert.equal(arrUint[2], THIRD, "should have correct index value at 2");
+    }
+
+    function testBytesIntactIfConvertedBack() public {
+        bytes memory arr = new bytes(96);
+
+        // Fill in bytes arr
+        uint256 first = FIRST;
+        uint256 second = SECOND;
+        uint256 third = THIRD;
+        assembly {
+            mstore(add(arr, 0x20), first)
+            mstore(add(arr, 0x40), second)
+            mstore(add(arr, 0x60), third)
+        }
+        uint256 arrLength = arr.length;
+
+        // Convert to and back
+        uint256[] memory arrUint = ConversionHelpers.dangerouslyCastBytesToUintArray(arr);
+        bytes memory arrReconverted = ConversionHelpers.dangerouslyCastUintArrayToBytes(arrUint);
+
+        // Check length
+        Assert.equal(arrLength, arrReconverted.length, "should have correct length after reconverting");
+
+        // Check memory position (conversion should be in place)
+        uint256 arrMemLoc;
+        uint256 arrReconvertedMemLoc;
+        assembly {
+            arrMemLoc := arr
+            arrReconvertedMemLoc := arrReconverted
+        }
+        Assert.equal(arrMemLoc, arrReconvertedMemLoc, "should have same memory location after reconverting");
+
+        // Check values
+        assembly {
+            first := mload(add(arrReconvertedMemLoc, 0x20))
+            second := mload(add(arrReconvertedMemLoc, 0x40))
+            third := mload(add(arrReconvertedMemLoc, 0x60))
+        }
+        Assert.equal(first, FIRST, "should have correct first value");
+        Assert.equal(second, SECOND, "should have correct second value");
+        Assert.equal(third, THIRD, "should have correct third value");
+    }
+}

--- a/test/conversion_helpers.js
+++ b/test/conversion_helpers.js
@@ -1,0 +1,3 @@
+const runSolidityTest = require('./helpers/runSolidityTest')
+
+runSolidityTest('TestConversionHelpers')

--- a/test/helpers/decodeEvent.js
+++ b/test/helpers/decodeEvent.js
@@ -6,7 +6,7 @@ module.exports = {
         const eventSignature = abi.encodeEventSignature(eventAbi)
         const eventLogs = receipt.logs.filter(l => l.topics[0] === eventSignature)
         return eventLogs.map(log => {
-            log.event = abi.name
+            log.event = eventAbi.name
             log.args = abi.decodeLog(eventAbi.inputs, log.data, log.topics.slice(1))
             return log
         })


### PR DESCRIPTION
Consolidates all the bytes<>uint256[] conversions into a library.

It's not _too_ costly to add, and hopefully makes us all feel a bit better about this bit 😄.

Also fixes the solidity test runner, which must've broke at some point along the way (due to the assert logs not being decoded properly) 😅.

Bytecode diff:

```
                              CODE DEPOSIT COST    DEPLOYED BYTES     INITIALIZATION BYTES
ACL.json                      5400 more gas        +27                0
APMRegistry.json              4400 more gas        +22                0
AragonApp.json                4000 more gas        +20                0
ENSSubdomainRegistrar.json    4000 more gas        +20                0
EVMScriptRegistry.json        4000 more gas        +20                0
EVMScriptRegistryFactory.json Same                 0                  +20
Kernel.json                   8000 less gas        -40                0
Repo.json                     4000 more gas        +20                0
TestACLInterpreter.json       5400 more gas        +27                0
```