### PR TITLE
Libs: Provide address utils library

### DIFF
--- a/contracts/acl/ACL.sol
+++ b/contracts/acl/ACL.sol
@@ -1,16 +1,19 @@
 pragma solidity 0.4.24;
 
-import "../apps/AragonApp.sol";
-import "../common/ConversionHelpers.sol";
-import "../common/TimeHelpers.sol";
-import "./ACLSyntaxSugar.sol";
 import "./IACL.sol";
 import "./IACLOracle.sol";
+import "./ACLSyntaxSugar.sol";
+import "../apps/AragonApp.sol";
+import "../common/TimeHelpers.sol";
+import "../common/AddressUtils.sol";
+import "../common/ConversionHelpers.sol";
 
 
 /* solium-disable function-order */
 // Allow public initialize() to be first
 contract ACL is IACL, TimeHelpers, AragonApp, ACLHelpers {
+    using AddressUtils for address;
+
     /* Hardcoded constants to save gas
     bytes32 public constant CREATE_PERMISSIONS_ROLE = keccak256("CREATE_PERMISSIONS_ROLE");
     */
@@ -66,7 +69,7 @@ contract ACL is IACL, TimeHelpers, AragonApp, ACLHelpers {
 
     modifier noPermissionManager(address _app, bytes32 _role) {
         // only allow permission creation (or re-creation) when there is no manager
-        require(getPermissionManager(_app, _role) == address(0), ERROR_EXISTENT_MANAGER);
+        require(getPermissionManager(_app, _role).isZero(), ERROR_EXISTENT_MANAGER);
         _;
     }
 

--- a/contracts/apm/Repo.sol
+++ b/contracts/apm/Repo.sol
@@ -1,11 +1,14 @@
 pragma solidity 0.4.24;
 
 import "../apps/AragonApp.sol";
+import "../common/AddressUtils.sol";
 
 
 /* solium-disable function-order */
 // Allow public initialize() to be first
 contract Repo is AragonApp {
+    using AddressUtils for address;
+
     /* Hardcoded constants to save gas
     bytes32 public constant CREATE_VERSION_ROLE = keccak256("CREATE_VERSION_ROLE");
     */
@@ -43,12 +46,7 @@ contract Repo is AragonApp {
     * @param _contractAddress address for smart contract logic for version (if set to 0, it uses last versions' contractAddress)
     * @param _contentURI External URI for fetching new version's content
     */
-    function newVersion(
-        uint16[3] _newSemanticVersion,
-        address _contractAddress,
-        bytes _contentURI
-    ) public auth(CREATE_VERSION_ROLE)
-    {
+    function newVersion(uint16[3] _newSemanticVersion, address _contractAddress, bytes _contentURI) public auth(CREATE_VERSION_ROLE) {
         address contractAddress = _contractAddress;
         uint256 lastVersionIndex = versionsNextIndex - 1;
 
@@ -58,7 +56,7 @@ contract Repo is AragonApp {
             Version storage lastVersion = versions[lastVersionIndex];
             lastSematicVersion = lastVersion.semanticVersion;
 
-            if (contractAddress == address(0)) {
+            if (contractAddress.isZero()) {
                 contractAddress = lastVersion.contractAddress;
             }
             // Only allows smart contract change on major version bumps

--- a/contracts/apps/AppProxyBase.sol
+++ b/contracts/apps/AppProxyBase.sol
@@ -1,12 +1,15 @@
 pragma solidity 0.4.24;
 
 import "./AppStorage.sol";
-import "../common/DepositableDelegateProxy.sol";
-import "../kernel/KernelConstants.sol";
 import "../kernel/IKernel.sol";
+import "../kernel/KernelConstants.sol";
+import "../common/AddressUtils.sol";
+import "../common/DepositableDelegateProxy.sol";
 
 
 contract AppProxyBase is AppStorage, DepositableDelegateProxy, KernelNamespaceConstants {
+    using AddressUtils for address;
+
     /**
     * @dev Initialize AppProxy
     * @param _kernel Reference to organization kernel for the app
@@ -25,7 +28,7 @@ contract AppProxyBase is AppStorage, DepositableDelegateProxy, KernelNamespaceCo
 
         // If initialize payload is provided, it will be executed
         if (_initializePayload.length > 0) {
-            require(isContract(appCode));
+            require(appCode.isContract());
             // Cannot make delegatecall as a delegateproxy.delegatedFwd as it
             // returns ending execution context and halts contract deployment
             require(appCode.delegatecall(_initializePayload));

--- a/contracts/apps/AppProxyPinned.sol
+++ b/contracts/apps/AppProxyPinned.sol
@@ -1,11 +1,12 @@
 pragma solidity 0.4.24;
 
 import "../common/UnstructuredStorage.sol";
-import "../common/IsContract.sol";
+import "../common/AddressUtils.sol";
 import "./AppProxyBase.sol";
 
 
-contract AppProxyPinned is IsContract, AppProxyBase {
+contract AppProxyPinned is AppProxyBase {
+    using AddressUtils for address;
     using UnstructuredStorage for bytes32;
 
     // keccak256("aragonOS.appStorage.pinnedCode")
@@ -22,7 +23,7 @@ contract AppProxyPinned is IsContract, AppProxyBase {
         public // solium-disable-line visibility-first
     {
         setPinnedCode(getAppBase(_appId));
-        require(isContract(pinnedCode()));
+        require(pinnedCode().isContract());
     }
 
     /**

--- a/contracts/apps/AragonApp.sol
+++ b/contracts/apps/AragonApp.sol
@@ -6,6 +6,7 @@ pragma solidity ^0.4.24;
 
 import "./AppStorage.sol";
 import "../acl/ACLSyntaxSugar.sol";
+import "../common/AddressUtils.sol";
 import "../common/Autopetrified.sol";
 import "../common/ConversionHelpers.sol";
 import "../common/ReentrancyGuard.sol";
@@ -19,6 +20,8 @@ import "../evmscript/EVMScriptRunner.sol";
 // ReentrancyGuard, EVMScriptRunner, and ACLSyntaxSugar are not directly used by this contract, but
 // are included so that they are automatically usable by subclassing contracts
 contract AragonApp is AppStorage, Autopetrified, VaultRecoverable, ReentrancyGuard, EVMScriptRunner, ACLSyntaxSugar {
+    using AddressUtils for address;
+
     string private constant ERROR_AUTH_FAILED = "APP_AUTH_FAILED";
 
     modifier auth(bytes32 _role) {
@@ -45,7 +48,7 @@ contract AragonApp is AppStorage, Autopetrified, VaultRecoverable, ReentrancyGua
         }
 
         IKernel linkedKernel = kernel();
-        if (address(linkedKernel) == address(0)) {
+        if (address(linkedKernel).isZero()) {
             return false;
         }
 

--- a/contracts/common/AddressUtils.sol
+++ b/contracts/common/AddressUtils.sol
@@ -5,7 +5,17 @@
 pragma solidity ^0.4.24;
 
 
-contract IsContract {
+library AddressUtils {
+    address internal constant ZERO_ADDRESS = address(0);
+
+    function isZero(address _target) internal pure returns (bool) {
+        return _target == ZERO_ADDRESS;
+    }
+
+    function isNotZero(address _target) internal pure returns (bool) {
+        return _target != ZERO_ADDRESS;
+    }
+
     /*
     * NOTE: this should NEVER be used for authentication
     * (see pitfalls: https://github.com/fergarrui/ethereum-security/tree/master/contracts/extcodesize).
@@ -14,7 +24,7 @@ contract IsContract {
     * RATHER THAN an address not being a contract.
     */
     function isContract(address _target) internal view returns (bool) {
-        if (_target == address(0)) {
+        if (isZero(_target)) {
             return false;
         }
 

--- a/contracts/common/DelegateProxy.sol
+++ b/contracts/common/DelegateProxy.sol
@@ -1,10 +1,12 @@
 pragma solidity 0.4.24;
 
-import "../common/IsContract.sol";
+import "../common/AddressUtils.sol";
 import "../lib/misc/ERCProxy.sol";
 
 
-contract DelegateProxy is ERCProxy, IsContract {
+contract DelegateProxy is ERCProxy {
+    using AddressUtils for address;
+
     uint256 internal constant FWD_GAS_LIMIT = 10000;
 
     /**
@@ -13,7 +15,7 @@ contract DelegateProxy is ERCProxy, IsContract {
     * @param _calldata Calldata for the delegatecall
     */
     function delegatedFwd(address _dst, bytes _calldata) internal {
-        require(isContract(_dst));
+        require(_dst.isContract());
         uint256 fwdGasLimit = FWD_GAS_LIMIT;
 
         assembly {

--- a/contracts/common/VaultRecoverable.sol
+++ b/contracts/common/VaultRecoverable.sol
@@ -6,13 +6,14 @@ pragma solidity ^0.4.24;
 
 import "../lib/token/ERC20.sol";
 import "./EtherTokenConstant.sol";
-import "./IsContract.sol";
+import "./AddressUtils.sol";
 import "./IVaultRecoverable.sol";
 import "./SafeERC20.sol";
 
 
-contract VaultRecoverable is IVaultRecoverable, EtherTokenConstant, IsContract {
+contract VaultRecoverable is IVaultRecoverable, EtherTokenConstant {
     using SafeERC20 for ERC20;
+    using AddressUtils for address;
 
     string private constant ERROR_DISALLOWED = "RECOVER_DISALLOWED";
     string private constant ERROR_VAULT_NOT_CONTRACT = "RECOVER_VAULT_NOT_CONTRACT";
@@ -26,7 +27,7 @@ contract VaultRecoverable is IVaultRecoverable, EtherTokenConstant, IsContract {
     function transferToVault(address _token) external {
         require(allowRecoverability(_token), ERROR_DISALLOWED);
         address vault = getRecoveryVault();
-        require(isContract(vault), ERROR_VAULT_NOT_CONTRACT);
+        require(vault.isContract(), ERROR_VAULT_NOT_CONTRACT);
 
         uint256 balance;
         if (_token == ETH) {

--- a/contracts/evmscript/EVMScriptRunner.sol
+++ b/contracts/evmscript/EVMScriptRunner.sol
@@ -9,10 +9,13 @@ import "./IEVMScriptRegistry.sol";
 
 import "../apps/AppStorage.sol";
 import "../kernel/KernelConstants.sol";
+import "../common/AddressUtils.sol";
 import "../common/Initializable.sol";
 
 
 contract EVMScriptRunner is AppStorage, Initializable, EVMScriptRegistryConstants, KernelNamespaceConstants {
+    using AddressUtils for address;
+
     string private constant ERROR_EXECUTOR_UNAVAILABLE = "EVMRUN_EXECUTOR_UNAVAILABLE";
     string private constant ERROR_PROTECTED_STATE_MODIFIED = "EVMRUN_PROTECTED_STATE_MODIFIED";
 
@@ -38,7 +41,7 @@ contract EVMScriptRunner is AppStorage, Initializable, EVMScriptRegistryConstant
         returns (bytes)
     {
         IEVMScriptExecutor executor = getEVMScriptExecutor(_script);
-        require(address(executor) != address(0), ERROR_EXECUTOR_UNAVAILABLE);
+        require(address(executor).isNotZero(), ERROR_EXECUTOR_UNAVAILABLE);
 
         bytes4 sig = executor.execScript.selector;
         bytes memory data = abi.encodeWithSelector(sig, _script, _input, _blacklist);

--- a/contracts/factory/APMRegistryFactory.sol
+++ b/contracts/factory/APMRegistryFactory.sol
@@ -4,6 +4,7 @@ pragma solidity 0.4.24;
 import "../apm/APMRegistry.sol";
 import "../apm/Repo.sol";
 import "../ens/ENSSubdomainRegistrar.sol";
+import "../common/AddressUtils.sol";
 
 import "./DAOFactory.sol";
 import "./ENSFactory.sol";
@@ -11,6 +12,8 @@ import "./AppProxyFactory.sol";
 
 
 contract APMRegistryFactory is APMInternalAppNames {
+    using AddressUtils for address;
+
     DAOFactory public daoFactory;
     APMRegistry public registryBase;
     Repo public repoBase;
@@ -46,7 +49,7 @@ contract APMRegistryFactory is APMInternalAppNames {
         // Either the ENS address provided is used, if any.
         // Or we use the ENSFactory to generate a test instance of ENS
         // If not the ENS address nor factory address are provided, this will revert
-        ens = _ens != address(0) ? _ens : _ensFactory.newENS(this);
+        ens = address(_ens).isNotZero() ? _ens : _ensFactory.newENS(this);
     }
 
     /**

--- a/contracts/factory/DAOFactory.sol
+++ b/contracts/factory/DAOFactory.sol
@@ -3,6 +3,7 @@ pragma solidity 0.4.24;
 import "../kernel/IKernel.sol";
 import "../kernel/Kernel.sol";
 import "../kernel/KernelProxy.sol";
+import "../common/AddressUtils.sol";
 
 import "../acl/IACL.sol";
 import "../acl/ACL.sol";
@@ -11,6 +12,8 @@ import "./EVMScriptRegistryFactory.sol";
 
 
 contract DAOFactory {
+    using AddressUtils for address;
+
     IKernel public baseKernel;
     IACL public baseACL;
     EVMScriptRegistryFactory public regFactory;
@@ -26,7 +29,7 @@ contract DAOFactory {
     */
     constructor(IKernel _baseKernel, IACL _baseACL, EVMScriptRegistryFactory _regFactory) public {
         // No need to init as it cannot be killed by devops199
-        if (address(_regFactory) != address(0)) {
+        if (address(_regFactory).isNotZero()) {
             regFactory = _regFactory;
         }
 
@@ -42,7 +45,7 @@ contract DAOFactory {
     function newDAO(address _root) public returns (Kernel) {
         Kernel dao = Kernel(new KernelProxy(baseKernel));
 
-        if (address(regFactory) == address(0)) {
+        if (address(regFactory).isZero()) {
             dao.initialize(baseACL, _root);
         } else {
             dao.initialize(baseACL, this);

--- a/contracts/kernel/KernelProxy.sol
+++ b/contracts/kernel/KernelProxy.sol
@@ -1,20 +1,22 @@
 pragma solidity 0.4.24;
 
 import "./IKernel.sol";
-import "./KernelConstants.sol";
 import "./KernelStorage.sol";
+import "./KernelConstants.sol";
+import "../common/AddressUtils.sol";
 import "../common/DepositableDelegateProxy.sol";
-import "../common/IsContract.sol";
 
 
-contract KernelProxy is IKernelEvents, KernelStorage, KernelAppIds, KernelNamespaceConstants, IsContract, DepositableDelegateProxy {
+contract KernelProxy is IKernelEvents, KernelStorage, KernelAppIds, KernelNamespaceConstants, DepositableDelegateProxy {
+    using AddressUtils for address;
+
     /**
     * @dev KernelProxy is a proxy contract to a kernel implementation. The implementation
     *      can update the reference, which effectively upgrades the contract
     * @param _kernelImpl Address of the contract used as implementation for kernel
     */
     constructor(IKernel _kernelImpl) public {
-        require(isContract(address(_kernelImpl)));
+        require(address(_kernelImpl).isContract());
         apps[KERNEL_CORE_NAMESPACE][KERNEL_CORE_APP_ID] = _kernelImpl;
 
         // Note that emitting this event is important for verifying that a KernelProxy instance

--- a/contracts/test/mocks/apps/AppStubConditionalRecovery.sol
+++ b/contracts/test/mocks/apps/AppStubConditionalRecovery.sol
@@ -12,6 +12,6 @@ contract AppStubConditionalRecovery is AragonApp, DepositableStorage {
 
     function allowRecoverability(address token) public view returns (bool) {
         // Doesn't allow to recover ether
-        return token != address(0);
+        return token.isNotZero();
     }
 }

--- a/contracts/test/mocks/common/ReentrancyGuardMock.sol
+++ b/contracts/test/mocks/common/ReentrancyGuardMock.sol
@@ -1,5 +1,6 @@
 pragma solidity 0.4.24;
 
+import "../../../common/AddressUtils.sol";
 import "../../../common/ReentrancyGuard.sol";
 import "../../../common/UnstructuredStorage.sol";
 
@@ -25,20 +26,21 @@ contract ReentrantActor {
 
 
 contract ReentrancyGuardMock is ReentrancyGuard {
+    using AddressUtils for address;
     using UnstructuredStorage for bytes32;
 
     uint256 public callCounter;
 
     function nonReentrantCall(ReentrantActor _target) public nonReentrant {
         callCounter++;
-        if (_target != address(0)) {
+        if (address(_target).isNotZero()) {
             _target.reenter(this);
         }
     }
 
     function reentrantCall(ReentrantActor _target) public {
         callCounter++;
-        if (_target != address(0)) {
+        if (address(_target).isNotZero()) {
             _target.reenter(this);
         }
     }

--- a/contracts/test/mocks/lib/token/TokenMock.sol
+++ b/contracts/test/mocks/lib/token/TokenMock.sol
@@ -3,10 +3,13 @@
 pragma solidity 0.4.24;
 
 import "../../../../lib/math/SafeMath.sol";
+import "../../../../common/AddressUtils.sol";
 
 
 contract TokenMock {
     using SafeMath for uint256;
+    using AddressUtils for address;
+
     mapping (address => uint256) private balances;
     mapping (address => mapping (address => uint256)) private allowed;
     uint256 private totalSupply_;
@@ -59,7 +62,7 @@ contract TokenMock {
     function transfer(address _to, uint256 _value) public returns (bool) {
         require(allowTransfer_);
         require(_value <= balances[msg.sender]);
-        require(_to != address(0));
+        require(_to.isNotZero());
 
         balances[msg.sender] = balances[msg.sender].sub(_value);
         balances[_to] = balances[_to].add(_value);
@@ -95,7 +98,7 @@ contract TokenMock {
         require(allowTransfer_);
         require(_value <= balances[_from]);
         require(_value <= allowed[_from][msg.sender]);
-        require(_to != address(0));
+        require(_to.isNotZero());
 
         balances[_from] = balances[_from].sub(_value);
         balances[_to] = balances[_to].add(_value);

--- a/contracts/test/mocks/lib/token/TokenReturnFalseMock.sol
+++ b/contracts/test/mocks/lib/token/TokenReturnFalseMock.sol
@@ -4,8 +4,12 @@
 
 pragma solidity 0.4.24;
 
+import "../../../../common/AddressUtils.sol";
+
 
 contract TokenReturnFalseMock {
+    using AddressUtils for address;
+
     mapping (address => uint256) private balances;
     mapping (address => mapping (address => uint256)) private allowed;
     uint256 private totalSupply_;
@@ -56,7 +60,7 @@ contract TokenReturnFalseMock {
     * @param _value The amount to be transferred.
     */
     function transfer(address _to, uint256 _value) public returns (bool) {
-        if (!allowTransfer_ || _to == address(0) || _value > balances[msg.sender]) {
+        if (!allowTransfer_ || _to.isZero() || _value > balances[msg.sender]) {
             return false;
         }
 
@@ -94,7 +98,7 @@ contract TokenReturnFalseMock {
     */
     function transferFrom(address _from, address _to, uint256 _value) public returns (bool) {
         if (!allowTransfer_ ||
-            _to == address(0) ||
+            _to.isZero() ||
             _value > balances[_from] ||
             _value > allowed[_from][msg.sender]
         ) {

--- a/contracts/test/mocks/lib/token/TokenReturnMissingMock.sol
+++ b/contracts/test/mocks/lib/token/TokenReturnMissingMock.sol
@@ -5,10 +5,13 @@
 pragma solidity 0.4.24;
 
 import "../../../../lib/math/SafeMath.sol";
+import "../../../../common/AddressUtils.sol";
 
 
 contract TokenReturnMissingMock {
     using SafeMath for uint256;
+    using AddressUtils for address;
+
     mapping (address => uint256) private balances;
     mapping (address => mapping (address => uint256)) private allowed;
     uint256 private totalSupply_;
@@ -61,7 +64,7 @@ contract TokenReturnMissingMock {
     function transfer(address _to, uint256 _value) public {
         require(allowTransfer_);
         require(_value <= balances[msg.sender]);
-        require(_to != address(0));
+        require(_to.isNotZero());
 
         balances[msg.sender] = balances[msg.sender].sub(_value);
         balances[_to] = balances[_to].add(_value);
@@ -95,7 +98,7 @@ contract TokenReturnMissingMock {
         require(allowTransfer_);
         require(_value <= balances[_from]);
         require(_value <= allowed[_from][msg.sender]);
-        require(_to != address(0));
+        require(_to.isNotZero());
 
         balances[_from] = balances[_from].sub(_value);
         balances[_to] = balances[_to].add(_value);

--- a/contracts/test/tests/TestDelegateProxy.sol
+++ b/contracts/test/tests/TestDelegateProxy.sol
@@ -3,6 +3,7 @@ pragma solidity 0.4.24;
 import "../helpers/Assert.sol";
 import "../helpers/ThrowProxy.sol";
 
+import "../../common/AddressUtils.sol";
 import "../../common/DelegateProxy.sol";
 import "../../evmscript/ScriptHelpers.sol";
 
@@ -16,6 +17,7 @@ contract Target {
 
 contract TestDelegateProxy is DelegateProxy {
     using ScriptHelpers for *;
+    using AddressUtils for address;
 
     Target target;
     ThrowProxy throwProxy;
@@ -57,13 +59,13 @@ contract TestDelegateProxy is DelegateProxy {
     }
 
     function testIsContractZero() public {
-        bool result = isContract(address(0));
+        bool result = address(0).isContract();
         Assert.isFalse(result, "should return false");
     }
 
     function testIsContractAddress() public {
         address nonContract = 0x1234;
-        bool result = isContract(nonContract);
+        bool result = nonContract.isContract();
         Assert.isFalse(result, "should return false");
     }
 


### PR DESCRIPTION
This PR proposes turning the `IsContract` contract into a Solidity library per se. 

The motivation for this change is underlaid by the idea of discouraging inheritance as a way to reuse helpers. Solidity basically provides two ways of reusing code besides composition, one of those is inheritance and the other is through libraries. Inheritance means a strong relation and in a multiple-inheritance universe it affects the linearization graph. Personally, I think it's better to use libraries if we are simply willing to reuse a helper functionality. For example, IMO, this is why we use `SafeMath` as library and not as an inheritable contract.

Additionally, I examined how much does a contract's bytecode increase applying this change vs as they are now. To do this I crafted a sample contract extending from Kernel (which is already using the `isContract` helper) and reusing said library in the sub contract as well. Using the library in the Kernel contract increases it's deployed bytecode length in 191 bytes, and it increases the deployed bytecode length of the sub Kernel sample in 200 bytes, which means it is not duplicating the whole library in the inherited contract. 

I know we may have different opinions on this topic, but I think we should encourage a single way of doing things, in this case, sharing helper functionalities between contracts.