### PR TITLE
Helpers: Fix assert revert helper

### DIFF
--- a/test/helpers/assertThrow.js
+++ b/test/helpers/assertThrow.js
@@ -32,7 +32,7 @@ module.exports = {
     }
 
     if (process.env.SOLIDITY_COVERAGE !== 'true' && reason) {
-      assert.equal(reason, error.reason, `Expected revert reason "${reason}" but failed with "${error.reason || 'no reason'}" instead.`)
+      assert.equal(error.reason, reason, `Expected revert reason "${reason}" but failed with "${error.reason || 'no reason'}" instead.`)
     }
   },
 }


### PR DESCRIPTION
The `assertRevert` helper was using the `actual` and `expected` values swapped. This was causing misleading logs while testing an unsuccessful scenario.