### PR TITLE
[DO NOT MERGE] Disputable: Move set agreement to Kernel

### DIFF
--- a/contracts/apps/disputable/DisputableAragonApp.sol
+++ b/contracts/apps/disputable/DisputableAragonApp.sol
@@ -13,6 +13,7 @@ import "../../lib/math/SafeMath64.sol";
 
 contract DisputableAragonApp is IDisputable, AragonApp {
     /* Validation errors */
+    string internal constant ERROR_SENDER_NOT_KERNEL = "DISPUTABLE_SENDER_NOT_KERNEL";
     string internal constant ERROR_SENDER_NOT_AGREEMENT = "DISPUTABLE_SENDER_NOT_AGREEMENT";
     string internal constant ERROR_AGREEMENT_STATE_INVALID = "DISPUTABLE_AGREEMENT_STATE_INVAL";
 
@@ -20,9 +21,6 @@ contract DisputableAragonApp is IDisputable, AragonApp {
     // to be validated in the app itself as the connected Agreement is responsible for performing the check on a challenge.
     // bytes32 public constant CHALLENGE_ROLE = keccak256("CHALLENGE_ROLE");
     bytes32 public constant CHALLENGE_ROLE = 0xef025787d7cd1a96d9014b8dc7b44899b8c1350859fb9e1e05f5a546dd65158d;
-
-    // bytes32 public constant SET_AGREEMENT_ROLE = keccak256("SET_AGREEMENT_ROLE");
-    bytes32 public constant SET_AGREEMENT_ROLE = 0x8dad640ab1b088990c972676ada708447affc660890ec9fc9a5483241c49f036;
 
     // bytes32 internal constant AGREEMENT_POSITION = keccak256("aragonOS.appStorage.agreement");
     bytes32 internal constant AGREEMENT_POSITION = 0x6dbe80ccdeafbf5f3fff5738b224414f85e9370da36f61bf21c65159df7409e9;
@@ -78,9 +76,11 @@ contract DisputableAragonApp is IDisputable, AragonApp {
     * @notice Set Agreement to `_agreement`
     * @param _agreement Agreement instance to be set
     */
-    function setAgreement(IAgreement _agreement) external auth(SET_AGREEMENT_ROLE) {
-        IAgreement agreement = _getAgreement();
-        require(agreement == IAgreement(0) && _agreement != IAgreement(0), ERROR_AGREEMENT_STATE_INVALID);
+    function setAgreement(IAgreement _agreement) external {
+        require(IKernel(msg.sender) == kernel(), ERROR_SENDER_NOT_KERNEL);
+
+        IAgreement currentAgreement = _getAgreement();
+        require(currentAgreement == IAgreement(0) && _agreement != IAgreement(0), ERROR_AGREEMENT_STATE_INVALID);
 
         AGREEMENT_POSITION.setStorageAddress(address(_agreement));
         emit AgreementSet(_agreement);

--- a/contracts/kernel/IKernel.sol
+++ b/contracts/kernel/IKernel.sol
@@ -17,11 +17,12 @@ interface IKernelEvents {
 
 // This should be an interface, but interfaces can't inherit yet :(
 contract IKernel is IKernelEvents, IVaultRecoverable {
-    function setAgreement(IDisputable _disputableApp, IAgreement _agreement) external;
-
     function acl() public view returns (IACL);
     function hasPermission(address who, address where, bytes32 what, bytes how) public view returns (bool);
 
     function setApp(bytes32 namespace, bytes32 appId, address app) public;
     function getApp(bytes32 namespace, bytes32 appId) public view returns (address);
+
+    // solium-disable function-order
+    function setAgreement(IDisputable _disputableApp, IAgreement _agreement) external;
 }

--- a/contracts/kernel/IKernel.sol
+++ b/contracts/kernel/IKernel.sol
@@ -6,6 +6,8 @@ pragma solidity ^0.4.24;
 
 import "../acl/IACL.sol";
 import "../common/IVaultRecoverable.sol";
+import "../apps/disputable/IAgreement.sol";
+import "../apps/disputable/IDisputable.sol";
 
 
 interface IKernelEvents {
@@ -15,6 +17,8 @@ interface IKernelEvents {
 
 // This should be an interface, but interfaces can't inherit yet :(
 contract IKernel is IKernelEvents, IVaultRecoverable {
+    function setAgreement(IDisputable _disputableApp, IAgreement _agreement) external;
+
     function acl() public view returns (IACL);
     function hasPermission(address who, address where, bytes32 what, bytes how) public view returns (bool);
 

--- a/contracts/kernel/Kernel.sol
+++ b/contracts/kernel/Kernel.sol
@@ -5,14 +5,14 @@ import "./KernelConstants.sol";
 import "./KernelStorage.sol";
 import "../acl/IACL.sol";
 import "../acl/ACLSyntaxSugar.sol";
+import "../apps/disputable/IAgreement.sol";
+import "../apps/disputable/IDisputable.sol";
 import "../common/ConversionHelpers.sol";
 import "../common/IsContract.sol";
 import "../common/Petrifiable.sol";
 import "../common/VaultRecoverable.sol";
 import "../factory/AppProxyFactory.sol";
 import "../lib/misc/ERCProxy.sol";
-import "../apps/disputable/IAgreement.sol";
-import "../apps/disputable/IDisputable.sol";
 
 
 // solium-disable-next-line max-len

--- a/contracts/kernel/Kernel.sol
+++ b/contracts/kernel/Kernel.sol
@@ -11,18 +11,29 @@ import "../common/Petrifiable.sol";
 import "../common/VaultRecoverable.sol";
 import "../factory/AppProxyFactory.sol";
 import "../lib/misc/ERCProxy.sol";
+import "../apps/disputable/IAgreement.sol";
+import "../apps/disputable/IDisputable.sol";
 
 
 // solium-disable-next-line max-len
 contract Kernel is IKernel, KernelStorage, KernelAppIds, KernelNamespaceConstants, Petrifiable, IsContract, VaultRecoverable, AppProxyFactory, ACLSyntaxSugar {
-    /* Hardcoded constants to save gas
-    bytes32 public constant APP_MANAGER_ROLE = keccak256("APP_MANAGER_ROLE");
-    */
+    // bytes32 public constant APP_MANAGER_ROLE = keccak256("APP_MANAGER_ROLE");
     bytes32 public constant APP_MANAGER_ROLE = 0xb6d92708f3d4817afc106147d969e229ced5c46e65e0a5002a0d391287762bd0;
+
+    // bytes32 public constant SET_AGREEMENT_ROLE = keccak256("SET_AGREEMENT_ROLE");
+    bytes32 public constant SET_AGREEMENT_ROLE = 0x8dad640ab1b088990c972676ada708447affc660890ec9fc9a5483241c49f036;
 
     string private constant ERROR_APP_NOT_CONTRACT = "KERNEL_APP_NOT_CONTRACT";
     string private constant ERROR_INVALID_APP_CHANGE = "KERNEL_INVALID_APP_CHANGE";
     string private constant ERROR_AUTH_FAILED = "KERNEL_AUTH_FAILED";
+
+    modifier auth(bytes32 _role, uint256[] memory _params) {
+        require(
+            hasPermission(msg.sender, address(this), _role, ConversionHelpers.dangerouslyCastUintArrayToBytes(_params)),
+            ERROR_AUTH_FAILED
+        );
+        _;
+    }
 
     /**
     * @dev Constructor that allows the deployer to choose if the base instance should be petrified immediately.
@@ -32,6 +43,19 @@ contract Kernel is IKernel, KernelStorage, KernelAppIds, KernelNamespaceConstant
         if (_shouldPetrify) {
             petrify();
         }
+    }
+
+    /**
+    * @dev Set an Agreement for a disputable app
+    * @notice Set `_agreement` as the Agreement for the disputable app `_disputableApp`
+    * @param _disputableApp Address of the disputable app to set the agreement of
+    * @param _agreement Agreement instance to be set
+    */
+    function setAgreement(IDisputable _disputableApp, IAgreement _agreement)
+        external
+        auth(SET_AGREEMENT_ROLE, arr(_disputableApp, _agreement))
+    {
+        _disputableApp.setAgreement(_agreement);
     }
 
     /**
@@ -226,13 +250,5 @@ contract Kernel is IKernel, KernelStorage, KernelAppIds, KernelNamespaceConstant
         } else {
             _setApp(_namespace, _appId, _app);
         }
-    }
-
-    modifier auth(bytes32 _role, uint256[] memory _params) {
-        require(
-            hasPermission(msg.sender, address(this), _role, ConversionHelpers.dangerouslyCastUintArrayToBytes(_params)),
-            ERROR_AUTH_FAILED
-        );
-        _;
     }
 }

--- a/test/contracts/apps/disputable/disputable_app.js
+++ b/test/contracts/apps/disputable/disputable_app.js
@@ -125,12 +125,16 @@ contract('DisputableApp', ([_, owner, agreement, anotherAgreement, someone]) => 
     context('when the sender does not have permissions', () => {
       const from = someone
 
-      it('reverts', async () => {
-        await assertRevert(dao.setAgreement(disputable.address, agreement, { from }), 'KERNEL_AUTH_FAILED')
+      context('when going through the kernel', () => {
+        it('reverts', async () => {
+          await assertRevert(dao.setAgreement(disputable.address, agreement, { from }), 'KERNEL_AUTH_FAILED')
+        })
       })
 
-      it('reverts', async () => {
-        await assertRevert(disputable.setAgreement(agreement, { from }), 'DISPUTABLE_SENDER_NOT_KERNEL')
+      context('when going through the disputable', () => {
+        it('reverts', async () => {
+          await assertRevert(disputable.setAgreement(agreement, { from }), 'DISPUTABLE_SENDER_NOT_KERNEL')
+        })
       })
     })
   })


### PR DESCRIPTION
This PR moves the `setAgreement` security check to the Kernel, allowing us to define Agreement<>Kernel permissions instead of Agreement<>Disputable ones. 