### PR TITLE
ACL: remove ACLOracle canPerform() gas limit

### DIFF
--- a/contracts/acl/ACL.sol
+++ b/contracts/acl/ACL.sol
@@ -3,7 +3,6 @@ pragma solidity 0.4.24;
 import "../apps/AragonApp.sol";
 import "../common/ConversionHelpers.sol";
 import "../common/TimeHelpers.sol";
-import "../lib/math/SafeMath.sol";
 import "./ACLSyntaxSugar.sol";
 import "./IACL.sol";
 import "./IACLOracle.sol";
@@ -12,7 +11,6 @@ import "./IACLOracle.sol";
 /* solium-disable function-order */
 // Allow public initialize() to be first
 contract ACL is IACL, TimeHelpers, AragonApp, ACLHelpers {
-    using SafeMath for uint256;
 
     /* Hardcoded constants to save gas
     bytes32 public constant CREATE_PERMISSIONS_ROLE = keccak256("CREATE_PERMISSIONS_ROLE");
@@ -429,7 +427,7 @@ contract ACL is IACL, TimeHelpers, AragonApp, ACLHelpers {
         bool ok;
 
         if (gasleft() > ERROR_GAS_ALLOWANCE) {
-            uint256 oracleCheckGas = gasleft().sub(ERROR_GAS_ALLOWANCE);
+            uint256 oracleCheckGas = gasleft() - ERROR_GAS_ALLOWANCE;
             assembly {
                 ok := staticcall(oracleCheckGas, _oracleAddr, add(checkCalldata, 0x20), mload(checkCalldata), 0, 0)
             }

--- a/contracts/acl/ACL.sol
+++ b/contracts/acl/ACL.sol
@@ -45,7 +45,7 @@ contract ACL is IACL, TimeHelpers, AragonApp, ACLHelpers {
     address public constant ANY_ENTITY = address(-1);
     address public constant BURN_ENTITY = address(1); // address(0) is already used as "no permission manager"
 
-    uint256 internal constant ERROR_GAS_ALLOWANCE = 100000;
+    uint256 internal constant ERROR_GAS_ALLOWANCE = 50000;
 
     string private constant ERROR_AUTH_INIT_KERNEL = "ACL_AUTH_INIT_KERNEL";
     string private constant ERROR_AUTH_NO_MANAGER = "ACL_AUTH_NO_MANAGER";

--- a/contracts/acl/ACL.sol
+++ b/contracts/acl/ACL.sol
@@ -11,7 +11,6 @@ import "./IACLOracle.sol";
 /* solium-disable function-order */
 // Allow public initialize() to be first
 contract ACL is IACL, TimeHelpers, AragonApp, ACLHelpers {
-
     /* Hardcoded constants to save gas
     bytes32 public constant CREATE_PERMISSIONS_ROLE = keccak256("CREATE_PERMISSIONS_ROLE");
     */

--- a/contracts/acl/ACL.sol
+++ b/contracts/acl/ACL.sol
@@ -3,6 +3,7 @@ pragma solidity 0.4.24;
 import "../apps/AragonApp.sol";
 import "../common/ConversionHelpers.sol";
 import "../common/TimeHelpers.sol";
+import "../lib/math/SafeMath.sol";
 import "./ACLSyntaxSugar.sol";
 import "./IACL.sol";
 import "./IACLOracle.sol";
@@ -11,6 +12,8 @@ import "./IACLOracle.sol";
 /* solium-disable function-order */
 // Allow public initialize() to be first
 contract ACL is IACL, TimeHelpers, AragonApp, ACLHelpers {
+    using SafeMath for uint256;
+
     /* Hardcoded constants to save gas
     bytes32 public constant CREATE_PERMISSIONS_ROLE = keccak256("CREATE_PERMISSIONS_ROLE");
     */
@@ -421,7 +424,7 @@ contract ACL is IACL, TimeHelpers, AragonApp, ACLHelpers {
 
         // a raw call is required so we can return false if the call reverts, rather than reverting
         bytes memory checkCalldata = abi.encodeWithSelector(sig, _who, _where, _what, _how);
-        uint256 oracleCheckGas = gasleft() - ERROR_GAS_ALLOWANCE;
+        uint256 oracleCheckGas = gasleft().sub(ERROR_GAS_ALLOWANCE);
 
         bool ok;
         assembly {

--- a/contracts/acl/ACL.sol
+++ b/contracts/acl/ACL.sol
@@ -422,6 +422,9 @@ contract ACL is IACL, TimeHelpers, AragonApp, ACLHelpers {
 
         bool ok;
         assembly {
+            // send all available gas; if the oracle eats up all the gas, we will eventually revert
+            // note that we are currently guaranteed to still have some gas after the call from
+            // EIP-150's 63/64 gas forward rule
             ok := staticcall(gas, _oracleAddr, add(checkCalldata, 0x20), mload(checkCalldata), 0, 0)
         }
 

--- a/contracts/acl/ACL.sol
+++ b/contracts/acl/ACL.sol
@@ -42,7 +42,7 @@ contract ACL is IACL, TimeHelpers, AragonApp, ACLHelpers {
     address public constant ANY_ENTITY = address(-1);
     address public constant BURN_ENTITY = address(1); // address(0) is already used as "no permission manager"
 
-    uint256 internal constant ORACLE_CHECK_GAS = 30000;
+    uint256 internal constant ERROR_GAS_ALLOWANCE = 100000;
 
     string private constant ERROR_AUTH_INIT_KERNEL = "ACL_AUTH_INIT_KERNEL";
     string private constant ERROR_AUTH_NO_MANAGER = "ACL_AUTH_NO_MANAGER";
@@ -421,7 +421,7 @@ contract ACL is IACL, TimeHelpers, AragonApp, ACLHelpers {
 
         // a raw call is required so we can return false if the call reverts, rather than reverting
         bytes memory checkCalldata = abi.encodeWithSelector(sig, _who, _where, _what, _how);
-        uint256 oracleCheckGas = ORACLE_CHECK_GAS;
+        uint256 oracleCheckGas = gasleft() - ERROR_GAS_ALLOWANCE;
 
         bool ok;
         assembly {

--- a/contracts/test/helpers/ACLHelper.sol
+++ b/contracts/test/helpers/ACLHelper.sol
@@ -60,8 +60,7 @@ contract ConditionalOracle is IACLOracle {
 
 contract OverGasLimitOracle is IACLOracle {
     function canPerform(address, address, bytes32, uint256[]) external view returns (bool) {
-        while (true) {
-        }
+        while (true) {}
         return true;
     }
 }

--- a/contracts/test/helpers/ACLHelper.sol
+++ b/contracts/test/helpers/ACLHelper.sol
@@ -57,3 +57,14 @@ contract ConditionalOracle is IACLOracle {
         return how[0] > 0;
     }
 }
+
+contract OverGasLimitOracle is IACLOracle {
+    uint256 storageVariable;
+
+    function canPerform(address, address, bytes32, uint256[]) external view returns (bool) {
+        for (uint256 i = 0; i < 99999; i++) {
+            uint256 localVariable = storageVariable;
+        }
+        return true;
+    }
+}

--- a/contracts/test/helpers/ACLHelper.sol
+++ b/contracts/test/helpers/ACLHelper.sol
@@ -59,11 +59,11 @@ contract ConditionalOracle is IACLOracle {
 }
 
 contract OverGasLimitOracle is IACLOracle {
-    uint256 storageVar;
-
     function canPerform(address, address, bytes32, uint256[]) external view returns (bool) {
         while (true) {
-            uint256 memoryVar = storageVar;
+            // Do an SLOAD increase the per-loop gas costs
+            uint256 loadFromStorage;
+            assembly { loadFromStorage := sload(0) }
         }
         return true;
     }

--- a/contracts/test/helpers/ACLHelper.sol
+++ b/contracts/test/helpers/ACLHelper.sol
@@ -59,8 +59,12 @@ contract ConditionalOracle is IACLOracle {
 }
 
 contract OverGasLimitOracle is IACLOracle {
+    uint256 storageVar;
+
     function canPerform(address, address, bytes32, uint256[]) external view returns (bool) {
-        while (true) {}
+        while (true) {
+            uint256 memoryVar = storageVar;
+        }
         return true;
     }
 }

--- a/contracts/test/helpers/ACLHelper.sol
+++ b/contracts/test/helpers/ACLHelper.sol
@@ -59,11 +59,11 @@ contract ConditionalOracle is IACLOracle {
 }
 
 contract OverGasLimitOracle is IACLOracle {
-    uint256 storageVariable;
+    uint256 outOfGasIterations = 99999; // Actual limit is ~7500, set very high in case of gas cost updates
 
     function canPerform(address, address, bytes32, uint256[]) external view returns (bool) {
-        for (uint256 i = 0; i < 99999; i++) {
-            uint256 localVariable = storageVariable;
+        for (uint256 i = 0; i < outOfGasIterations; i++) {
+            uint256 localVariable = outOfGasIterations;
         }
         return true;
     }

--- a/contracts/test/helpers/ACLHelper.sol
+++ b/contracts/test/helpers/ACLHelper.sol
@@ -60,11 +60,7 @@ contract ConditionalOracle is IACLOracle {
 
 contract OverGasLimitOracle is IACLOracle {
     function canPerform(address, address, bytes32, uint256[]) external view returns (bool) {
-        while (true) {
-            // Do an SLOAD increase the per-loop gas costs
-            uint256 loadFromStorage;
-            assembly { loadFromStorage := sload(0) }
-        }
+        assert(false);
         return true;
     }
 }

--- a/contracts/test/helpers/ACLHelper.sol
+++ b/contracts/test/helpers/ACLHelper.sol
@@ -59,11 +59,8 @@ contract ConditionalOracle is IACLOracle {
 }
 
 contract OverGasLimitOracle is IACLOracle {
-    uint256 outOfGasIterations = 99999; // Actual limit is ~7500, set very high in case of gas cost updates
-
     function canPerform(address, address, bytes32, uint256[]) external view returns (bool) {
-        for (uint256 i = 0; i < outOfGasIterations; i++) {
-            uint256 localVariable = outOfGasIterations;
+        while (true) {
         }
         return true;
     }

--- a/contracts/test/helpers/ACLHelper.sol
+++ b/contracts/test/helpers/ACLHelper.sol
@@ -34,6 +34,12 @@ contract RevertOracle is IACLOracle {
     }
 }
 
+contract AssertOracle is IACLOracle {
+    function canPerform(address, address, bytes32, uint256[]) external view returns (bool) {
+        assert(false);
+    }
+}
+
 // Can't implement from IACLOracle as its canPerform() is marked as view-only
 contract StateModifyingOracle /* is IACLOracle */ {
     bool modifyState;
@@ -60,7 +66,11 @@ contract ConditionalOracle is IACLOracle {
 
 contract OverGasLimitOracle is IACLOracle {
     function canPerform(address, address, bytes32, uint256[]) external view returns (bool) {
-        assert(false);
+        while (true) {
+            // Do an SLOAD to increase the per-loop gas costs
+            uint256 loadFromStorage;
+            assembly { loadFromStorage := sload(0) }
+        }
         return true;
     }
 }

--- a/contracts/test/tests/TestACLInterpreter.sol
+++ b/contracts/test/tests/TestACLInterpreter.sol
@@ -100,11 +100,6 @@ contract TestACLInterpreter is ACL, ACLHelper {
         assertEval(arr(), ORACLE_PARAM_ID, Op.EQ, uint256(new StateModifyingOracle()), false);
     }
 
-    function testOverGasLimitOracle() public {
-        // the transaction should not revert even if the oracle uses all of the provided gas
-        assertEval(arr(), ORACLE_PARAM_ID, Op.EQ, uint256(new OverGasLimitOracle()), false);
-    }
-
     function testReturn() public {
         assertEval(arr(), PARAM_VALUE_PARAM_ID, Op.RET, uint256(1), true);
         assertEval(arr(), PARAM_VALUE_PARAM_ID, Op.RET, uint256(0), false);

--- a/contracts/test/tests/TestACLInterpreter.sol
+++ b/contracts/test/tests/TestACLInterpreter.sol
@@ -80,6 +80,8 @@ contract TestACLInterpreter is ACL, ACLHelper {
         assertEval(arr(), ORACLE_PARAM_ID, Op.EQ, uint256(new RejectOracle()), false);
         assertEval(arr(), ORACLE_PARAM_ID, Op.NEQ, uint256(new RejectOracle()), true);
 
+        // doesn't revert even if oracle reverts
+        assertEval(arr(), ORACLE_PARAM_ID, Op.EQ, uint256(new RevertOracle()), false);
         // if returned data size is not correct, returns false
         assertEval(arr(), ORACLE_PARAM_ID, Op.EQ, uint256(new EmptyDataReturnOracle()), false);
 
@@ -88,16 +90,6 @@ contract TestACLInterpreter is ACL, ACLHelper {
 
         assertEval(arr(uint256(1)), ORACLE_PARAM_ID, Op.EQ, uint256(conditionalOracle), true);
         assertEval(arr(uint256(0), uint256(1)), ORACLE_PARAM_ID, Op.EQ, uint256(conditionalOracle), false);
-    }
-
-    function testRevertOracle() public {
-        // doesn't revert even if oracle reverts
-        assertEval(arr(), ORACLE_PARAM_ID, Op.EQ, uint256(new RevertOracle()), false);
-    }
-
-    function testStateModifyingOracle() public {
-        // the staticcall will error as the oracle tries to modify state, so a no is returned
-        assertEval(arr(), ORACLE_PARAM_ID, Op.EQ, uint256(new StateModifyingOracle()), false);
     }
 
     function testReturn() public {

--- a/contracts/test/tests/TestACLInterpreter.sol
+++ b/contracts/test/tests/TestACLInterpreter.sol
@@ -80,10 +80,6 @@ contract TestACLInterpreter is ACL, ACLHelper {
         assertEval(arr(), ORACLE_PARAM_ID, Op.EQ, uint256(new RejectOracle()), false);
         assertEval(arr(), ORACLE_PARAM_ID, Op.NEQ, uint256(new RejectOracle()), true);
 
-        // doesn't revert even if oracle reverts
-        assertEval(arr(), ORACLE_PARAM_ID, Op.EQ, uint256(new RevertOracle()), false);
-        // the staticcall will error as the oracle tries to modify state, so a no is returned
-        assertEval(arr(), ORACLE_PARAM_ID, Op.EQ, uint256(new StateModifyingOracle()), false);
         // if returned data size is not correct, returns false
         assertEval(arr(), ORACLE_PARAM_ID, Op.EQ, uint256(new EmptyDataReturnOracle()), false);
 
@@ -92,6 +88,21 @@ contract TestACLInterpreter is ACL, ACLHelper {
 
         assertEval(arr(uint256(1)), ORACLE_PARAM_ID, Op.EQ, uint256(conditionalOracle), true);
         assertEval(arr(uint256(0), uint256(1)), ORACLE_PARAM_ID, Op.EQ, uint256(conditionalOracle), false);
+    }
+
+    function testRevertOracle() public {
+        // doesn't revert even if oracle reverts
+        assertEval(arr(), ORACLE_PARAM_ID, Op.EQ, uint256(new RevertOracle()), false);
+    }
+
+    function testStateModifyingOracle() public {
+        // the staticcall will error as the oracle tries to modify state, so a no is returned
+        assertEval(arr(), ORACLE_PARAM_ID, Op.EQ, uint256(new StateModifyingOracle()), false);
+    }
+
+    function testOverGasLimitOracle() public {
+        // the transaction should not revert even if the oracle uses all of the provided gas
+        assertEval(arr(), ORACLE_PARAM_ID, Op.EQ, uint256(new OverGasLimitOracle()), false);
     }
 
     function testReturn() public {

--- a/test/contracts/acl/acl_params.js
+++ b/test/contracts/acl/acl_params.js
@@ -10,6 +10,8 @@ const OverGasLimitOracle = artifacts.require('OverGasLimitOracle')
 const StateModifyingOracle = artifacts.require('StateModifyingOracle')
 
 const ANY_ADDR = '0xffffffffffffffffffffffffffffffffffffffff'
+const MAX_GAS_AVAILABLE = 6900000
+const EXPECTED_GAS_USAGE = MAX_GAS_AVAILABLE * 63 / 64
 
 contract('ACL params', ([permissionsRoot, mockAppAddress]) => {
   let aclBase, kernelBase, acl, kernel
@@ -67,14 +69,22 @@ contract('ACL params', ([permissionsRoot, mockAppAddress]) => {
       describe('when permission is set for ANY_ADDR', () => {
         it('ACL disallows actions', async () => {
           await acl.grantPermissionP(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE, [param])
-          assert.isFalse(await acl.hasPermission(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE))
+
+          const hasPermissionTxHash = await acl.hasPermission.sendTransaction(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE, { gas: MAX_GAS_AVAILABLE })
+          const hasPermissionGasConsumed = web3.eth.getTransactionReceipt(hasPermissionTxHash).gasUsed
+          assert.closeTo(hasPermissionGasConsumed, EXPECTED_GAS_USAGE, 1000)
+          assert.isFalse(await acl.hasPermission(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE, { gas: MAX_GAS_AVAILABLE }))
         })
       })
 
       describe('when permission is set for specific address', async () => {
         it('ACL disallows actions', async () => {
           await acl.grantPermissionP(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE, [param])
-          assert.isFalse(await acl.hasPermission(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE))
+
+          const hasPermissionTxHash = await acl.hasPermission.sendTransaction(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE, { gas: MAX_GAS_AVAILABLE })
+          const hasPermissionGasConsumed = web3.eth.getTransactionReceipt(hasPermissionTxHash).gasUsed
+          assert.closeTo(hasPermissionGasConsumed, EXPECTED_GAS_USAGE, 1000)
+          assert.isFalse(await acl.hasPermission(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE, { gas: MAX_GAS_AVAILABLE }))
         })
       })
     })
@@ -91,12 +101,22 @@ contract('ACL params', ([permissionsRoot, mockAppAddress]) => {
         // Note `evalParams()` is called twice when calling `hasPermission` for `ANY_ADDR`
         it('ACL disallows actions', async () => {
           await acl.grantPermissionP(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE, [param])
-          assert.isFalse(await acl.hasPermission(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE))
+
+          const hasPermissionTxHash = await acl.hasPermission.sendTransaction(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE, { gas: MAX_GAS_AVAILABLE })
+          const hasPermissionGasConsumed = web3.eth.getTransactionReceipt(hasPermissionTxHash).gasUsed
+          assert.closeTo(hasPermissionGasConsumed, EXPECTED_GAS_USAGE, 1000)
+          assert.isFalse(await acl.hasPermission(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE, { gas: MAX_GAS_AVAILABLE}))
         })
 
         it('ACL disallows actions with medium gas', async () => {
+          const gasAvailable = 3000000
+          const expectedGasUsage = gasAvailable * 63 / 64
           await acl.grantPermissionP(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE, [param])
-          assert.isFalse(await acl.hasPermission(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE, { gas: 3000000 }))
+
+          const hasPermissionTxHash = await acl.hasPermission.sendTransaction(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE, { gas: gasAvailable })
+          const hasPermissionGasConsumed = web3.eth.getTransactionReceipt(hasPermissionTxHash).gasUsed
+          assert.closeTo(hasPermissionGasConsumed, expectedGasUsage, 1000)
+          assert.isFalse(await acl.hasPermission(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE, { gas: gasAvailable }))
         })
 
         it('ACL fails with low gas', async () => {
@@ -110,12 +130,22 @@ contract('ACL params', ([permissionsRoot, mockAppAddress]) => {
         // Note `evalParams()` is only called once when calling `hasPermission` for a specific address
         it('ACL disallows actions', async () => {
           await acl.grantPermissionP(permissionsRoot, mockAppAddress, MOCK_APP_ROLE, [param])
-          assert.isFalse(await acl.hasPermission(permissionsRoot, mockAppAddress, MOCK_APP_ROLE))
+
+          const hasPermissionTxHash = await acl.hasPermission.sendTransaction(permissionsRoot, mockAppAddress, MOCK_APP_ROLE, { gas: MAX_GAS_AVAILABLE })
+          const hasPermissionGasConsumed = web3.eth.getTransactionReceipt(hasPermissionTxHash).gasUsed
+          assert.closeTo(hasPermissionGasConsumed, EXPECTED_GAS_USAGE, 105000)
+          assert.isFalse(await acl.hasPermission(permissionsRoot, mockAppAddress, MOCK_APP_ROLE), { gas: MAX_GAS_AVAILABLE })
         })
 
         it('ACL disallows actions with low gas', async () => {
+          const gasAvailable = 190000
+          const expectedGasUsage = gasAvailable * 63 / 64
           await acl.grantPermissionP(permissionsRoot, mockAppAddress, MOCK_APP_ROLE, [param])
-          assert.isFalse(await acl.hasPermission(permissionsRoot, mockAppAddress, MOCK_APP_ROLE, { gas: 190000}))
+
+          const hasPermissionTxHash = await acl.hasPermission.sendTransaction(permissionsRoot, mockAppAddress, MOCK_APP_ROLE, { gas: gasAvailable})
+          const hasPermissionGasConsumed = web3.eth.getTransactionReceipt(hasPermissionTxHash).gasUsed
+          assert.closeTo(hasPermissionGasConsumed, expectedGasUsage, 10000)
+          assert.isFalse(await acl.hasPermission(permissionsRoot, mockAppAddress, MOCK_APP_ROLE, { gas: gasAvailable}))
         })
 
         it('ACL fails with low gas', async () => {

--- a/test/contracts/acl/acl_params.js
+++ b/test/contracts/acl/acl_params.js
@@ -1,0 +1,42 @@
+const { assertRevert } = require('../../helpers/assertThrow')
+
+const ACL = artifacts.require('ACL')
+const Kernel = artifacts.require('Kernel')
+const KernelProxy = artifacts.require('KernelProxy')
+const OverGasLimitOracle = artifacts.require('OverGasLimitOracle')
+
+const ANY_ADDR = '0xffffffffffffffffffffffffffffffffffffffff'
+
+contract('ACL', ([permissionsRoot, mockAppAddress]) => {
+  let aclBase, kernelBase, acl, kernel, overGasLimitOracle
+  const MOCK_APP_ROLE = "0xAB"
+
+  before(async () => {
+    kernelBase = await Kernel.new(true) // petrify immediately
+    aclBase = await ACL.new()
+  })
+
+  beforeEach(async () => {
+    kernel = Kernel.at((await KernelProxy.new(kernelBase.address)).address)
+    await kernel.initialize(aclBase.address, permissionsRoot)
+    acl = ACL.at(await kernel.acl())
+    overGasLimitOracle = await OverGasLimitOracle.new()
+  })
+
+  context('> ACLOracle Permissions', () => {
+
+    it('fails when oracle canPerform goes OOG', async () => {
+      // Set role such that the Oracle canPerform() function is used to determine the permission
+      const argId = '0xCB' // arg 203 - Oracle ID
+      const op = '01'      // equal
+      const value = `00000000000000000000${overGasLimitOracle.address.slice(2)}`  // oracle address
+      const param = new web3.BigNumber(`${argId}${op}${value}`)
+
+      await acl.createPermission(permissionsRoot, mockAppAddress, MOCK_APP_ROLE, permissionsRoot)
+      await acl.grantPermissionP(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE, [param])
+
+      await assertRevert(acl.hasPermission(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE), "ACL_ORACLE_OOG")
+    })
+
+  })
+})

--- a/test/contracts/acl/acl_params.js
+++ b/test/contracts/acl/acl_params.js
@@ -1,4 +1,5 @@
 const { assertRevert } = require('../../helpers/assertThrow')
+const { skipCoverage } = require('../../helpers/coverage')
 const { paramForOracle } = require('../../helpers/permissionParams')
 
 const ACL = artifacts.require('ACL')
@@ -9,7 +10,6 @@ const OverGasLimitOracle = artifacts.require('OverGasLimitOracle')
 const StateModifyingOracle = artifacts.require('StateModifyingOracle')
 
 const ANY_ADDR = '0xffffffffffffffffffffffffffffffffffffffff'
-const disableForCoverage = (process.env.SOLIDITY_COVERAGE === 'true' ? describe.skip : describe)
 
 contract('ACL params', ([permissionsRoot, mockAppAddress]) => {
   let aclBase, kernelBase, acl, kernel
@@ -79,7 +79,7 @@ contract('ACL params', ([permissionsRoot, mockAppAddress]) => {
       })
     })
 
-    disableForCoverage('when the oracle uses all available gas', () => {
+    describe('when the oracle uses all available gas', skipCoverage(() => {
       let overGasLimitOracle, param
 
       before(async () => {
@@ -123,6 +123,6 @@ contract('ACL params', ([permissionsRoot, mockAppAddress]) => {
           await assertRevert(acl.hasPermission(permissionsRoot, mockAppAddress, MOCK_APP_ROLE, { gas: 180000}))
         })
       })
-    })
+    }))
   })
 })

--- a/test/contracts/acl/acl_params.js
+++ b/test/contracts/acl/acl_params.js
@@ -61,19 +61,19 @@ contract('ACL params', ([permissionsRoot, mockAppAddress]) => {
       describe('when permission is set for ANY_ADDR', () => {
         it('ACL disallows actions', async () => {
           await acl.grantPermissionP(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE, [param])
-          await assertRevert(acl.hasPermission(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE), "ACL_ORACLE_OOG")
+          assert.isFalse(await acl.hasPermission(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE))
         })
       })
 
       describe('when permission is set for specific address', async () => {
         it('ACL disallows actions', async () => {
           await acl.grantPermissionP(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE, [param])
-          await assertRevert(acl.hasPermission(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE), "ACL_ORACLE_OOG")
+          assert.isFalse(await acl.hasPermission(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE))
         })
       })
     })
 
-    describe('when the oracle goes out of gas', () => {
+    describe('when the oracle uses all available gas', () => {
       let overGasLimitOracle, param
 
       before(async () => {
@@ -85,7 +85,7 @@ contract('ACL params', ([permissionsRoot, mockAppAddress]) => {
         // Note `evalParams()` is called twice when calling `hasPermission` for `ANY_ADDR`
         it('ACL disallows actions', async () => {
           await acl.grantPermissionP(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE, [param])
-          await assertRevert(acl.hasPermission(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE), "ACL_ORACLE_OOG")
+          assert.isFalse(await acl.hasPermission(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE))
         })
       })
 
@@ -93,7 +93,7 @@ contract('ACL params', ([permissionsRoot, mockAppAddress]) => {
         // Note `evalParams()` is only called once when calling `hasPermission` for a specific address
         it('ACL disallows actions', async () => {
           await acl.grantPermissionP(permissionsRoot, mockAppAddress, MOCK_APP_ROLE, [param])
-          await assertRevert(acl.hasPermission(permissionsRoot, mockAppAddress, MOCK_APP_ROLE), "ACL_ORACLE_OOG")
+          assert.isFalse(await acl.hasPermission(permissionsRoot, mockAppAddress, MOCK_APP_ROLE))
         })
       })
     })

--- a/test/contracts/acl/acl_params.js
+++ b/test/contracts/acl/acl_params.js
@@ -165,6 +165,11 @@ contract('ACL params', ([permissionsRoot, specificEntity, noPermission, mockAppA
 
           describe('when permission is set for specific address', async () => {
             const MEDIUM_GAS = 190000
+            // Note that these gas values are still quite high for causing reverts in "low gas"
+            // situations, as we incur some overhead with delegating into proxies and other checks.
+            // Assuming we incur 40-60k gas overhead for this, we only have ~140,000 gas left.
+            // After the oracle call, we only have 140,000 / 64 ~= 2000 gas left, which begins to
+            // quick run out with SLOADs.
             const LOW_GAS = 180000
 
             beforeEach(async () => {

--- a/test/contracts/acl/acl_params.js
+++ b/test/contracts/acl/acl_params.js
@@ -23,7 +23,7 @@ contract('ACL', ([permissionsRoot, mockAppAddress]) => {
     overGasLimitOracle = await OverGasLimitOracle.new()
   })
 
-  context('> ACLOracle Permissions', () => {
+  context('> ACLOracle Permission', () => {
 
     it('fails when oracle canPerform goes OOG', async () => {
       // Set role such that the Oracle canPerform() function is used to determine the permission

--- a/test/contracts/acl/acl_params.js
+++ b/test/contracts/acl/acl_params.js
@@ -4,6 +4,7 @@ const { paramForOracle } = require('../../helpers/permissionParams')
 const ACL = artifacts.require('ACL')
 const Kernel = artifacts.require('Kernel')
 const KernelProxy = artifacts.require('KernelProxy')
+const AcceptOracle = artifacts.require('AcceptOracle')
 const OverGasLimitOracle = artifacts.require('OverGasLimitOracle')
 const StateModifyingOracle = artifacts.require('StateModifyingOracle')
 
@@ -25,6 +26,20 @@ contract('ACL', ([permissionsRoot, mockAppAddress]) => {
     await acl.createPermission(permissionsRoot, mockAppAddress, MOCK_APP_ROLE, permissionsRoot)
   })
 
+  it('ACLOracle succeeds when oracle canPerform returns true', async () => {
+    const acceptOracle = await AcceptOracle.new()
+    const param = paramForOracle(acceptOracle.address)
+    await acl.grantPermissionP(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE, [param])
+    assert.isTrue(await acl.hasPermission(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE))
+  })
+
+  it('ACLOracle fails when oracle canPerform modifies state', async () => {
+    const stateModifyingOracle = await StateModifyingOracle.new()
+    const param = paramForOracle(stateModifyingOracle.address)
+    await acl.grantPermissionP(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE, [param])
+    await assertRevert(acl.hasPermission(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE), "ACL_ORACLE_OOG")
+  })
+
   context('> ACLOracle OverGasLimitOracle', () => {
     let overGasLimitOracle, param
 
@@ -43,21 +58,6 @@ contract('ACL', ([permissionsRoot, mockAppAddress]) => {
     it('fails when oracle canPerform goes OOG with specified permission owner', async () => {
       await acl.grantPermissionP(permissionsRoot, mockAppAddress, MOCK_APP_ROLE, [param])
       await assertRevert(acl.hasPermission(permissionsRoot, mockAppAddress, MOCK_APP_ROLE), "ACL_ORACLE_OOG")
-    })
-
-  })
-
-  context('> ACLOracle StateModifyingOracle', () => {
-    let stateModifyingOracle, param
-
-    beforeEach(async () => {
-      stateModifyingOracle = await StateModifyingOracle.new()
-      param = paramForOracle(stateModifyingOracle.address)
-    })
-
-    it('fails when oracle canPerform modifies state', async () => {
-      await acl.grantPermissionP(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE, [param])
-      await assertRevert(acl.hasPermission(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE), "ACL_ORACLE_OOG")
     })
   })
 })

--- a/test/contracts/acl/acl_params.js
+++ b/test/contracts/acl/acl_params.js
@@ -4,11 +4,20 @@ const ACL = artifacts.require('ACL')
 const Kernel = artifacts.require('Kernel')
 const KernelProxy = artifacts.require('KernelProxy')
 const OverGasLimitOracle = artifacts.require('OverGasLimitOracle')
+const StateModifyingOracle = artifacts.require('StateModifyingOracle')
 
 const ANY_ADDR = '0xffffffffffffffffffffffffffffffffffffffff'
 
+const paramForOracle = (oracleAddress) => {
+  // Set role such that the Oracle canPerform() function is used to determine the permission
+  const argId = '0xCB' // arg 203 - Oracle ID
+  const op = '01'      // equal
+  const value = `00000000000000000000${oracleAddress.slice(2)}`
+  return new web3.BigNumber(`${argId}${op}${value}`)
+}
+
 contract('ACL', ([permissionsRoot, mockAppAddress]) => {
-  let aclBase, kernelBase, acl, kernel, overGasLimitOracle
+  let aclBase, kernelBase, acl, kernel
   const MOCK_APP_ROLE = "0xAB"
 
   before(async () => {
@@ -20,23 +29,42 @@ contract('ACL', ([permissionsRoot, mockAppAddress]) => {
     kernel = Kernel.at((await KernelProxy.new(kernelBase.address)).address)
     await kernel.initialize(aclBase.address, permissionsRoot)
     acl = ACL.at(await kernel.acl())
-    overGasLimitOracle = await OverGasLimitOracle.new()
+    await acl.createPermission(permissionsRoot, mockAppAddress, MOCK_APP_ROLE, permissionsRoot)
   })
 
-  context('> ACLOracle Permission', () => {
+  context('> ACLOracle OverGasLimitOracle', () => {
+    let overGasLimitOracle, param
 
+    beforeEach(async () => {
+      overGasLimitOracle = await OverGasLimitOracle.new()
+      param = paramForOracle(overGasLimitOracle.address)
+    })
+
+    // Note `evalParams()` is called twice when calling `hasPermission` for `ANY_ADDR`
     it('fails when oracle canPerform goes OOG', async () => {
-      // Set role such that the Oracle canPerform() function is used to determine the permission
-      const argId = '0xCB' // arg 203 - Oracle ID
-      const op = '01'      // equal
-      const value = `00000000000000000000${overGasLimitOracle.address.slice(2)}`  // oracle address
-      const param = new web3.BigNumber(`${argId}${op}${value}`)
-
-      await acl.createPermission(permissionsRoot, mockAppAddress, MOCK_APP_ROLE, permissionsRoot)
       await acl.grantPermissionP(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE, [param])
-
       await assertRevert(acl.hasPermission(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE), "ACL_ORACLE_OOG")
     })
 
+    // In this situation `evalParams()` is only called once
+    it('fails when oracle canPerform goes OOG with specified permission owner', async () => {
+      await acl.grantPermissionP(permissionsRoot, mockAppAddress, MOCK_APP_ROLE, [param])
+      await assertRevert(acl.hasPermission(permissionsRoot, mockAppAddress, MOCK_APP_ROLE), "ACL_ORACLE_OOG")
+    })
+
+  })
+
+  context('> ACLOracle StateModifyingOracle', () => {
+    let stateModifyingOracle, param
+
+    beforeEach(async () => {
+      stateModifyingOracle = await StateModifyingOracle.new()
+      param = paramForOracle(stateModifyingOracle.address)
+    })
+
+    it('fails when oracle canPerform modifies state', async () => {
+      await acl.grantPermissionP(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE, [param])
+      await assertRevert(acl.hasPermission(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE), "ACL_ORACLE_OOG")
+    })
   })
 })

--- a/test/contracts/acl/acl_params.js
+++ b/test/contracts/acl/acl_params.js
@@ -1,4 +1,5 @@
 const { assertRevert } = require('../../helpers/assertThrow')
+const { paramForOracle } = require('../../helpers/permissionParams')
 
 const ACL = artifacts.require('ACL')
 const Kernel = artifacts.require('Kernel')
@@ -7,14 +8,6 @@ const OverGasLimitOracle = artifacts.require('OverGasLimitOracle')
 const StateModifyingOracle = artifacts.require('StateModifyingOracle')
 
 const ANY_ADDR = '0xffffffffffffffffffffffffffffffffffffffff'
-
-const paramForOracle = (oracleAddress) => {
-  // Set role such that the Oracle canPerform() function is used to determine the permission
-  const argId = '0xCB' // arg 203 - Oracle ID
-  const op = '01'      // equal
-  const value = `00000000000000000000${oracleAddress.slice(2)}`
-  return new web3.BigNumber(`${argId}${op}${value}`)
-}
 
 contract('ACL', ([permissionsRoot, mockAppAddress]) => {
   let aclBase, kernelBase, acl, kernel
@@ -46,7 +39,7 @@ contract('ACL', ([permissionsRoot, mockAppAddress]) => {
       await assertRevert(acl.hasPermission(ANY_ADDR, mockAppAddress, MOCK_APP_ROLE), "ACL_ORACLE_OOG")
     })
 
-    // In this situation `evalParams()` is only called once
+    // Note `evalParams()` is only called once when calling `hasPermission` for a specific address
     it('fails when oracle canPerform goes OOG with specified permission owner', async () => {
       await acl.grantPermissionP(permissionsRoot, mockAppAddress, MOCK_APP_ROLE, [param])
       await assertRevert(acl.hasPermission(permissionsRoot, mockAppAddress, MOCK_APP_ROLE), "ACL_ORACLE_OOG")

--- a/test/helpers/coverage.js
+++ b/test/helpers/coverage.js
@@ -9,6 +9,12 @@ const skipCoverage = test => {
     }
 }
 
+// For some reason, adding skipCoverage() to `before()`s were not working
+const skipSuiteCoverage = suite => {
+  return process.env.SOLIDITY_COVERAGE === 'true' ? suite.skip : suite
+}
+
 module.exports = {
-  skipCoverage
+  skipCoverage,
+  skipSuiteCoverage,
 }

--- a/test/helpers/permissionParams.js
+++ b/test/helpers/permissionParams.js
@@ -1,4 +1,4 @@
-const paramForOracle = (oracleAddress) => {
+const permissionParamEqOracle = (oracleAddress) => {
   // Set role such that the Oracle canPerform() function is used to determine the permission
   const argId = '0xCB' // arg 203 - Oracle ID
   const op = '01'      // equal
@@ -7,5 +7,5 @@ const paramForOracle = (oracleAddress) => {
 }
 
 module.exports = {
-  paramForOracle
+  permissionParamEqOracle
 }

--- a/test/helpers/permissionParams.js
+++ b/test/helpers/permissionParams.js
@@ -1,0 +1,12 @@
+
+const paramForOracle = (oracleAddress) => {
+  // Set role such that the Oracle canPerform() function is used to determine the permission
+  const argId = '0xCB' // arg 203 - Oracle ID
+  const op = '01'      // equal
+  const value = `00000000000000000000${oracleAddress.slice(2)}`
+  return new web3.BigNumber(`${argId}${op}${value}`)
+}
+
+module.exports = {
+  paramForOracle
+}

--- a/test/helpers/permissionParams.js
+++ b/test/helpers/permissionParams.js
@@ -1,9 +1,8 @@
-
 const paramForOracle = (oracleAddress) => {
   // Set role such that the Oracle canPerform() function is used to determine the permission
   const argId = '0xCB' // arg 203 - Oracle ID
   const op = '01'      // equal
-  const value = `00000000000000000000${oracleAddress.slice(2)}`
+  const value = oracleAddress.slice(2).padStart(60, 0) // 60 as params are uint240
   return new web3.BigNumber(`${argId}${op}${value}`)
 }
 


### PR DESCRIPTION
This PR will enable the 1Hive Oracles to function as expected since the Istanbul hard fork. Unfortunately our Oracles `canPerform()` functions can not be guaranteed to execute under the gas limit of `30000`.

Relevant functions in the Oracles can be seen here:
https://github.com/1Hive/token-oracle/blob/master/contracts/TokenBalanceOracle.sol#L59
https://github.com/1Hive/dandelion-voting-app/blob/master/contracts/DandelionVoting.sol#L252

I've replaced the Oracle `canPerform()` `staticcall` gas limit of `30000` with `gasleft()` minus some amount for returning an error (preventing a revert if the `staticcall` runs out of gas). As suggested by @sohkai.

I've observed that if the `staticcall` reverts with an oog after being given all of `gasleft()` it still seems to reserve about `100000` gas, as can be seen with a `gasleft()` directly after the oog `staticcall` (tested on remix). The function doesn't revert and returns false. I've still included the error gas allowance but it may not be necessary.

I had to extract `testRevertOracle` and `testStateModifyingOracle` from the `testOracle` test because when the `staticcall` reverts it consumes all the available gas, leaving very little to none for the remaining tests in the same transaction.