### PR TITLE
License: replace SPDX-Identifier misspelling in contract headers

### DIFF
--- a/contracts/acl/ACLSyntaxSugar.sol
+++ b/contracts/acl/ACLSyntaxSugar.sol
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identitifer:    MIT
+ * SPDX-License-Identifier:    MIT
  */
 
 pragma solidity ^0.4.24;

--- a/contracts/acl/IACL.sol
+++ b/contracts/acl/IACL.sol
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identitifer:    MIT
+ * SPDX-License-Identifier:    MIT
  */
 
 pragma solidity ^0.4.24;

--- a/contracts/acl/IACLOracle.sol
+++ b/contracts/acl/IACLOracle.sol
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identitifer:    MIT
+ * SPDX-License-Identifier:    MIT
  */
 
 pragma solidity ^0.4.24;

--- a/contracts/apm/APMNamehash.sol
+++ b/contracts/apm/APMNamehash.sol
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identitifer:    MIT
+ * SPDX-License-Identifier:    MIT
  */
 
 pragma solidity ^0.4.24;

--- a/contracts/apps/AppStorage.sol
+++ b/contracts/apps/AppStorage.sol
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identitifer:    MIT
+ * SPDX-License-Identifier:    MIT
  */
 
 pragma solidity ^0.4.24;

--- a/contracts/apps/AragonApp.sol
+++ b/contracts/apps/AragonApp.sol
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identitifer:    MIT
+ * SPDX-License-Identifier:    MIT
  */
 
 pragma solidity ^0.4.24;

--- a/contracts/apps/UnsafeAragonApp.sol
+++ b/contracts/apps/UnsafeAragonApp.sol
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identitifer:    MIT
+ * SPDX-License-Identifier:    MIT
  */
 
 pragma solidity ^0.4.24;

--- a/contracts/common/Autopetrified.sol
+++ b/contracts/common/Autopetrified.sol
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identitifer:    MIT
+ * SPDX-License-Identifier:    MIT
  */
 
 pragma solidity ^0.4.24;

--- a/contracts/common/EtherTokenConstant.sol
+++ b/contracts/common/EtherTokenConstant.sol
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identitifer:    MIT
+ * SPDX-License-Identifier:    MIT
  */
 
 pragma solidity ^0.4.24;

--- a/contracts/common/IForwarder.sol
+++ b/contracts/common/IForwarder.sol
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identitifer:    MIT
+ * SPDX-License-Identifier:    MIT
  */
 
 pragma solidity ^0.4.24;

--- a/contracts/common/IForwarderFee.sol
+++ b/contracts/common/IForwarderFee.sol
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identitifer:    MIT
+ * SPDX-License-Identifier:    MIT
  */
 
 pragma solidity ^0.4.24;

--- a/contracts/common/IVaultRecoverable.sol
+++ b/contracts/common/IVaultRecoverable.sol
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identitifer:    MIT
+ * SPDX-License-Identifier:    MIT
  */
 
 pragma solidity ^0.4.24;

--- a/contracts/common/Initializable.sol
+++ b/contracts/common/Initializable.sol
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identitifer:    MIT
+ * SPDX-License-Identifier:    MIT
  */
 
 pragma solidity ^0.4.24;

--- a/contracts/common/IsContract.sol
+++ b/contracts/common/IsContract.sol
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identitifer:    MIT
+ * SPDX-License-Identifier:    MIT
  */
 
 pragma solidity ^0.4.24;

--- a/contracts/common/Petrifiable.sol
+++ b/contracts/common/Petrifiable.sol
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identitifer:    MIT
+ * SPDX-License-Identifier:    MIT
  */
 
 pragma solidity ^0.4.24;

--- a/contracts/common/ReentrancyGuard.sol
+++ b/contracts/common/ReentrancyGuard.sol
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identitifer:    MIT
+ * SPDX-License-Identifier:    MIT
  */
 
 pragma solidity ^0.4.24;

--- a/contracts/common/TimeHelpers.sol
+++ b/contracts/common/TimeHelpers.sol
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identitifer:    MIT
+ * SPDX-License-Identifier:    MIT
  */
 
 pragma solidity ^0.4.24;

--- a/contracts/common/UnstructuredStorage.sol
+++ b/contracts/common/UnstructuredStorage.sol
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identitifer:    MIT
+ * SPDX-License-Identifier:    MIT
  */
 
 pragma solidity ^0.4.24;

--- a/contracts/common/VaultRecoverable.sol
+++ b/contracts/common/VaultRecoverable.sol
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identitifer:    MIT
+ * SPDX-License-Identifier:    MIT
  */
 
 pragma solidity ^0.4.24;

--- a/contracts/ens/ENSConstants.sol
+++ b/contracts/ens/ENSConstants.sol
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identitifer:    MIT
+ * SPDX-License-Identifier:    MIT
  */
 
 pragma solidity ^0.4.24;

--- a/contracts/evmscript/EVMScriptRunner.sol
+++ b/contracts/evmscript/EVMScriptRunner.sol
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identitifer:    MIT
+ * SPDX-License-Identifier:    MIT
  */
 
 pragma solidity ^0.4.24;

--- a/contracts/evmscript/IEVMScriptExecutor.sol
+++ b/contracts/evmscript/IEVMScriptExecutor.sol
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identitifer:    MIT
+ * SPDX-License-Identifier:    MIT
  */
 
 pragma solidity ^0.4.24;

--- a/contracts/evmscript/IEVMScriptRegistry.sol
+++ b/contracts/evmscript/IEVMScriptRegistry.sol
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identitifer:    MIT
+ * SPDX-License-Identifier:    MIT
  */
 
 pragma solidity ^0.4.24;

--- a/contracts/evmscript/ScriptHelpers.sol
+++ b/contracts/evmscript/ScriptHelpers.sol
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identitifer:    MIT
+ * SPDX-License-Identifier:    MIT
  */
 
 pragma solidity ^0.4.24;

--- a/contracts/evmscript/executors/BaseEVMScriptExecutor.sol
+++ b/contracts/evmscript/executors/BaseEVMScriptExecutor.sol
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identitifer:    MIT
+ * SPDX-License-Identifier:    MIT
  */
 
 pragma solidity ^0.4.24;

--- a/contracts/kernel/IKernel.sol
+++ b/contracts/kernel/IKernel.sol
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identitifer:    MIT
+ * SPDX-License-Identifier:    MIT
  */
 
 pragma solidity ^0.4.24;

--- a/contracts/kernel/KernelConstants.sol
+++ b/contracts/kernel/KernelConstants.sol
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identitifer:    MIT
+ * SPDX-License-Identifier:    MIT
  */
 
 pragma solidity ^0.4.24;

--- a/contracts/lib/misc/ERCProxy.sol
+++ b/contracts/lib/misc/ERCProxy.sol
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identitifer:    MIT
+ * SPDX-License-Identifier:    MIT
  */
 
 pragma solidity ^0.4.24;


### PR DESCRIPTION
Even though it was fun to spot projects reusing or forking aragon contracts: https://github.com/search?q=SPDX-License-Identitifer&type=Code

But I thought it might be interesting to fix the misspelling, in case any automated script might eventually parse that header to show the license.

Related: https://github.com/aragon/aragon-apps/pull/1013