### PR TITLE
Disputables: Avoid calling close action if closed

### DIFF
--- a/contracts/apps/disputable/DisputableAragonApp.sol
+++ b/contracts/apps/disputable/DisputableAragonApp.sol
@@ -138,7 +138,11 @@ contract DisputableAragonApp is IDisputable, AragonApp {
     */
     function _closeAgreementAction(uint256 _actionId) internal {
         IAgreement agreement = _ensureAgreement();
-        agreement.closeAction(_actionId);
+        (,,,,, bool closed,,) = agreement.getAction(_actionId);
+
+        if (!closed) {
+            agreement.closeAction(_actionId);
+        }
     }
 
     /**

--- a/contracts/test/mocks/apps/disputable/AgreementMock.sol
+++ b/contracts/test/mocks/apps/disputable/AgreementMock.sol
@@ -2,12 +2,33 @@ pragma solidity 0.4.24;
 
 
 contract AgreementMock {
-    function newAction(uint256 /* _disputableActionId */, bytes /* _context */, address /* _submitter */) external payable returns (uint256) {
-        // do nothing
-        return 0;
+    string internal constant ERROR_ACTION_DOES_NOT_EXIST = "AGR_ACTION_DOES_NOT_EXIST";
+    string internal constant ERROR_ACTION_ALREADY_CLOSED = "AGR_ACTION_ALREADY_CLOSED";
+
+    event NewAction(uint256 disputableActionId, bytes context, address submitter);
+    event CloseAction(uint256 actionId);
+
+    uint256 internal actionsLength;
+    mapping (uint256 => bool) internal actionClosed;
+
+    function newAction(uint256 _disputableActionId, bytes _context, address _submitter) external payable returns (uint256) {
+        emit NewAction(_disputableActionId, _context, _submitter);
+        return actionsLength++;
     }
 
-    function closeAction(uint256 /* _actionId */) external {
-        // do nothing
+    function closeAction(uint256 _actionId) external {
+        require(_actionId < actionsLength, ERROR_ACTION_DOES_NOT_EXIST);
+        require(!actionClosed[_actionId], ERROR_ACTION_ALREADY_CLOSED);
+        actionClosed[_actionId] = true;
+        emit CloseAction(_actionId);
+    }
+
+    function getAction(uint256 _actionId)
+        external
+        view
+        returns (address, uint256, uint256, uint256, address, bool closed, bytes, uint256)
+    {
+        require(_actionId < actionsLength, ERROR_ACTION_DOES_NOT_EXIST);
+        closed = actionClosed[_actionId];
     }
 }

--- a/test/contracts/common/depositable_delegate_proxy.js
+++ b/test/contracts/common/depositable_delegate_proxy.js
@@ -1,4 +1,3 @@
-const { toChecksumAddress } = require('web3-utils')
 const { assertAmountOfEvents, assertEvent } = require('../../helpers/assertEvent')(web3)
 const { skipCoverage } = require('../../helpers/coverage')
 const { decodeEventsOfType } = require('../../helpers/decodeEvent')
@@ -138,7 +137,7 @@ contract('DepositableDelegateProxy', ([ sender ]) => {
         const receipt = await web3.eth.getTransactionReceipt(tx)
         const logs = decodeEventsOfType(receipt, DepositableDelegateProxyMock.abi, 'ProxyDeposit')
         assertAmountOfEvents({ logs }, 'ProxyDeposit')
-        assertEvent({ logs }, 'ProxyDeposit', { sender: toChecksumAddress(ethSender.address), value })
+        assertEvent({ logs }, 'ProxyDeposit', { sender: ethSender.address, value })
       })
 
       itRevertsOnInvalidDeposits()

--- a/test/helpers/assertEvent.js
+++ b/test/helpers/assertEvent.js
@@ -1,3 +1,4 @@
+const { isAddress } = require('web3-utils')
 const { getEventAt, getEvents } = require('./events')
 
 module.exports = web3 => {
@@ -8,9 +9,11 @@ module.exports = web3 => {
         for (const arg of Object.keys(expectedArgs)) {
             let foundArg = event.args[arg]
             if (foundArg instanceof web3.BigNumber) foundArg = foundArg.toString()
+            else if (isAddress(foundArg)) foundArg = foundArg.toLowerCase()
 
             let expectedArg = expectedArgs[arg]
             if (expectedArg instanceof web3.BigNumber) expectedArg = expectedArg.toString()
+            else if (isAddress(expectedArg)) expectedArg = expectedArg.toLowerCase()
 
             assert.equal(foundArg, expectedArg, `${eventName} event ${arg} value does not match`)
         }


### PR DESCRIPTION
Related to https://github.com/aragon/aragon-apps/pull/1214

This PR adds an improvement to avoid calling `IAgreement#closeAction` from the internal helper method of `DisputableAragonApp` if the requested action is already closed.