### PR TITLE
DepositableDelegateProxy: optimize for EIP-1884

### DIFF
--- a/contracts/common/DepositableDelegateProxy.sol
+++ b/contracts/common/DepositableDelegateProxy.sol
@@ -17,8 +17,8 @@ contract DepositableDelegateProxy is DepositableStorage, DelegateProxy {
             // Continue only if the gas left is lower than the threshold for forwarding to the implementation code,
             // otherwise continue outside of the assembly block.
             if lt(gas, forwardGasThreshold) {
-                // If the proxy accepts deposits, msg.data.length == 0 and msg.value > 0,
-                // accept the deposit and emit an event
+                // Only accept the deposit and emit an event if all of the following are true:
+                // the proxy accepts deposits (isDepositable), msg.data.length == 0, and msg.value > 0
                 if and(and(sload(isDepositablePosition), iszero(calldatasize)), gt(callvalue, 0)) {
                     let logData := mload(0x40) // free memory pointer
                     mstore(logData, caller) // add 'msg.sender' to the log data (first event param)

--- a/contracts/common/DepositableDelegateProxy.sol
+++ b/contracts/common/DepositableDelegateProxy.sol
@@ -14,7 +14,7 @@ contract DepositableDelegateProxy is DepositableStorage, DelegateProxy {
         // Optimized assembly implementation to prevent EIP-1884 from breaking deposits, reference code in Solidity:
         // https://github.com/aragon/aragonOS/blob/v4.2.1/contracts/common/DepositableDelegateProxy.sol#L10-L20
         assembly {
-            // If the gas left is lower than the threshold for forwarding to the implementation code,
+            // Continue only if the gas left is lower than the threshold for forwarding to the implementation code,
             // otherwise continue outside of the assembly block.
             if lt(gas, forwardGasThreshold) {
                 // If the proxy accepts deposits, msg.data.length == 0 and msg.value > 0,

--- a/contracts/common/DepositableDelegateProxy.sol
+++ b/contracts/common/DepositableDelegateProxy.sol
@@ -8,14 +8,34 @@ contract DepositableDelegateProxy is DepositableStorage, DelegateProxy {
     event ProxyDeposit(address sender, uint256 value);
 
     function () external payable {
-        // send / transfer
-        if (gasleft() < FWD_GAS_LIMIT) {
-            require(msg.value > 0 && msg.data.length == 0);
-            require(isDepositable());
-            emit ProxyDeposit(msg.sender, msg.value);
-        } else { // all calls except for send or transfer
-            address target = implementation();
-            delegatedFwd(target, msg.data);
+        uint256 forwardGasThreshold = FWD_GAS_LIMIT;
+        bytes32 isDepositablePosition = DEPOSITABLE_POSITION;
+
+        // Optimized assembly implementation to prevent EIP-1884 from breaking deposits, reference code in Solidity:
+        // https://github.com/aragon/aragonOS/blob/v4.2.1/contracts/common/DepositableDelegateProxy.sol#L10-L20
+        assembly {
+            // If the gas left is lower than the threshold for forwarding to the implementation code,
+            // otherwise continue outside of the assembly block.
+            if lt(gas, forwardGasThreshold) {
+                // If the proxy accepts deposits, msg.data.length == 0 and msg.value > 0,
+                // accept the deposit and emit an event
+                if and(and(sload(isDepositablePosition), iszero(calldatasize)), gt(callvalue, 0)) {
+                    let logData := mload(0x40) // free memory pointer
+                    mstore(logData, caller) // add 'msg.sender' to the log data (first event param)
+                    mstore(add(logData, 0x20), callvalue) // add 'msg.value' to the log data (second event param)
+
+                    // Emit an event with one topic to identify the event: keccak256('ProxyDeposit(address,uint256)') = 0x15ee...dee1
+                    log1(logData, 0x40, 0x15eeaa57c7bd188c1388020bcadc2c436ec60d647d36ef5b9eb3c742217ddee1)
+
+                    stop() // Stop. Exits execution context
+                }
+
+                // If any of above checks failed, revert the execution (if ETH was sent, it is returned to the sender)
+                revert(0, 0)
+            }
         }
+
+        address target = implementation();
+        delegatedFwd(target, msg.data);
     }
 }

--- a/contracts/common/DepositableDelegateProxy.sol
+++ b/contracts/common/DepositableDelegateProxy.sol
@@ -20,6 +20,9 @@ contract DepositableDelegateProxy is DepositableStorage, DelegateProxy {
                 // Only accept the deposit and emit an event if all of the following are true:
                 // the proxy accepts deposits (isDepositable), msg.data.length == 0, and msg.value > 0
                 if and(and(sload(isDepositablePosition), iszero(calldatasize)), gt(callvalue, 0)) {
+                    // Equivalent Solidity code for emitting the event:
+                    // emit ProxyDeposit(msg.sender, msg.value);
+
                     let logData := mload(0x40) // free memory pointer
                     mstore(logData, caller) // add 'msg.sender' to the log data (first event param)
                     mstore(add(logData, 0x20), callvalue) // add 'msg.value' to the log data (second event param)

--- a/contracts/test/helpers/EthSender.sol
+++ b/contracts/test/helpers/EthSender.sol
@@ -1,0 +1,8 @@
+pragma solidity 0.4.24;
+
+
+contract EthSender {
+    function sendEth(address to) external payable {
+        to.transfer(msg.value);
+    }
+}

--- a/contracts/test/helpers/ProxyTarget.sol
+++ b/contracts/test/helpers/ProxyTarget.sol
@@ -1,0 +1,17 @@
+pragma solidity 0.4.24;
+
+contract ProxyTarget {
+    event Pong();
+
+    function ping() external {
+      emit Pong();
+    }
+}
+
+contract ProxyTargetWithFallback is ProxyTarget {
+    event ReceivedEth();
+
+    function () external payable {
+      emit ReceivedEth();
+    }
+}

--- a/contracts/test/helpers/ProxyTarget.sol
+++ b/contracts/test/helpers/ProxyTarget.sol
@@ -1,6 +1,6 @@
 pragma solidity 0.4.24;
 
-contract ProxyTarget {
+contract ProxyTargetWithoutFallback {
     event Pong();
 
     function ping() external {
@@ -8,7 +8,7 @@ contract ProxyTarget {
     }
 }
 
-contract ProxyTargetWithFallback is ProxyTarget {
+contract ProxyTargetWithFallback is ProxyTargetWithoutFallback {
     event ReceivedEth();
 
     function () external payable {

--- a/contracts/test/mocks/apps/DepositableDelegateProxyMock.sol
+++ b/contracts/test/mocks/apps/DepositableDelegateProxyMock.sol
@@ -1,0 +1,24 @@
+pragma solidity 0.4.24;
+
+import "../../../common/DepositableDelegateProxy.sol";
+
+
+contract DepositableDelegateProxyMock is DepositableDelegateProxy {
+    address private implementationMock;
+
+    function enableDepositsOnMock() external {
+        setDepositable(true);
+    }
+
+    function setImplementationOnMock(address _implementationMock) external {
+        implementationMock = _implementationMock;
+    }
+
+    function implementation() public view returns (address) {
+        return implementationMock;
+    }
+
+    function proxyType() public pure returns (uint256 proxyTypeId) {
+        return UPGRADEABLE;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "ethereumjs-abi": "^0.6.5",
     "ganache-cli": "^6.4.2",
     "mocha-lcov-reporter": "^1.3.0",
-    "solidity-coverage": "^0.6.2",
+    "solidity-coverage": "0.6.2",
     "solium": "^1.2.3",
     "truffle": "4.1.14",
     "truffle-bytecode-manager": "^1.1.1",

--- a/test/contracts/apps/app_funds.js
+++ b/test/contracts/apps/app_funds.js
@@ -17,7 +17,8 @@ const UnsafeAppStubDepositable = artifacts.require('UnsafeAppStubDepositable')
 
 const APP_ID = hash('stub.aragonpm.test')
 const EMPTY_BYTES = '0x'
-const SEND_ETH_GAS = 31000 // 21k base tx cost + 10k limit on depositable proxies
+const TX_BASE_GAS = 21000
+const SEND_ETH_GAS = TX_BASE_GAS + 9999 // <10k gas is the threshold for depositing
 
 contract('App funds', ([permissionsRoot]) => {
   let aclBase, kernelBase

--- a/test/contracts/apps/recovery_to_vault.js
+++ b/test/contracts/apps/recovery_to_vault.js
@@ -283,7 +283,7 @@ contract('Recovery to vault', ([ permissionsRoot ]) => {
             // TODO: Remove when the targetted EVM has been upgraded to Istanbul (EIP-1884)
             it('can receive ETH (Istanbul, EIP-1884)', async () => {
               const { gasUsed } = await sendEth({ target, value: 1, gas: SOLIDITY_TRANSFER_GAS - ISTANBUL_SLOAD_GAS_INCREASE })
-              console.log('Used gas:', gasUsed)
+              console.log('Used gas:', gasUsed - TX_BASE_GAS)
             })
 
             it('OOGs if sending ETH with too little gas', async () => {
@@ -390,7 +390,7 @@ contract('Recovery to vault', ([ permissionsRoot ]) => {
     // TODO: Remove when the targetted EVM has been upgraded to Istanbul (EIP-1884)
     it('can receive ETH (Istanbul, EIP-1884)', async () => {
       const { gasUsed } = await sendEth({ target: kernel, value: 1, gas: SOLIDITY_TRANSFER_GAS - ISTANBUL_SLOAD_GAS_INCREASE })
-      console.log('Used gas:', gasUsed)
+      console.log('Used gas:', gasUsed - TX_BASE_GAS)
     })
 
     it('OOGs if sending ETH with too little gas', async () => {

--- a/test/contracts/apps/recovery_to_vault.js
+++ b/test/contracts/apps/recovery_to_vault.js
@@ -20,7 +20,8 @@ const KernelDepositableMock = artifacts.require('KernelDepositableMock')
 
 const APP_ID = hash('stub.aragonpm.test')
 const EMPTY_BYTES = '0x'
-const SEND_ETH_GAS = 31000 // 21k base tx cost + 10k limit on depositable proxies
+const TX_BASE_GAS = 21000
+const SEND_ETH_GAS = TX_BASE_GAS + 9999 // <10k gas is the threshold for depositing
 
 contract('Recovery to vault', ([permissionsRoot]) => {
   let aclBase, appBase, appConditionalRecoveryBase

--- a/test/contracts/apps/recovery_to_vault.js
+++ b/test/contracts/apps/recovery_to_vault.js
@@ -1,12 +1,15 @@
 const { hash } = require('eth-ens-namehash')
+const { toChecksumAddress } = require('web3-utils')
 const { assertAmountOfEvents, assertEvent } = require('../../helpers/assertEvent')(web3)
-const { assertRevert } = require('../../helpers/assertThrow')
+const { assertRevert, assertOutOfGas } = require('../../helpers/assertThrow')
 const { getNewProxyAddress } = require('../../helpers/events')
 const { getBalance } = require('../../helpers/web3')
+const { decodeEventsOfType } = require('../../helpers/decodeEvent')
 
 const ACL = artifacts.require('ACL')
 const Kernel = artifacts.require('Kernel')
 const KernelProxy = artifacts.require('KernelProxy')
+const DepositableDelegateProxy = artifacts.require('DepositableDelegateProxy')
 
 // Mocks
 const AppStubDepositable = artifacts.require('AppStubDepositable')
@@ -17,22 +20,53 @@ const TokenReturnFalseMock = artifacts.require('TokenReturnFalseMock')
 const TokenReturnMissingMock = artifacts.require('TokenReturnMissingMock')
 const VaultMock = artifacts.require('VaultMock')
 const KernelDepositableMock = artifacts.require('KernelDepositableMock')
+const EthSender = artifacts.require('EthSender')
 
 const APP_ID = hash('stub.aragonpm.test')
 const EMPTY_BYTES = '0x'
-const SEND_ETH_GAS = 31000 // 21k base tx cost + 10k limit on depositable proxies
+const TX_BASE_GAS = 21000
+const SEND_ETH_GAS = TX_BASE_GAS + 10000 // 10k limit on depositable proxies
+const SOLIDITY_TRANSFER_GAS = 2300
+const ISTANBUL_SLOAD_GAS_INCREASE = 600
 
-contract('Recovery to vault', ([permissionsRoot]) => {
-  let aclBase, appBase, appConditionalRecoveryBase
+contract('Recovery to vault', ([ permissionsRoot ]) => {
+  let aclBase, appBase, appConditionalRecoveryBase, ethSender
   let APP_ADDR_NAMESPACE, ETH
 
   // Helpers
+  const sendEth = async ({ target, value, gas = SOLIDITY_TRANSFER_GAS, shouldOOG }) => {
+    const initialBalance = await getBalance(target.address)
+
+    const useSenderContract = gas === SOLIDITY_TRANSFER_GAS
+    const sender = useSenderContract ? ethSender.address : permissionsRoot
+
+    const sendAction = () => useSenderContract
+      ? ethSender.sendEth(target.address, { value })
+      : target.sendTransaction({ gas: gas + TX_BASE_GAS, value })
+
+    if (shouldOOG) {
+      await assertOutOfGas(sendAction)
+      assert.equal((await getBalance(target.address)).valueOf(), initialBalance, 'Target balance should be the same as before')
+    } else {
+      const { tx } = await sendAction()
+      const receipt = await web3.eth.getTransactionReceipt(tx)
+
+      assert.equal((await getBalance(target.address)).valueOf(), initialBalance.plus(value), 'Target balance should be correct')
+
+      const logs = decodeEventsOfType(receipt, DepositableDelegateProxy.abi, 'ProxyDeposit')
+      assertAmountOfEvents({ logs }, 'ProxyDeposit')
+      assertEvent({ logs }, 'ProxyDeposit', { sender: toChecksumAddress(sender), value })
+
+      return receipt
+    }
+  }
+
   const recoverEth = async ({ shouldFail, target, vault }) => {
     const amount = 1
     const initialBalance = await getBalance(target.address)
     const initialVaultBalance = await getBalance(vault.address)
-    await target.sendTransaction({ value: 1, gas: SEND_ETH_GAS })
-    assert.equal((await getBalance(target.address)).valueOf(), initialBalance.plus(amount), 'Target initial balance should be correct')
+
+    await sendEth({ target, value: amount })
 
     const recoverAction = () => target.transferToVault(ETH)
 
@@ -123,6 +157,7 @@ contract('Recovery to vault', ([permissionsRoot]) => {
     aclBase = await ACL.new()
     appBase = await AppStubDepositable.new()
     appConditionalRecoveryBase = await AppStubConditionalRecovery.new()
+    ethSender = await EthSender.new()
 
     // Setup constants
     const kernel = await Kernel.new(true)
@@ -241,6 +276,20 @@ contract('Recovery to vault', ([permissionsRoot]) => {
               await assertRevert(target.sendTransaction({ value: 1, data: '0x01', gas: SEND_ETH_GAS }))
             })
 
+            it('can receive ETH (Constantinople)', async () => {
+              await sendEth({ target, value: 1 })
+            })
+
+            // TODO: Remove when the targetted EVM has been upgraded to Istanbul (EIP-1884)
+            it('can receive ETH (Istanbul, EIP-1884)', async () => {
+              const { gasUsed } = await sendEth({ target, value: 1, gas: SOLIDITY_TRANSFER_GAS - ISTANBUL_SLOAD_GAS_INCREASE })
+              console.log('Used gas:', gasUsed)
+            })
+
+            it('OOGs if sending ETH with too little gas', async () => {
+              await sendEth({ target, value: 1, gas: SOLIDITY_TRANSFER_GAS - 850, shouldOOG: true })
+            })
+
             it('recovers ETH', async () =>
               await recoverEth({ target, vault })
             )
@@ -332,6 +381,20 @@ contract('Recovery to vault', ([permissionsRoot]) => {
       await vault.initialize()
 
       await kernel.setRecoveryVaultAppId(vaultId)
+    })
+
+    it('can receive ETH (Constantinople)', async () => {
+      await sendEth({ target: kernel, value: 1 })
+    })
+
+    // TODO: Remove when the targetted EVM has been upgraded to Istanbul (EIP-1884)
+    it('can receive ETH (Istanbul, EIP-1884)', async () => {
+      const { gasUsed } = await sendEth({ target: kernel, value: 1, gas: SOLIDITY_TRANSFER_GAS - ISTANBUL_SLOAD_GAS_INCREASE })
+      console.log('Used gas:', gasUsed)
+    })
+
+    it('OOGs if sending ETH with too little gas', async () => {
+      await sendEth({ target: kernel, value: 1, gas: SOLIDITY_TRANSFER_GAS - 850, shouldOOG: true })
     })
 
     it('recovers ETH from the kernel', async () => {

--- a/test/contracts/common/depositable_delegate_proxy.js
+++ b/test/contracts/common/depositable_delegate_proxy.js
@@ -12,11 +12,11 @@ const ProxyTargetWithFallback = artifacts.require('ProxyTargetWithFallback')
 
 const TX_BASE_GAS = 21000
 const SEND_ETH_GAS = TX_BASE_GAS + 9999 // 10k gas is the threshold for depositing
-const FALLBACK_SETUP_GAS = 300 // rough estimation of how much gas it spends before executing the fallback code (increased for coverage)
+const FALLBACK_SETUP_GAS = process.env.SOLIDITY_COVERAGE ? 5000 : 100 // rough estimation of how much gas it spends before executing the fallback code
 const SOLIDITY_TRANSFER_GAS = 2300
 const ISTANBUL_SLOAD_GAS_INCREASE = 600
 
-contract.only('DepositableDelegateProxy', ([ sender ]) => {
+contract('DepositableDelegateProxy', ([ sender ]) => {
   let ethSender, proxy, target, proxyTargetWithoutFallbackBase, proxyTargetWithFallbackBase
 
   // Initial setup
@@ -133,8 +133,10 @@ contract.only('DepositableDelegateProxy', ([ sender ]) => {
 
       // TODO: Remove when the targetted EVM has been upgraded to Istanbul (EIP-1884)
       it('cannot receive ETH if sent with a small amount of gas', async () => {
+        // solidity-coverage seems to be increasing the gas amount to prevent failures
+        const oogDecrease = process.env.SOLIDITY_COVERAGE ? 600 : 250
         // deposit cannot be done with this amount of gas
-        const gas = TX_BASE_GAS + SOLIDITY_TRANSFER_GAS - ISTANBUL_SLOAD_GAS_INCREASE - 250
+        const gas = TX_BASE_GAS + SOLIDITY_TRANSFER_GAS - ISTANBUL_SLOAD_GAS_INCREASE - oogDecrease
         await assertSendEthToProxy({ shouldOOG: true, value, gas })
       })
 

--- a/test/contracts/common/depositable_delegate_proxy.js
+++ b/test/contracts/common/depositable_delegate_proxy.js
@@ -1,0 +1,173 @@
+const { toChecksumAddress } = require('web3-utils')
+const { assertAmountOfEvents, assertEvent } = require('../../helpers/assertEvent')(web3)
+const { decodeEventsOfType } = require('../../helpers/decodeEvent')
+const { assertRevert, assertOutOfGas } = require('../../helpers/assertThrow')
+const { getBalance } = require('../../helpers/web3')
+
+// Mocks
+const DepositableDelegateProxyMock = artifacts.require('DepositableDelegateProxyMock')
+const EthSender = artifacts.require('EthSender')
+const ProxyTarget = artifacts.require('ProxyTarget')
+const ProxyTargetWithFallback = artifacts.require('ProxyTargetWithFallback')
+
+const TX_BASE_GAS = 21000
+const SEND_ETH_GAS = TX_BASE_GAS + 9999 // 10k gas is the threshold for depositing
+const FALLBACK_SETUP_GAS = 100 // rough estimation of how much gas it spends before executing the fallback code
+const SOLIDITY_TRANSFER_GAS = 2300
+const ISTANBUL_SLOAD_GAS_INCREASE = 600
+
+contract('DepositableDelegateProxy', ([ sender ]) => {
+  let ethSender, proxy, proxyTargetBase, proxyTargetWithFallbackBase
+
+  // Initial setup
+  before(async () => {
+    ethSender = await EthSender.new()
+    proxyTargetBase = await ProxyTarget.new()
+    proxyTargetWithFallbackBase = await ProxyTargetWithFallback.new()
+  })
+
+  beforeEach(async () => {
+    proxy = await DepositableDelegateProxyMock.new()
+  })
+
+  const itForwardsToImplementationIfGasIsOverThreshold = () => {
+    let target
+    
+    beforeEach(() => {
+      target = ProxyTargetWithFallback.at(proxy.address)
+    })
+
+    context('when implementation address is set', () => {
+      const itSuccessfullyForwardsCall = () => {
+        it('forwards call with data', async () => {
+          const receipt = await target.ping()
+          assertAmountOfEvents(receipt, 'Pong')
+        })
+      }
+
+      context('when implementation has a fallback', () => {
+        beforeEach(async () => {
+          await proxy.setImplementationOnMock(proxyTargetWithFallbackBase.address)
+        })
+
+        itSuccessfullyForwardsCall()
+
+        it('can receive ETH', async () => {
+          const receipt = await target.sendTransaction({ value: 1, gas: SEND_ETH_GAS + FALLBACK_SETUP_GAS })
+          assertAmountOfEvents(receipt, 'ReceivedEth')
+        })
+      })
+
+      context('when implementation doesn\'t have a fallback', () => {
+        beforeEach(async () => {
+          await proxy.setImplementationOnMock(proxyTargetBase.address)
+        })
+
+        itSuccessfullyForwardsCall()
+
+        it('reverts when sending ETH', async () => {
+          await assertRevert(target.sendTransaction({ value: 1 }))
+        })
+      })
+    })
+
+    context('when implementation address is not set', () => {
+      it('reverts when a function is called', async () => {
+        await assertRevert(target.ping())
+      })
+
+      it('reverts when sending ETH', async () => {
+        await assertRevert(target.sendTransaction({ value: 1 }))
+      })
+    })
+  }
+
+  const itRevertsOnInvalidDeposits = () => {
+    it('reverts when call has data', async () => {
+      await assertRevert(proxy.sendTransaction({ value: 1, data: '0x01', gas: SEND_ETH_GAS }))
+    })
+
+    it('reverts when call sends 0 value', async () => {
+      await assertRevert(proxy.sendTransaction({ value: 0, gas: SEND_ETH_GAS }))
+    })
+  }
+
+  context('when proxy is set as depositable', () => {
+    beforeEach(async () => {
+      await proxy.enableDepositsOnMock()
+    })
+
+    context('when call gas is below the forwarding threshold', () => {
+      const value = 100
+
+      const sendEthToProxy = async ({ value, gas, shouldOOG }) => {
+        const initialBalance = await getBalance(proxy.address)
+
+        const sendEthAction = () => proxy.sendTransaction({ from: sender, gas, value })
+
+        if (shouldOOG) {
+          await assertOutOfGas(sendEthAction())
+          assert.equal((await getBalance(proxy.address)).valueOf(), initialBalance, 'Target balance should be the same as before')
+        } else {
+          const { receipt, logs } = await sendEthAction()
+
+          assert.equal((await getBalance(proxy.address)).valueOf(), initialBalance.plus(value), 'Target balance should be correct')
+          assertAmountOfEvents({ logs }, 'ProxyDeposit')
+          assertEvent({ logs }, 'ProxyDeposit', { sender, value })
+
+          return receipt
+        }
+      }
+
+      it('can receive ETH (Constantinople)', async () => {
+        const { gasUsed } = await sendEthToProxy({ value, gas: SEND_ETH_GAS })
+        console.log('Used gas:', gasUsed - TX_BASE_GAS)
+      })
+
+      // TODO: Remove when the targetted EVM has been upgraded to Istanbul (EIP-1884)
+      it('can receive ETH (Istanbul, EIP-1884)', async () => {
+        const gas = TX_BASE_GAS + SOLIDITY_TRANSFER_GAS - ISTANBUL_SLOAD_GAS_INCREASE
+        const { gasUsed } = await sendEthToProxy({ value, gas })
+        const gasUsedIstanbul = gasUsed - TX_BASE_GAS + ISTANBUL_SLOAD_GAS_INCREASE
+        console.log('Used gas (Istanbul):', gasUsedIstanbul)
+
+        assert.isBelow(gasUsedIstanbul, 2300, 'Gas cost under Istanbul cannot be above 2300 gas')
+      })
+
+      // TODO: Remove when the targetted EVM has been upgraded to Istanbul (EIP-1884)
+      it('cannot receive ETH if sent with a small amount of gas', async () => {
+        // deposit cannot be done with this amount of gas
+        const gas = TX_BASE_GAS + SOLIDITY_TRANSFER_GAS - ISTANBUL_SLOAD_GAS_INCREASE - 250
+        await sendEthToProxy({ shouldOOG: true, value, gas })
+      })
+
+      it('can receive ETH from contract', async () => {
+        const { tx } = await ethSender.sendEth(proxy.address, { value })
+        const receipt = await web3.eth.getTransactionReceipt(tx)
+        const logs = decodeEventsOfType(receipt, DepositableDelegateProxyMock.abi, 'ProxyDeposit')
+        assertAmountOfEvents({ logs }, 'ProxyDeposit')
+        assertEvent({ logs }, 'ProxyDeposit', { sender: toChecksumAddress(ethSender.address), value })
+      })
+
+      itRevertsOnInvalidDeposits()
+    })
+
+    context('when call gas is over forwarding threshold', () => {
+      itForwardsToImplementationIfGasIsOverThreshold()
+    })
+  })
+
+  context('when proxy is not set as depositable', () => {
+    context('when call gas is below the forwarding threshold', () => {
+      it('reverts when depositing ETH', async () => {
+        await assertRevert(proxy.sendTransaction({ value: 1, gas: SEND_ETH_GAS }))
+      })
+
+      itRevertsOnInvalidDeposits()
+    })
+
+    context('when call gas is over forwarding threshold', () => {
+      itForwardsToImplementationIfGasIsOverThreshold()
+    })
+  })
+})

--- a/test/contracts/kernel/kernel_funds.js
+++ b/test/contracts/kernel/kernel_funds.js
@@ -9,7 +9,8 @@ const KernelProxy = artifacts.require('KernelProxy')
 // Mocks
 const KernelDepositableMock = artifacts.require('KernelDepositableMock')
 
-const SEND_ETH_GAS = 31000 // 21k base tx cost + 10k limit on depositable proxies
+const TX_BASE_GAS = 21000
+const SEND_ETH_GAS = TX_BASE_GAS + 9999 // <10k gas is the threshold for depositing
 
 contract('Kernel funds', ([permissionsRoot]) => {
   let aclBase

--- a/test/helpers/assertThrow.js
+++ b/test/helpers/assertThrow.js
@@ -24,6 +24,10 @@ module.exports = {
     return assertThrows(blockOrPromise, 'invalid opcode')
   },
 
+  async assertOutOfGas(blockOrPromise) {
+    return assertThrows(blockOrPromise, 'out of gas')
+  },
+
   async assertRevert(blockOrPromise, reason) {
     const error = await assertThrows(blockOrPromise, 'revert', reason)
     const errorPrefix = `${THROW_ERROR_PREFIX} revert`


### PR DESCRIPTION
Optimizes the fallback function in the proxy so it can receive ETH after EIP-1884 is implemented in Istanbul. 

With these changes, the gas cost for executing the fallback function has gone down **from 1759 gas to 1619**, which after the SLOAD opcode is repriced to 800 gas will still execute under 2300 gas (2219 gas).

Closes #549 (even though this issue doesn't tackle the potential migration for all existing DAOs whose Vaults would break)