### PR TITLE
ConversionHelpers: check length on bytes to uint256[]

### DIFF
--- a/contracts/common/ConversionHelpers.sol
+++ b/contracts/common/ConversionHelpers.sol
@@ -2,6 +2,8 @@ pragma solidity ^0.4.24;
 
 
 library ConversionHelpers {
+    string private constant ERROR_IMPROPER_LENGTH = "CONVERSION_IMPROPER_LENGTH";
+
     function dangerouslyCastUintArrayToBytes(uint256[] memory _input) internal pure returns (bytes memory output) {
         // Force cast the uint256[] into a bytes array, by overwriting its length
         // Note that the bytes array doesn't need to be initialized as we immediately overwrite it
@@ -18,6 +20,8 @@ library ConversionHelpers {
         // Note that the uint256[] doesn't need to be initialized as we immediately overwrite it
         // with the input and a new length. The input becomes invalid from this point forward.
         uint256 intsLength = _input.length / 32;
+        require(_input.length == intsLength * 32, ERROR_IMPROPER_LENGTH);
+
         assembly {
             output := _input
             mstore(output, intsLength)


### PR DESCRIPTION
There are publicly exposed interfaces that expect `bytes` and immediately turn them into `uint256[]` (e.g. `hasPermission()` in the ACL and Kernel.

There might be some cases where the truncation could lead to Bad Things<sup>TM</sup>, like the ACL being tricked into thinking a contract had permission to do something when it actually didn't. We never use the `bytes` form of `hasPermission()` directly ourselves, so this isn't exploitable, but could be if an external contract decided to.

With help from @wadeAlexC.

Bytecode diff (`AragonApp` doesn't use `dangerouslyCastBytesToUintArray()`):

```
                           CODE DEPOSIT COST    DEPLOYED BYTES     INITIALIZATION BYTES
ACL.json                   33200 more gas       +166               0
TestACLInterpreter.json    33200 more gas       +166               0
TestConversionHelpers.json 707400 more gas      +3537              0
```