### PR TITLE
kill-switch: provide emergency upgrade path

### DIFF
--- a/contracts/kill-switch/IKillSwitch.sol
+++ b/contracts/kill-switch/IKillSwitch.sol
@@ -4,5 +4,6 @@ import "./IIssuesRegistry.sol";
 
 
 contract IKillSwitch {
-    function shouldDenyCallingApp(bytes32 _appId, address _base, address _proxy) external view returns (bool);
+    function shouldDenyCallingApp(bytes32 _appId, address _base, address _instance) external view returns (bool);
+    function shouldDenyCallingBaseApp(bytes32 _appId, address _base) public view returns (bool);
 }

--- a/contracts/kill-switch/KillSwitch.sol
+++ b/contracts/kill-switch/KillSwitch.sol
@@ -91,17 +91,22 @@ contract KillSwitch is IKillSwitch, IsContract, AragonApp {
      *      and we have several tests to make sure its usage is working as expected.
      */
     function shouldDenyCallingApp(bytes32 _appId, address _base, address _instance) external view returns (bool) {
-        // if the instance is the kill switch itself, then allow given call
+        // If the instance is the kill switch itself, then allow given call
         if (_instance == address(this)) {
             return false;
         }
 
-        // if the instance is whitelisted, then allow given call
+        // If the instance is whitelisted, then allow given call
         if (isInstanceWhitelisted(_instance)) {
             return false;
         }
 
-        // if the base implementation is blacklisted, then deny given call
+        // Check if the base implementation is allowed
+        return shouldDenyCallingBaseApp(_appId, _base);
+    }
+
+    function shouldDenyCallingBaseApp(bytes32 _appId, address _base) public view returns (bool) {
+        // If the base implementation is blacklisted, then deny given call
         if (isBaseImplementationBlacklisted(_base)) {
             return true;
         }

--- a/contracts/test/mocks/common/KeccakConstants.sol
+++ b/contracts/test/mocks/common/KeccakConstants.sol
@@ -18,6 +18,7 @@ contract KeccakConstants {
     bytes32 public constant KERNEL_APP_ADDR_NAMESPACE = keccak256(abi.encodePacked("app"));
 
     bytes32 public constant APP_MANAGER_ROLE = keccak256(abi.encodePacked("APP_MANAGER_ROLE"));
+    bytes32 public constant APP_MANAGER_EMERGENCY_ROLE = keccak256(abi.encodePacked("APP_MANAGER_EMERGENCY_ROLE"));
 
     bytes32 public constant KERNEL_APP_ID = keccak256(abi.encodePacked(APM_NODE, keccak256("kernel")));
     bytes32 public constant DEFAULT_ACL_APP_ID = keccak256(abi.encodePacked(APM_NODE, keccak256("acl")));

--- a/contracts/test/mocks/kill-switch/EmergencyAppManagerMock.sol
+++ b/contracts/test/mocks/kill-switch/EmergencyAppManagerMock.sol
@@ -1,0 +1,38 @@
+pragma solidity 0.4.24;
+
+import "../../../kernel/Kernel.sol";
+import "../../../apps/AragonApp.sol";
+
+
+/**
+* @title EmergencyAppManagerMock
+* @dev This mock mimics a contract that is allowed to manage contract upgrades in emergency situations
+*/
+contract EmergencyAppManagerMock is AragonApp {
+    bytes32 public constant APP_MANAGER_EMERGENCY_ROLE = keccak256("APP_MANAGER_EMERGENCY_ROLE");
+
+    function initialize() external onlyInit {
+        initialized();
+    }
+
+    function setAppOnEmergency(bytes32 _namespace, bytes32 _appId, address _app) public auth(APP_MANAGER_EMERGENCY_ROLE) {
+        Kernel(kernel()).setAppOnEmergency(_namespace, _appId, _app);
+    }
+}
+
+
+/**
+* @title AppManagerMock
+* @dev This mock mimics a contract that is allowed to manage contract upgrades in non-emergency situations
+*/
+contract AppManagerMock is AragonApp {
+    bytes32 public constant APP_MANAGER_ROLE = keccak256("APP_MANAGER_ROLE");
+
+    function initialize() external onlyInit {
+        initialized();
+    }
+
+    function setApp(bytes32 _namespace, bytes32 _appId, address _app) public auth(APP_MANAGER_ROLE) {
+        kernel().setApp(_namespace, _appId, _app);
+    }
+}

--- a/contracts/test/mocks/kill-switch/RevertingKillSwitchMock.sol
+++ b/contracts/test/mocks/kill-switch/RevertingKillSwitchMock.sol
@@ -9,4 +9,8 @@ contract RevertingKillSwitchMock is KillSwitch {
     function shouldDenyCallingApp(bytes32 _appId, address _base, address _instance) external view returns (bool) {
         revert(ERROR_MESSAGE);
     }
+
+    function shouldDenyCallingBaseApp(bytes32 _appId, address _base) public view returns (bool) {
+        revert(ERROR_MESSAGE);
+    }
 }

--- a/test/contracts/common/keccak_constants.js
+++ b/test/contracts/common/keccak_constants.js
@@ -34,6 +34,7 @@ contract('Constants', () => {
 
     const kernel = await getContract('Kernel').new(false)
     assert.equal(await kernel.APP_MANAGER_ROLE(), await keccakConstants.APP_MANAGER_ROLE(), "app manager role doesn't match")
+    assert.equal(await kernel.APP_MANAGER_EMERGENCY_ROLE(), await keccakConstants.APP_MANAGER_EMERGENCY_ROLE(), "app manager emergency role doesn't match")
     assert.equal(await kernel.KERNEL_APP_ID(), await keccakConstants.KERNEL_APP_ID(), "app id doesn't match")
     assert.equal(await kernel.DEFAULT_ACL_APP_ID(), await keccakConstants.DEFAULT_ACL_APP_ID(), "default acl id doesn't match")
     assert.equal(await kernel.DEFAULT_KILL_SWITCH_APP_ID(), await keccakConstants.DEFAULT_KILL_SWITCH_APP_ID(), "default kill switch id doesn't match")

--- a/test/contracts/kill-switch/kill_switch_kernel.js
+++ b/test/contracts/kill-switch/kill_switch_kernel.js
@@ -10,6 +10,8 @@ const IssuesRegistry = artifacts.require('IssuesRegistry')
 const KillSwitchedApp = artifacts.require('KillSwitchedAppMock')
 const EVMScriptRegistryFactory = artifacts.require('EVMScriptRegistryFactory')
 
+const AppManagerMock = artifacts.require('AppManagerMock')
+const EmergencyAppManagerMock = artifacts.require('EmergencyAppManagerMock')
 const RevertingKillSwitchMock = artifacts.require('RevertingKillSwitchMock')
 const KernelWithoutKillSwitchMock = artifacts.require('KernelWithoutKillSwitchMock')
 const KernelWithNonCompliantKillSwitchMock = artifacts.require('KernelWithNonCompliantKillSwitchMock')
@@ -21,7 +23,8 @@ contract('KillSwitch Kernel', ([_, root, owner, securityPartner]) => {
   let dao, acl, app, registryFactory
   let kernelBase, aclBase, appBase, killSwitchBase, issuesRegistryBase, daoFactory
   let kernelWithoutKillSwitchBase, kernelWithNonCompliantKillSwitchBase, failingKillSwitchBase
-  let CORE_NAMESPACE, KERNEL_APP_ID, APP_MANAGER_ROLE, CHANGE_SEVERITY_ROLE, CHANGE_DEFAULT_ISSUES_REGISTRY_ROLE, CHANGE_ISSUES_REGISTRY_ROLE, CHANGE_WHITELISTED_INSTANCES_ROLE, CHANGE_BLACKLISTED_BASE_IMPLS_ROLE, CHANGE_HIGHEST_ALLOWED_SEVERITY_ROLE, WRITER_ROLE
+  let CORE_NAMESPACE, APP_ADDR_NAMESPACE, APP_BASES_NAMESPACE, KERNEL_APP_ID, APP_MANAGER_ROLE, APP_MANAGER_EMERGENCY_ROLE, WRITER_ROLE
+  let CHANGE_SEVERITY_ROLE, CHANGE_DEFAULT_ISSUES_REGISTRY_ROLE, CHANGE_ISSUES_REGISTRY_ROLE, CHANGE_WHITELISTED_INSTANCES_ROLE, CHANGE_BLACKLISTED_BASE_IMPLS_ROLE, CHANGE_HIGHEST_ALLOWED_SEVERITY_ROLE
 
   before('deploy base implementations', async () => {
     // real
@@ -39,10 +42,14 @@ contract('KillSwitch Kernel', ([_, root, owner, securityPartner]) => {
   })
 
   before('load constants and roles', async () => {
-    WRITER_ROLE = await appBase.WRITER_ROLE()
     CORE_NAMESPACE = await kernelBase.CORE_NAMESPACE()
+    APP_ADDR_NAMESPACE = await kernelBase.APP_ADDR_NAMESPACE()
+    APP_BASES_NAMESPACE = await kernelBase.APP_BASES_NAMESPACE()
     KERNEL_APP_ID = await kernelBase.KERNEL_APP_ID()
+
+    WRITER_ROLE = await appBase.WRITER_ROLE()
     APP_MANAGER_ROLE = await kernelBase.APP_MANAGER_ROLE()
+    APP_MANAGER_EMERGENCY_ROLE = await kernelBase.APP_MANAGER_EMERGENCY_ROLE()
     CHANGE_SEVERITY_ROLE = await issuesRegistryBase.CHANGE_SEVERITY_ROLE()
     CHANGE_DEFAULT_ISSUES_REGISTRY_ROLE = await killSwitchBase.CHANGE_DEFAULT_ISSUES_REGISTRY_ROLE()
     CHANGE_ISSUES_REGISTRY_ROLE = await killSwitchBase.CHANGE_ISSUES_REGISTRY_ROLE()
@@ -315,257 +322,409 @@ contract('KillSwitch Kernel', ([_, root, owner, securityPartner]) => {
 
       beforeEach('create kill switched app', async () => {
         const initializeData = appBase.contract.initialize.getData(owner)
-        const receipt = await dao.newAppInstance(SAMPLE_APP_ID, appBase.address, initializeData, false, { from: root })
+        const receipt = await dao.newAppInstance(SAMPLE_APP_ID, appBase.address, initializeData, true, { from: root })
         app = KillSwitchedApp.at(getNewProxyAddress(receipt))
         await acl.createPermission(owner, app.address, WRITER_ROLE, root, { from: root })
       })
 
-      context('when the function being called is not tagged', () => {
+      describe('isAppEnabled', () => {
+        context('when the function being called is not tagged', () => {
 
-        const itExecutesTheCallEvenWhenBaseImplementationIsBlacklisted = () => {
-          const itExecutesTheCall = () => {
-            it('executes the call', async () => {
-              assert.equal(await app.read(), 42)
+          const itExecutesTheCallEvenWhenBaseImplementationIsBlacklisted = () => {
+            const itExecutesTheCall = () => {
+              it('executes the call', async () => {
+                assert.equal(await app.read(), 42)
+              })
+            }
+
+            context('when the instance being called is whitelisted', () => {
+              beforeEach('whitelist instance', async () => {
+                await killSwitch.setWhitelistedInstance(app.address, true, { from: owner })
+              })
+
+              context('when the base implementation is not blacklisted', () => {
+                beforeEach('do not blacklist base implementation', async () => {
+                  await killSwitch.setBlacklistedBaseImplementation(appBase.address, false, { from: owner })
+                })
+
+                itExecutesTheCall()
+              })
+
+              context('when the base implementation is blacklisted', () => {
+                beforeEach('blacklist base implementation', async () => {
+                  await killSwitch.setBlacklistedBaseImplementation(appBase.address, true, { from: owner })
+                })
+
+                itExecutesTheCall()
+              })
+            })
+
+            context('when the instance being called is not marked as whitelisted', () => {
+              beforeEach('dot not whitelist instance', async () => {
+                await killSwitch.setWhitelistedInstance(app.address, false, { from: owner })
+              })
+
+              context('when the base implementation is not blacklisted', () => {
+                beforeEach('do not blacklist base implementation', async () => {
+                  await killSwitch.setBlacklistedBaseImplementation(appBase.address, false, { from: owner })
+                })
+
+                itExecutesTheCall()
+              })
+
+              context('when the base implementation is blacklisted', () => {
+                beforeEach('blacklist base implementation', async () => {
+                  await killSwitch.setBlacklistedBaseImplementation(appBase.address, true, { from: owner })
+                })
+
+                itExecutesTheCall()
+              })
             })
           }
 
-          context('when the instance being called is whitelisted', () => {
-            beforeEach('whitelist instance', async () => {
-              await killSwitch.setWhitelistedInstance(app.address, true, { from: owner })
-            })
-
-            context('when the base implementation is not blacklisted', () => {
-              beforeEach('do not blacklist base implementation', async () => {
-                await killSwitch.setBlacklistedBaseImplementation(appBase.address, false, { from: owner })
-              })
-
-              itExecutesTheCall()
-            })
-
-            context('when the base implementation is blacklisted', () => {
-              beforeEach('blacklist base implementation', async () => {
-                await killSwitch.setBlacklistedBaseImplementation(appBase.address, true, { from: owner })
-              })
-
-              itExecutesTheCall()
-            })
+          context('when there is no bug registered', () => {
+            itExecutesTheCallEvenWhenBaseImplementationIsBlacklisted()
           })
 
-          context('when the instance being called is not marked as whitelisted', () => {
-            beforeEach('dot not whitelist instance', async () => {
-              await killSwitch.setWhitelistedInstance(app.address, false, { from: owner })
+          context('when there is a bug registered', () => {
+            beforeEach('register a bug', async () => {
+              await defaultIssuesRegistry.setSeverityFor(appBase.address, SEVERITY.MID, { from: securityPartner })
             })
 
-            context('when the base implementation is not blacklisted', () => {
-              beforeEach('do not blacklist base implementation', async () => {
-                await killSwitch.setBlacklistedBaseImplementation(appBase.address, false, { from: owner })
-              })
-
-              itExecutesTheCall()
-            })
-
-            context('when the base implementation is blacklisted', () => {
-              beforeEach('blacklist base implementation', async () => {
-                await killSwitch.setBlacklistedBaseImplementation(appBase.address, true, { from: owner })
-              })
-
-              itExecutesTheCall()
-            })
+            itExecutesTheCallEvenWhenBaseImplementationIsBlacklisted()
           })
-        }
-
-        context('when there is no bug registered', () => {
-          itExecutesTheCallEvenWhenBaseImplementationIsBlacklisted()
         })
 
-        context('when there is a bug registered', () => {
-          beforeEach('register a bug', async () => {
-            await defaultIssuesRegistry.setSeverityFor(appBase.address, SEVERITY.MID, { from: securityPartner })
-          })
-
-          itExecutesTheCallEvenWhenBaseImplementationIsBlacklisted()
-        })
-      })
-
-      context('when the function being called is tagged', () => {
-        const itExecutesTheCall = () => {
-          it('executes the call', async () => {
-            await app.write(10, { from: owner })
-            assert.equal(await app.read(), 10)
-          })
-        }
-
-        const itDoesNotExecuteTheCall = () => {
-          it('does not execute the call', async () => {
-            await assertRevert(app.write(10, { from: owner }), 'APP_AUTH_FAILED')
-          })
-        }
-
-        const itExecutesTheCallOnlyWhenWhitelisted = () => {
-          context('when the instance being called is whitelisted', () => {
-            beforeEach('whitelist instance', async () => {
-              await killSwitch.setWhitelistedInstance(app.address, true, { from: owner })
+        context('when the function being called is tagged', () => {
+          const itExecutesTheCall = () => {
+            it('executes the call', async () => {
+              await app.write(10, { from: owner })
+              assert.equal(await app.read(), 10)
             })
+          }
 
-            context('when the base implementation is not blacklisted', () => {
-              beforeEach('do not blacklist base implementation', async () => {
-                await killSwitch.setBlacklistedBaseImplementation(appBase.address, false, { from: owner })
+          const itDoesNotExecuteTheCall = () => {
+            it('does not execute the call', async () => {
+              await assertRevert(app.write(10, { from: owner }), 'APP_AUTH_FAILED')
+            })
+          }
+
+          const itExecutesTheCallOnlyWhenWhitelisted = () => {
+            context('when the instance being called is whitelisted', () => {
+              beforeEach('whitelist instance', async () => {
+                await killSwitch.setWhitelistedInstance(app.address, true, { from: owner })
               })
 
-              itExecutesTheCall()
-            })
-
-            context('when the base implementation is blacklisted', () => {
-              beforeEach('blacklist base implementation', async () => {
-                await killSwitch.setBlacklistedBaseImplementation(appBase.address, true, { from: owner })
-              })
-
-              itExecutesTheCall()
-            })
-          })
-
-          context('when the instance being called is not marked as whitelisted', () => {
-            beforeEach('dot not whitelist instance', async () => {
-              await killSwitch.setWhitelistedInstance(app.address, false, { from: owner })
-            })
-
-            context('when the base implementation is not blacklisted', () => {
-              beforeEach('do not blacklist base implementation', async () => {
-                await killSwitch.setBlacklistedBaseImplementation(appBase.address, false, { from: owner })
-              })
-
-              itDoesNotExecuteTheCall()
-            })
-
-            context('when the base implementation is blacklisted', () => {
-              beforeEach('blacklist base implementation', async () => {
-                await killSwitch.setBlacklistedBaseImplementation(appBase.address, true, { from: owner })
-              })
-
-              itDoesNotExecuteTheCall()
-            })
-          })
-        }
-
-        const itExecutesTheCallUnlessInstanceNotWhitelistedAndBaseBlacklisted = () => {
-          context('when the instance being called is whitelisted', () => {
-            beforeEach('whitelist instance', async () => {
-              await killSwitch.setWhitelistedInstance(app.address, true, { from: owner })
-            })
-
-            context('when the base implementation is not blacklisted', () => {
-              beforeEach('do not blacklist base implementation', async () => {
-                await killSwitch.setBlacklistedBaseImplementation(appBase.address, false, { from: owner })
-              })
-
-              itExecutesTheCall()
-            })
-
-            context('when the base implementation is blacklisted', () => {
-              beforeEach('blacklist base implementation', async () => {
-                await killSwitch.setBlacklistedBaseImplementation(appBase.address, true, { from: owner })
-              })
-
-              itExecutesTheCall()
-            })
-          })
-
-          context('when the instance being called is not marked as whitelisted', () => {
-            beforeEach('dot not whitelist instance', async () => {
-              await killSwitch.setWhitelistedInstance(app.address, false, { from: owner })
-            })
-
-            context('when the base implementation is not blacklisted', () => {
-              beforeEach('do not blacklist base implementation', async () => {
-                await killSwitch.setBlacklistedBaseImplementation(appBase.address, false, { from: owner })
-              })
-
-              itExecutesTheCall()
-            })
-
-            context('when the base implementation is blacklisted', () => {
-              beforeEach('blacklist base implementation', async () => {
-                await killSwitch.setBlacklistedBaseImplementation(appBase.address, true, { from: owner })
-              })
-
-              itDoesNotExecuteTheCall()
-            })
-          })
-        }
-
-        context('when there is no bug registered', () => {
-          itExecutesTheCallUnlessInstanceNotWhitelistedAndBaseBlacklisted()
-        })
-
-        context('when there is a bug registered', () => {
-          beforeEach('register a bug', async () => {
-            await defaultIssuesRegistry.setSeverityFor(appBase.address, SEVERITY.MID, { from: securityPartner })
-          })
-
-          context('when the bug was real', () => {
-            context('when there is no highest allowed severity set for the contract being called', () => {
-              itExecutesTheCallOnlyWhenWhitelisted()
-            })
-
-            context('when there is a highest allowed severity set for the contract being called', () => {
-              context('when the highest allowed severity is under the reported bug severity', () => {
-                beforeEach('set highest allowed severity below the one reported', async () => {
-                  await killSwitch.setHighestAllowedSeverity(SAMPLE_APP_ID, SEVERITY.LOW, { from: owner })
+              context('when the base implementation is not blacklisted', () => {
+                beforeEach('do not blacklist base implementation', async () => {
+                  await killSwitch.setBlacklistedBaseImplementation(appBase.address, false, { from: owner })
                 })
 
+                itExecutesTheCall()
+              })
+
+              context('when the base implementation is blacklisted', () => {
+                beforeEach('blacklist base implementation', async () => {
+                  await killSwitch.setBlacklistedBaseImplementation(appBase.address, true, { from: owner })
+                })
+
+                itExecutesTheCall()
+              })
+            })
+
+            context('when the instance being called is not marked as whitelisted', () => {
+              beforeEach('dot not whitelist instance', async () => {
+                await killSwitch.setWhitelistedInstance(app.address, false, { from: owner })
+              })
+
+              context('when the base implementation is not blacklisted', () => {
+                beforeEach('do not blacklist base implementation', async () => {
+                  await killSwitch.setBlacklistedBaseImplementation(appBase.address, false, { from: owner })
+                })
+
+                itDoesNotExecuteTheCall()
+              })
+
+              context('when the base implementation is blacklisted', () => {
+                beforeEach('blacklist base implementation', async () => {
+                  await killSwitch.setBlacklistedBaseImplementation(appBase.address, true, { from: owner })
+                })
+
+                itDoesNotExecuteTheCall()
+              })
+            })
+          }
+
+          const itExecutesTheCallUnlessInstanceNotWhitelistedAndBaseBlacklisted = () => {
+            context('when the instance being called is whitelisted', () => {
+              beforeEach('whitelist instance', async () => {
+                await killSwitch.setWhitelistedInstance(app.address, true, { from: owner })
+              })
+
+              context('when the base implementation is not blacklisted', () => {
+                beforeEach('do not blacklist base implementation', async () => {
+                  await killSwitch.setBlacklistedBaseImplementation(appBase.address, false, { from: owner })
+                })
+
+                itExecutesTheCall()
+              })
+
+              context('when the base implementation is blacklisted', () => {
+                beforeEach('blacklist base implementation', async () => {
+                  await killSwitch.setBlacklistedBaseImplementation(appBase.address, true, { from: owner })
+                })
+
+                itExecutesTheCall()
+              })
+            })
+
+            context('when the instance being called is not marked as whitelisted', () => {
+              beforeEach('dot not whitelist instance', async () => {
+                await killSwitch.setWhitelistedInstance(app.address, false, { from: owner })
+              })
+
+              context('when the base implementation is not blacklisted', () => {
+                beforeEach('do not blacklist base implementation', async () => {
+                  await killSwitch.setBlacklistedBaseImplementation(appBase.address, false, { from: owner })
+                })
+
+                itExecutesTheCall()
+              })
+
+              context('when the base implementation is blacklisted', () => {
+                beforeEach('blacklist base implementation', async () => {
+                  await killSwitch.setBlacklistedBaseImplementation(appBase.address, true, { from: owner })
+                })
+
+                itDoesNotExecuteTheCall()
+              })
+            })
+          }
+
+          context('when there is no bug registered', () => {
+            itExecutesTheCallUnlessInstanceNotWhitelistedAndBaseBlacklisted()
+          })
+
+          context('when there is a bug registered', () => {
+            beforeEach('register a bug', async () => {
+              await defaultIssuesRegistry.setSeverityFor(appBase.address, SEVERITY.MID, { from: securityPartner })
+            })
+
+            context('when the bug was real', () => {
+              context('when there is no highest allowed severity set for the contract being called', () => {
                 itExecutesTheCallOnlyWhenWhitelisted()
               })
 
-              context('when the highest allowed severity is equal to the reported bug severity', () => {
-                beforeEach('set highest allowed severity equal to the one reported', async () => {
-                  await killSwitch.setHighestAllowedSeverity(SAMPLE_APP_ID, SEVERITY.MID, { from: owner })
+              context('when there is a highest allowed severity set for the contract being called', () => {
+                context('when the highest allowed severity is under the reported bug severity', () => {
+                  beforeEach('set highest allowed severity below the one reported', async () => {
+                    await killSwitch.setHighestAllowedSeverity(SAMPLE_APP_ID, SEVERITY.LOW, { from: owner })
+                  })
+
+                  itExecutesTheCallOnlyWhenWhitelisted()
                 })
 
+                context('when the highest allowed severity is equal to the reported bug severity', () => {
+                  beforeEach('set highest allowed severity equal to the one reported', async () => {
+                    await killSwitch.setHighestAllowedSeverity(SAMPLE_APP_ID, SEVERITY.MID, { from: owner })
+                  })
+
+                  itExecutesTheCallUnlessInstanceNotWhitelistedAndBaseBlacklisted()
+                })
+
+                context('when the highest allowed severity is greater than the reported bug severity', () => {
+                  beforeEach('set highest allowed severity above the one reported', async () => {
+                    await killSwitch.setHighestAllowedSeverity(SAMPLE_APP_ID, SEVERITY.CRITICAL, { from: owner })
+                  })
+
+                  itExecutesTheCallUnlessInstanceNotWhitelistedAndBaseBlacklisted()
+                })
+              })
+            })
+
+            context('when the bug was a false positive', () => {
+              beforeEach('roll back reported bug', async () => {
+                await defaultIssuesRegistry.setSeverityFor(appBase.address, SEVERITY.NONE, { from: securityPartner })
+              })
+
+              context('when there is no highest allowed severity set for the contract being called', () => {
                 itExecutesTheCallUnlessInstanceNotWhitelistedAndBaseBlacklisted()
               })
 
-              context('when the highest allowed severity is greater than the reported bug severity', () => {
-                beforeEach('set highest allowed severity above the one reported', async () => {
-                  await killSwitch.setHighestAllowedSeverity(SAMPLE_APP_ID, SEVERITY.CRITICAL, { from: owner })
+              context('when there is a highest allowed severity set for the contract being called', () => {
+                context('when the highest allowed severity is under the reported bug severity', () => {
+                  beforeEach('set highest allowed severity below the one reported', async () => {
+                    await killSwitch.setHighestAllowedSeverity(SAMPLE_APP_ID, SEVERITY.LOW, { from: owner })
+                  })
+
+                  itExecutesTheCallUnlessInstanceNotWhitelistedAndBaseBlacklisted()
                 })
 
-                itExecutesTheCallUnlessInstanceNotWhitelistedAndBaseBlacklisted()
+                context('when the highest allowed severity is equal to the reported bug severity', () => {
+                  beforeEach('set highest allowed severity equal to the one reported', async () => {
+                    await killSwitch.setHighestAllowedSeverity(SAMPLE_APP_ID, SEVERITY.MID, { from: owner })
+                  })
+
+                  itExecutesTheCallUnlessInstanceNotWhitelistedAndBaseBlacklisted()
+                })
+
+                context('when the highest allowed severity is greater than the reported bug severity', () => {
+                  beforeEach('set highest allowed severity above the one reported', async () => {
+                    await killSwitch.setHighestAllowedSeverity(SAMPLE_APP_ID, SEVERITY.CRITICAL, { from: owner })
+                  })
+
+                  itExecutesTheCallUnlessInstanceNotWhitelistedAndBaseBlacklisted()
+                })
+              })
+            })
+          })
+        })
+      })
+
+      describe('setAppOnEmergency', () => {
+        const MANAGER_APP_ID = '0x22222'
+        const EMERGENCY_MANAGER_APP_ID = '0x33333'
+
+        let appBaseV2, managerAppBaseV1, managerAppBaseV2, emergencyManagerAppBase, managerApp, emergencyManagerApp
+
+        before('deploy base implementations', async () => {
+          appBaseV2 = await KillSwitchedApp.new()
+          managerAppBaseV1 = await AppManagerMock.new()
+          managerAppBaseV2 = await AppManagerMock.new()
+          emergencyManagerAppBase = await EmergencyAppManagerMock.new()
+        })
+
+        beforeEach('create emergency manager app', async () => {
+          // create emergency manager app
+          const emergencyManagerReceipt = await dao.newAppInstance(EMERGENCY_MANAGER_APP_ID, emergencyManagerAppBase.address, '0x', true, {from: root})
+          emergencyManagerApp = EmergencyAppManagerMock.at(getNewProxyAddress(emergencyManagerReceipt))
+          await emergencyManagerApp.initialize()
+
+          // grant APP_MANAGER_EMERGENCY_ROLE permission
+          await acl.createPermission(emergencyManagerApp.address, dao.address, APP_MANAGER_EMERGENCY_ROLE, root, { from: root })
+          await acl.createPermission(root, emergencyManagerApp.address, APP_MANAGER_EMERGENCY_ROLE, root, { from: root })
+        })
+
+        beforeEach('create manager app', async () => {
+          // create manager app instance and whitelist it in the kill-switch
+          const managerReceipt = await dao.newAppInstance(MANAGER_APP_ID, managerAppBaseV1.address, '0x', true, { from: root })
+          managerApp = AppManagerMock.at(getNewProxyAddress(managerReceipt))
+          await managerApp.initialize()
+
+          // set manager app as the APP_MANAGER_ROLE permissions manager
+          await acl.createPermission(root, managerApp.address, APP_MANAGER_ROLE, root, { from: root })
+          await acl.grantPermission(managerApp.address, dao.address, APP_MANAGER_ROLE, { from: root })
+          await acl.revokePermission(root, dao.address, APP_MANAGER_ROLE, { from: root })
+          await acl.setPermissionManager(managerApp.address, dao.address, APP_MANAGER_ROLE, { from: root })
+        })
+
+        it('has a manager app installed with root authority permissions', async () => {
+          assert.equal(await dao.getApp(APP_ADDR_NAMESPACE, MANAGER_APP_ID), managerApp.address, 'manager app instance does not match')
+          assert.isTrue(await acl.hasPermission(managerApp.address, dao.address, APP_MANAGER_ROLE), 'manager app should have APP_MANAGER_ROLE permissions')
+          assert.equal(await acl.getPermissionManager(dao.address, APP_MANAGER_ROLE), managerApp.address, 'manager app should be the APP_MANAGER_ROLE permissions manager of the DAO')
+        })
+
+        it('has a emergency manager app installed with emergency permissions', async () => {
+          assert.equal(await dao.getApp(APP_ADDR_NAMESPACE, EMERGENCY_MANAGER_APP_ID), emergencyManagerApp.address, 'emergency manager app instance does not match')
+          assert.isTrue(await acl.hasPermission(emergencyManagerApp.address, dao.address, APP_MANAGER_EMERGENCY_ROLE), 'emergency manager app should have APP_MANAGER_EMERGENCY_ROLE permissions')
+        })
+
+        context('with a non kill-switched contract', () => {
+          context('when trying to update it through the manager app', () => {
+            it('can be updated', async () => {
+              assert.equal(await dao.getApp(APP_BASES_NAMESPACE, SAMPLE_APP_ID), appBase.address, 'sample app should be V1')
+              assert.isFalse(await killSwitch.shouldDenyCallingApp(SAMPLE_APP_ID, appBase.address, app.address), 'sample app should not be kill-switched')
+              await app.write(10, { from: owner })
+              assert.equal(await app.read(), 10)
+
+              await managerApp.setApp(APP_BASES_NAMESPACE, SAMPLE_APP_ID, appBaseV2.address, { from: root })
+
+              assert.equal(await dao.getApp(APP_BASES_NAMESPACE, SAMPLE_APP_ID), appBaseV2.address, 'sample app should be V2')
+              assert.isFalse(await killSwitch.shouldDenyCallingApp(SAMPLE_APP_ID, appBaseV2.address, app.address), 'sample app should not be kill-switched')
+              await app.write(12, { from: owner })
+              assert.equal(await app.read(), 12)
+            })
+          })
+
+          context('when trying to update it through the emergency manager app', () => {
+            it('reverts', async () => {
+              await assertRevert(emergencyManagerApp.setAppOnEmergency(APP_BASES_NAMESPACE, SAMPLE_APP_ID, appBaseV2.address, { from: root }), 'KERNEL_BAD_EMERGENCY_UPDATE')
+            })
+          })
+        })
+
+        context('with a kill-switched base app', () => {
+          beforeEach('kill switch base app', async () => {
+            assert.isFalse(await killSwitch.shouldDenyCallingApp(SAMPLE_APP_ID, appBase.address, app.address), 'sample app should not be kill-switched')
+            await app.write(10, { from: owner })
+            assert.equal(await app.read(), 10)
+
+            await killSwitch.setBlacklistedBaseImplementation(appBase.address, true, { from: owner })
+            assert.isTrue(await killSwitch.shouldDenyCallingApp(SAMPLE_APP_ID, appBase.address, app.address), 'sample app should be kill-switched')
+            await assertRevert(app.write(12, { from: owner }), 'APP_AUTH_FAILED')
+          })
+
+          context('when the manager app is not kill switched', () => {
+            context('when trying to update it through the manager app', () => {
+              it('can be updated', async () => {
+                await managerApp.setApp(APP_BASES_NAMESPACE, SAMPLE_APP_ID, appBaseV2.address, { from: root })
+                assert.equal(await dao.getApp(APP_BASES_NAMESPACE, SAMPLE_APP_ID), appBaseV2.address, 'sample app should have been updated')
+                assert.isFalse(await killSwitch.shouldDenyCallingApp(SAMPLE_APP_ID, appBaseV2.address, app.address), 'new sample app should not be kill-switched')
+
+                assert.equal(await app.read(), 10)
+                await app.write(12, { from: owner })
+                assert.equal(await app.read(), 12)
+              })
+            })
+
+            context('when trying to update it through the emergency manager app', () => {
+              it('can be updated', async () => {
+                await emergencyManagerApp.setAppOnEmergency(APP_BASES_NAMESPACE, SAMPLE_APP_ID, appBaseV2.address, { from: root })
+                assert.equal(await dao.getApp(APP_BASES_NAMESPACE, SAMPLE_APP_ID), appBaseV2.address, 'sample app should have been updated')
+                assert.isFalse(await killSwitch.shouldDenyCallingApp(SAMPLE_APP_ID, appBaseV2.address, app.address), 'new sample app should not be kill-switched')
+
+                assert.equal(await app.read(), 10)
+                await app.write(12, { from: owner })
+                assert.equal(await app.read(), 12)
               })
             })
           })
 
-          context('when the bug was a false positive', () => {
-            beforeEach('roll back reported bug', async () => {
-              await defaultIssuesRegistry.setSeverityFor(appBase.address, SEVERITY.NONE, { from: securityPartner })
+          context('when the manager app is kill switched', () => {
+            beforeEach('kill switch manager app', async () => {
+              await killSwitch.setBlacklistedBaseImplementation(managerAppBaseV1.address, true, { from: owner })
+              assert.isTrue(await killSwitch.shouldDenyCallingApp(MANAGER_APP_ID, managerAppBaseV1.address, managerApp.address), 'manager app should be kill-switched')
             })
 
-            context('when there is no highest allowed severity set for the contract being called', () => {
-              itExecutesTheCallUnlessInstanceNotWhitelistedAndBaseBlacklisted()
+            context('when trying to update it through the manager app', () => {
+              it('reverts', async () => {
+                await assertRevert(managerApp.setApp(APP_BASES_NAMESPACE, SAMPLE_APP_ID, appBaseV2.address, { from: root }), 'APP_AUTH_FAILED')
+              })
             })
 
-            context('when there is a highest allowed severity set for the contract being called', () => {
-              context('when the highest allowed severity is under the reported bug severity', () => {
-                beforeEach('set highest allowed severity below the one reported', async () => {
-                  await killSwitch.setHighestAllowedSeverity(SAMPLE_APP_ID, SEVERITY.LOW, { from: owner })
-                })
+            context('when trying to update it through the emergency manager app', () => {
+              it('can be updated directly', async () => {
+                await emergencyManagerApp.setAppOnEmergency(APP_BASES_NAMESPACE, SAMPLE_APP_ID, appBaseV2.address, { from: root })
+                assert.equal(await dao.getApp(APP_BASES_NAMESPACE, SAMPLE_APP_ID), appBaseV2.address, 'sample app should have been updated')
+                assert.isFalse(await killSwitch.shouldDenyCallingApp(SAMPLE_APP_ID, appBaseV2.address, app.address), 'new sample app should not be kill-switched')
 
-                itExecutesTheCallUnlessInstanceNotWhitelistedAndBaseBlacklisted()
+                assert.equal(await app.read(), 10)
+                await app.write(12, { from: owner })
+                assert.equal(await app.read(), 12)
               })
 
-              context('when the highest allowed severity is equal to the reported bug severity', () => {
-                beforeEach('set highest allowed severity equal to the one reported', async () => {
-                  await killSwitch.setHighestAllowedSeverity(SAMPLE_APP_ID, SEVERITY.MID, { from: owner })
-                })
+              it('can be updated passing through the manager app first', async () => {
+                await emergencyManagerApp.setAppOnEmergency(APP_BASES_NAMESPACE, MANAGER_APP_ID, managerAppBaseV2.address, { from: root })
+                assert.equal(await dao.getApp(APP_BASES_NAMESPACE, MANAGER_APP_ID), managerAppBaseV2.address, 'manager app should have been updated')
+                assert.isFalse(await killSwitch.shouldDenyCallingApp(MANAGER_APP_ID, managerAppBaseV2.address, managerApp.address), 'new manager app should not be kill-switched')
 
-                itExecutesTheCallUnlessInstanceNotWhitelistedAndBaseBlacklisted()
-              })
+                await managerApp.setApp(APP_BASES_NAMESPACE, SAMPLE_APP_ID, appBaseV2.address, { from: root })
+                assert.equal(await dao.getApp(APP_BASES_NAMESPACE, SAMPLE_APP_ID), appBaseV2.address, 'sample app should have been updated')
+                assert.isFalse(await killSwitch.shouldDenyCallingApp(SAMPLE_APP_ID, appBaseV2.address, app.address), 'new sample app should not be kill-switched')
 
-              context('when the highest allowed severity is greater than the reported bug severity', () => {
-                beforeEach('set highest allowed severity above the one reported', async () => {
-                  await killSwitch.setHighestAllowedSeverity(SAMPLE_APP_ID, SEVERITY.CRITICAL, { from: owner })
-                })
-
-                itExecutesTheCallUnlessInstanceNotWhitelistedAndBaseBlacklisted()
+                assert.equal(await app.read(), 10)
+                await app.write(12, { from: owner })
+                assert.equal(await app.read(), 12)
               })
             })
           })


### PR DESCRIPTION
Fixes #523 
Follow up #518 

This PR provides an entry point in the Kernel that a new way to access the `setApp` functionality, but only when the app address that is requested to be updated is disallowed in the kill-switch instance of a DAO. It also implements a new role called `APP_MANAGER_EMERGENCY_ROLE` , obviously different than the `APP_MANAGER_ROLE`, since it is supposed to be used from a separate flow. For example, if the `APP_MANAGER_ROLE` app has been kill-switched, then the `APP_MANAGER_EMERGENCY_ROLE` app is allowed to perform an upgrade of the `APP_MANAGER_ROLE` app.

We could use this new entry point from the voting app to provide all the DAOs a way to bypass the root of authority chain in case any of its components gets kill-switched. Ofc, as explained in the issue linked, there is a list of minimum components we will need whitelist to make that happen (Kernel, ACL, Kill switch, Voting app, ...). But note that with this entry point we can now make sure we don't need the full chain whitelisted.