### PR TITLE
ACL: update user/who parameters to who/grantee

### DIFF
--- a/contracts/acl/ACL.sol
+++ b/contracts/acl/ACL.sol
@@ -443,7 +443,15 @@ contract ACL is IACL, TimeHelpers, AragonApp, ACLHelpers {
     /**
     * @dev Internal function to eval a non-IF-ELSE logic operator
     */
-    function _evalNonIfElseLogicOp(Param _param, bytes32 _paramsHash, address _who, address _grantee, address _where, bytes32 _what, uint256[] _how)
+    function _evalNonIfElseLogicOp(
+        Param _param,
+        bytes32 _paramsHash,
+        address _who,
+        address _grantee,
+        address _where,
+        bytes32 _what,
+        uint256[] _how
+    )
         internal
         view
         returns (bool)

--- a/contracts/acl/ACL.sol
+++ b/contracts/acl/ACL.sol
@@ -264,19 +264,19 @@ contract ACL is IACL, TimeHelpers, AragonApp, ACLHelpers {
     /**
     * @dev Function called by apps to evaluate ACL params
     * @param _paramsHash Params hash identifier
-    * @param _user Sender of the original call
-    * @param _who Grantee of the role
+    * @param _who Sender of the original call
+    * @param _grantee Grantee of the role
     * @param _where Address of the app
     * @param _what Identifier for a group of actions in app (role)
     * @param _how Permission parameters
     * @return boolean indicating whether the ACL allows the role or not
     */
-    function evalParams(bytes32 _paramsHash, address _user, address _who, address _where, bytes32 _what, uint256[] _how)
+    function evalParams(bytes32 _paramsHash, address _who, address _grantee, address _where, bytes32 _what, uint256[] _how)
         external
         view
         returns (bool)
     {
-        return _evalParams(_paramsHash, _user, _who, _where, _what, _how);
+        return _evalParams(_paramsHash, _who, _grantee, _where, _what, _how);
     }
 
     /**
@@ -362,7 +362,7 @@ contract ACL is IACL, TimeHelpers, AragonApp, ACLHelpers {
     /**
     * @dev Internal function to perform an ACL check
     */
-    function _evalParams(bytes32 _paramsHash, address _user, address _who, address _where, bytes32 _what, uint256[] _how)
+    function _evalParams(bytes32 _paramsHash, address _who, address _grantee, address _where, bytes32 _what, uint256[] _how)
         internal
         view
         returns (bool)
@@ -372,13 +372,13 @@ contract ACL is IACL, TimeHelpers, AragonApp, ACLHelpers {
         }
 
         // `_evalParam()` will internally traverse all the parameters, starting from the first parameter (0)
-        return _evalParam(_paramsHash, 0, _user, _who, _where, _what, _how);
+        return _evalParam(_paramsHash, 0, _who, _grantee, _where, _what, _how);
     }
 
     /**
     * @dev Internal function to perform an ACL check on a single permission parameter
     */
-    function _evalParam(bytes32 _paramsHash, uint32 _paramId, address _user, address _who, address _where, bytes32 _what, uint256[] _how)
+    function _evalParam(bytes32 _paramsHash, uint32 _paramId, address _who, address _grantee, address _where, bytes32 _what, uint256[] _how)
         internal
         view
         returns (bool)
@@ -391,8 +391,8 @@ contract ACL is IACL, TimeHelpers, AragonApp, ACLHelpers {
 
         if (param.id == LOGIC_OP_PARAM_ID) {
             return (Op(param.op) == Op.IF_ELSE)
-                ? _evalIfElseLogicOp(param, _paramsHash, _user, _who, _where, _what, _how)
-                : _evalNonIfElseLogicOp(param, _paramsHash, _user, _who, _where, _what, _how);
+                ? _evalIfElseLogicOp(param, _paramsHash, _who, _grantee, _where, _what, _how)
+                : _evalNonIfElseLogicOp(param, _paramsHash, _who, _grantee, _where, _what, _how);
         }
 
         uint256 value;
@@ -400,7 +400,7 @@ contract ACL is IACL, TimeHelpers, AragonApp, ACLHelpers {
 
         // get value
         if (param.id == ORACLE_PARAM_ID) {
-            value = _checkOracle(IACLOracle(param.value), _user, _who, _where, _what, _how) ? 1 : 0;
+            value = _checkOracle(IACLOracle(param.value), _who, _grantee, _where, _what, _how) ? 1 : 0;
             comparedTo = 1;
         } else if (param.id == BLOCK_NUMBER_PARAM_ID) {
             value = getBlockNumber();
@@ -425,7 +425,7 @@ contract ACL is IACL, TimeHelpers, AragonApp, ACLHelpers {
     /**
     * @dev Internal function to eval an IF-ELSE logic operator
     */
-    function _evalIfElseLogicOp(Param _param, bytes32 _paramsHash, address _user, address _who, address _where, bytes32 _what, uint256[] _how)
+    function _evalIfElseLogicOp(Param _param, bytes32 _paramsHash, address _who, address _grantee, address _where, bytes32 _what, uint256[] _how)
         internal
         view
         returns (bool)
@@ -435,21 +435,21 @@ contract ACL is IACL, TimeHelpers, AragonApp, ACLHelpers {
         uint32 failureParam;
 
         (conditionParam, successParam, failureParam) = decodeParamsList(uint256(_param.value));
-        bool result = _evalParam(_paramsHash, conditionParam, _user, _who, _where, _what, _how);
+        bool result = _evalParam(_paramsHash, conditionParam, _who, _grantee, _where, _what, _how);
 
-        return _evalParam(_paramsHash, result ? successParam : failureParam, _user, _who, _where, _what, _how);
+        return _evalParam(_paramsHash, result ? successParam : failureParam, _who, _grantee, _where, _what, _how);
     }
 
     /**
     * @dev Internal function to eval a non-IF-ELSE logic operator
     */
-    function _evalNonIfElseLogicOp(Param _param, bytes32 _paramsHash, address _user, address _who, address _where, bytes32 _what, uint256[] _how)
+    function _evalNonIfElseLogicOp(Param _param, bytes32 _paramsHash, address _who, address _grantee, address _where, bytes32 _what, uint256[] _how)
         internal
         view
         returns (bool)
     {
         (uint32 param1, uint32 param2,) = decodeParamsList(uint256(_param.value));
-        bool r1 = _evalParam(_paramsHash, param1, _user, _who, _where, _what, _how);
+        bool r1 = _evalParam(_paramsHash, param1, _who, _grantee, _where, _what, _how);
 
         if (Op(_param.op) == Op.NOT) {
             return !r1;
@@ -463,7 +463,7 @@ contract ACL is IACL, TimeHelpers, AragonApp, ACLHelpers {
             return false;
         }
 
-        bool r2 = _evalParam(_paramsHash, param2, _user, _who, _where, _what, _how);
+        bool r2 = _evalParam(_paramsHash, param2, _who, _grantee, _where, _what, _how);
 
         if (Op(_param.op) == Op.XOR) {
             return r1 != r2;
@@ -475,14 +475,14 @@ contract ACL is IACL, TimeHelpers, AragonApp, ACLHelpers {
     /**
     * @dev Internal function to perform an ACL oracle check
     */
-    function _checkOracle(IACLOracle _oracleAddr, address _user, address _who, address _where, bytes32 _what, uint256[] _how)
+    function _checkOracle(IACLOracle _oracleAddr, address _who, address _grantee, address _where, bytes32 _what, uint256[] _how)
         internal
         view
         returns (bool)
     {
         // a raw call is required so we can return false if the call reverts, rather than reverting
         bytes4 sig = _oracleAddr.canPerform.selector;
-        bytes memory checkCalldata = abi.encodeWithSelector(sig, _user, _who, _where, _what, _how);
+        bytes memory checkCalldata = abi.encodeWithSelector(sig, _who, _grantee, _where, _what, _how);
 
         bool ok;
         assembly {

--- a/contracts/acl/IACLOracle.sol
+++ b/contracts/acl/IACLOracle.sol
@@ -7,18 +7,18 @@ pragma solidity ^0.4.24;
 
 /**
 * @title ACL Oracle interface
-* @dev This interface simply defines a check method that must be implemented by smart contracts to be plugged in as ACL oracles.
-*      ACL oracles are the most suitable way to have external contracts validating ACL permissions with custom logic.
+* @dev This interface simply defines a predicate method that must be implemented by smart contracts intended to be used as ACL Oracles.
+*      ACL oracles should be used if you would like to protect a permission with custom logic from an external contract.
 */
 interface IACLOracle {
     /**
-    * @dev Tells whether `user` can execute `what`(`how`) in `where` if it's currently set up for `who`
-    * @param user Entity trying to execute `what` in `where`
-    * @param who Entity to which `what` is granted based on the current ACL permissions configuration
-    * @param where Entity where `what` is trying to be executed
-    * @param what Identifier of the action willing to be executed in `where`
-    * @param how Can be used to define a set of arguments to give more context about `what` is trying to be executed in `where`
-    * @return True if the user is allowed to execute the requested action for the given context, false otherwise
+    * @dev Tells whether `sender` can execute `what` (and `how`) in `where` for the grantee `who`
+    * @param who Sender of the original call
+    * @param grantee Grantee of the permission being evaluated
+    * @param where Address of the app
+    * @param what Identifier for a group of actions in app (role)
+    * @param how Permission parameters
+    * @return True if the action should be accepted
     */
-    function canPerform(address user, address who, address where, bytes32 what, uint256[] how) external view returns (bool);
+    function canPerform(address who, address grantee, address where, bytes32 what, uint256[] how) external view returns (bool);
 }

--- a/contracts/acl/IACLOracleV1.sol
+++ b/contracts/acl/IACLOracleV1.sol
@@ -6,9 +6,9 @@ pragma solidity ^0.4.24;
 
 
 /**
-* @title Previous version of the ACL Oracle interface
-* @dev This interface simply defines a check method that must be implemented by smart contracts to be plugged in as ACL oracles.
-*      ACL oracles are the most suitable way to have external contracts validating ACL permissions with custom logic.
+* @title Previous version of the ACL Oracle interface (aragonOS@4)
+* @dev This interface simply defines a predicate method that must be implemented by smart contracts intended to be used as ACL Oracles.
+*      ACL oracles should be used if you would like to protect a permission with custom logic from an external contract.
 */
 interface IACLOracleV1 {
     function canPerform(address who, address where, bytes32 what, uint256[] how) external view returns (bool);

--- a/contracts/test/tests/TestACLInterpreter.sol
+++ b/contracts/test/tests/TestACLInterpreter.sol
@@ -278,10 +278,10 @@ contract TestACLInterpreter is ACL, ACLHelper {
         assertEval(params, false);
     }
 
-    function assertEval(uint256[] memory args, uint8 argId, Op op, uint256 value, address user, address who, bool expected) internal {
+    function assertEval(uint256[] memory args, uint8 argId, Op op, uint256 value, address who, address grantee, bool expected) internal {
         Param[] memory params = new Param[](1);
         params[0] = Param(argId, uint8(op), uint240(value));
-        assertEval(params, args, user, who, expected);
+        assertEval(params, args, who, grantee, expected);
     }
 
     function assertEval(uint256[] memory args, uint8 argId, Op op, uint256 value, bool expected) internal {
@@ -296,9 +296,9 @@ contract TestACLInterpreter is ACL, ACLHelper {
         assertEval(params, args, address(0), address(0), expected);
     }
 
-    function assertEval(Param[] memory params, uint256[] memory args, address user, address who, bool expected) internal {
+    function assertEval(Param[] memory params, uint256[] memory args, address who, address grantee, bool expected) internal {
         bytes32 paramHash = _encodeAndSaveParams(params);
-        bool allow = _evalParam(paramHash, 0, user, who, address(0), bytes32(0), args);
+        bool allow = _evalParam(paramHash, 0, who, grantee, address(0), bytes32(0), args);
 
         Assert.equal(allow, expected, "eval got unexpected result");
     }


### PR DESCRIPTION
Updates the parameter names for the new `user`/`who` concepts for ACLOracleV2 to be `who`/`grantee`.

I wanted to keep `who` the same as before, as we use `who` as the original sender everywhere else (e.g. `hasPermission()`).