### PR TITLE
chore: Update to Istanbul context

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,21 +34,21 @@
   "repository": "https://github.com/aragon/aragonOS",
   "license": "(GPL-3.0-or-later OR MIT)",
   "devDependencies": {
-    "@aragon/truffle-config-v4": "^1.0.0",
+    "@aragon/truffle-config-v4": "^1.0.1",
     "@codechecks/client": "^0.1.5",
-    "coveralls": "^2.13.3",
+    "coveralls": "^3.0.9",
     "eth-ens-namehash": "^2.0.8",
-    "eth-gas-reporter": "^0.2.9",
+    "eth-gas-reporter": "^0.2.14",
     "ethereumjs-abi": "^0.6.5",
-    "ganache-cli": "^6.4.2",
+    "ganache-cli": "^6.9.0",
     "mocha-lcov-reporter": "^1.3.0",
     "solidity-coverage": "0.6.2",
     "solium": "^1.2.3",
     "truffle": "4.1.14",
     "truffle-bytecode-manager": "^1.1.1",
     "truffle-extract": "^1.2.1",
-    "web3-eth-abi": "1.0.0-beta.33",
-    "web3-utils": "1.0.0-beta.33"
+    "web3-eth-abi": "1.2.5",
+    "web3-utils": "1.2.5"
   },
   "dependencies": {
     "mkdirp": "^0.5.1",

--- a/test/helpers/coverage.js
+++ b/test/helpers/coverage.js
@@ -1,0 +1,14 @@
+const skipCoverage = test => {
+    // Required dynamic this binding to attach onto the running test
+    return function skipCoverage() {
+        if (process.env.SOLIDITY_COVERAGE === 'true') {
+            this.skip()
+        } else {
+            return test()
+        }
+    }
+}
+
+module.exports = {
+  skipCoverage
+}

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -1,1 +1,1 @@
-module.exports = require('@aragon/truffle-config-v4/truffle-config')
+module.exports = require('@aragon/truffle-config-v4')


### PR DESCRIPTION
Updates the tests to drop the deprecated Constantinople context.

Skips the `solidity-coverage@0.7` upgrade for now, to avoid too much churn. We will do this later.